### PR TITLE
Add bibliography.json for 2021/645

### DIFF
--- a/data/markdown/eprint/2021_645/bibliography.json
+++ b/data/markdown/eprint/2021_645/bibliography.json
@@ -2,17 +2,17 @@
   "paper_id": "2021_645",
   "references": [
     {
-      "key": "[1]",
-      "raw_text": "Akshima, Cash, D., Drucker, A., Wee, H.: Time-space tradeoffs and short collisions in merkle-damg\u00e5rd hash functions. In: Micciancio, D., Ristenpart, T. (eds.) CRYPTO 2020, Part I. LNCS, vol. 12170, pp. 157\u2013186. Springer, Heidelberg (Aug 2020)",
+      "key": "[AKC+20]",
+      "raw_text": "",
       "authors": [
         "Akshima",
-        "Cash, David",
-        "Drucker, Andrew",
-        "Wee, Hoeteck"
+        "Cash, D.",
+        "Drucker, A.",
+        "Wee, H."
       ],
       "title": "Time-space tradeoffs and short collisions in merkle-damg\u00e5rd hash functions",
       "year": "2020",
-      "venue": "CRYPTO 2020, Part I",
+      "venue": "CRYPTO",
       "volume": "12170",
       "pages": "157\u2013186",
       "doi": "",
@@ -25,15 +25,15 @@
       "alpha_key": "ACDW20"
     },
     {
-      "key": "[2]",
-      "raw_text": "Bach, E.: Realistic analysis of some randomized algorithms. Journal of Computer and System Sciences 42(1), 30\u201353 (1991)",
+      "key": "[Bac91]",
+      "raw_text": "",
       "authors": [
-        "Bach, Eric"
+        "Bach, E."
       ],
       "title": "Realistic analysis of some randomized algorithms",
       "year": "1991",
       "venue": "Journal of Computer and System Sciences",
-      "volume": "42(1)",
+      "volume": "42",
       "pages": "30\u201353",
       "doi": "",
       "urls": [],
@@ -45,15 +45,15 @@
       "alpha_key": "Bac91"
     },
     {
-      "key": "[3]",
-      "raw_text": "Bernstein, D.J., Lange, T.: Computing small discrete logarithms faster. In: Galbraith, S.D., Nandi, M. (eds.) INDOCRYPT 2012. LNCS, vol. 7668, pp. 317\u2013338. Springer, Heidelberg (Dec 2012)",
+      "key": "[BL12]",
+      "raw_text": "",
       "authors": [
-        "Bernstein, Daniel J.",
-        "Lange, Tanja"
+        "Bernstein, D.J.",
+        "Lange, T."
       ],
       "title": "Computing small discrete logarithms faster",
       "year": "2012",
-      "venue": "INDOCRYPT 2012",
+      "venue": "INDOCRYPT",
       "volume": "7668",
       "pages": "317\u2013338",
       "doi": "",
@@ -66,18 +66,18 @@
       "alpha_key": "BL12"
     },
     {
-      "key": "[4]",
-      "raw_text": "Beullens, W., Beyne, T., Udovenko, A., Vitto, G.: Cryptanalysis of the Legendre PRF and generalizations. IACR Trans. Symm. Cryptol. 2020(1), 313\u2013330 (2020)",
+      "key": "[BBU+20]",
+      "raw_text": "",
       "authors": [
-        "Beullens, Ward",
-        "Beyne, Tim",
-        "Udovenko, Aleksei",
-        "Vitto, Giuseppe"
+        "Beullens, W.",
+        "Beyne, T.",
+        "Udovenko, A.",
+        "Vitto, G."
       ],
       "title": "Cryptanalysis of the Legendre PRF and generalizations",
       "year": "2020",
       "venue": "IACR Trans. Symm. Cryptol.",
-      "volume": "2020(1)",
+      "volume": "2020",
       "pages": "313\u2013330",
       "doi": "",
       "urls": [],
@@ -89,15 +89,15 @@
       "alpha_key": "BBUV20"
     },
     {
-      "key": "[5]",
-      "raw_text": "Beullens, W., de Saint Guilhem, C.: LegRoast: Efficient post-quantum signatures from the Legendre PRF. In: Ding, J., Tillich, J.P. (eds.) Post-Quantum Cryptography - 11th International Conference, PQCrypto 2020. pp. 130\u2013150. Springer, Heidelberg (2020)",
+      "key": "[BSG+20]",
+      "raw_text": "",
       "authors": [
-        "Beullens, Ward",
-        "de Saint Guilhem, Cyprien"
+        "Beullens, W.",
+        "de Saint Guilhem, C."
       ],
       "title": "LegRoast: Efficient post-quantum signatures from the Legendre PRF",
       "year": "2020",
-      "venue": "PQCrypto 2020",
+      "venue": "PQCrypto",
       "volume": "",
       "pages": "130\u2013150",
       "doi": "",
@@ -110,17 +110,17 @@
       "alpha_key": "BdSG20"
     },
     {
-      "key": "[6]",
-      "raw_text": "Coretti, S., Dodis, Y., Guo, S., Steinberger, J.: Random oracles and non-uniformity. In: Annual International Conference on the Theory and Applications of Cryptographic Techniques. pp. 227\u2013258. Springer (2018)",
+      "key": "[CDG+18]",
+      "raw_text": "",
       "authors": [
-        "Coretti, Sandro",
-        "Dodis, Yevgeniy",
-        "Guo, Siyao",
-        "Steinberger, John"
+        "Coretti, S.",
+        "Dodis, Y.",
+        "Guo, S.",
+        "Steinberger, J."
       ],
       "title": "Random oracles and non-uniformity",
       "year": "2018",
-      "venue": "EUROCRYPT 2018",
+      "venue": "EUROCRYPT",
       "volume": "",
       "pages": "227\u2013258",
       "doi": "",
@@ -133,15 +133,15 @@
       "alpha_key": "CDGS18"
     },
     {
-      "key": "[7]",
-      "raw_text": "Corrigan-Gibbs, H., Kogan, D.: The discrete-logarithm problem with preprocessing. In: Nielsen, J.B., Rijmen, V. (eds.) EUROCRYPT 2018, Part II. LNCS, vol. 10821, pp. 415\u2013447. Springer, Heidelberg (Apr / May 2018)",
+      "key": "[CGK18]",
+      "raw_text": "",
       "authors": [
-        "Corrigan-Gibbs, Henry",
-        "Kogan, Dmitry"
+        "Corrigan-Gibbs, H.",
+        "Kogan, D."
       ],
       "title": "The discrete-logarithm problem with preprocessing",
       "year": "2018",
-      "venue": "EUROCRYPT 2018, Part II",
+      "venue": "EUROCRYPT",
       "volume": "10821",
       "pages": "415\u2013447",
       "doi": "",
@@ -154,20 +154,18 @@
       "alpha_key": "CGK18"
     },
     {
-      "key": "[8]",
-      "raw_text": "Damg\u00e5rd, I.: On the randomness of legendre and jacobi sequences. In: Goldwasser, S. (ed.) Advances in Cryptology - CRYPTO '88. Lecture Notes in Computer Science, vol. 403, pp. 163\u2013172. Springer (1988)",
+      "key": "[Dam88]",
+      "raw_text": "",
       "authors": [
-        "Damg\u00e5rd, Ivan"
+        "Damg\u00e5rd, I."
       ],
       "title": "On the randomness of legendre and jacobi sequences",
       "year": "1988",
-      "venue": "CRYPTO '88",
+      "venue": "CRYPTO",
       "volume": "403",
       "pages": "163\u2013172",
       "doi": "10.1007/0-387-34799-2_13",
-      "urls": [
-        "https://doi.org/10.1007/0-387-34799-2_13"
-      ],
+      "urls": [],
       "eprint_id": "",
       "arxiv_id": "",
       "isbn": "",
@@ -176,17 +174,17 @@
       "alpha_key": "Dam88"
     },
     {
-      "key": "[9]",
-      "raw_text": "Davenport, H.: On the distribution of quadratic residues (mod p). Journal of the London Mathematical Society s1-8(1), 46-52 (1933)",
+      "key": "[Dav33]",
+      "raw_text": "",
       "authors": [
-        "Davenport, Harold"
+        "Davenport, H."
       ],
       "title": "On the distribution of quadratic residues (mod p)",
       "year": "1933",
       "venue": "Journal of the London Mathematical Society",
-      "volume": "s1-8(1)",
-      "pages": "46\u201352",
-      "doi": "10.1112/jlms/s1-8.1.46",
+      "volume": "s1-8",
+      "pages": "46-52",
+      "doi": "",
       "urls": [
         "https://londmathsoc.onlinelibrary.wiley.com/doi/abs/10.1112/jlms/s1-8.1.46"
       ],
@@ -198,16 +196,16 @@
       "alpha_key": "Dav33"
     },
     {
-      "key": "[10]",
-      "raw_text": "Erd\u0151s, P., R\u00e9nyi, A.: On the evolution of random graphs. Publ. Math. Inst. Hung. Acad. Sci 5(1), 17\u201360 (1960)",
+      "key": "[ER60]",
+      "raw_text": "",
       "authors": [
-        "Erd\u0151s, Paul",
-        "R\u00e9nyi, Alfr\u00e9d"
+        "Erd\u0151s, P.",
+        "R\u00e9nyi, A."
       ],
       "title": "On the evolution of random graphs",
       "year": "1960",
       "venue": "Publ. Math. Inst. Hung. Acad. Sci",
-      "volume": "5(1)",
+      "volume": "5",
       "pages": "17\u201360",
       "doi": "",
       "urls": [],
@@ -219,19 +217,19 @@
       "alpha_key": "ER60"
     },
     {
-      "key": "[11]",
-      "raw_text": "Escott, A., Sager, J., Selkirk, A., Tsapakidis, D.: Attacking elliptic curve cryptosystems using the parallel pollard rho method. CryptoBytes-The Technical Newsletter of RSA Laboratories 4(2), 15-19 (1999)",
+      "key": "[ESS+99]",
+      "raw_text": "",
       "authors": [
-        "Escott, Adrian",
-        "Sager, John",
-        "Selkirk, Aaron",
-        "Tsapakidis, Dimitrios"
+        "Escott, A.",
+        "Sager, J.",
+        "Selkirk, A.",
+        "Tsapakidis, D."
       ],
       "title": "Attacking elliptic curve cryptosystems using the parallel pollard rho method",
       "year": "1999",
-      "venue": "CryptoBytes-The Technical Newsletter of RSA Laboratories",
-      "volume": "4(2)",
-      "pages": "15\u201319",
+      "venue": "CryptoBytes",
+      "volume": "4",
+      "pages": "15-19",
       "doi": "",
       "urls": [],
       "eprint_id": "",
@@ -242,15 +240,15 @@
       "alpha_key": "ESST99"
     },
     {
-      "key": "[12]",
-      "raw_text": "Esser, A., May, A.: Low weight discrete logarithm and subset sum in 2^0.65n with polynomial memory. In: Canteaut, A., Ishai, Y. (eds.) EUROCRYPT 2020, Part III. LNCS, vol. 12107, pp. 94\u2013122. Springer, Heidelberg (May 2020)",
+      "key": "[EMM+20]",
+      "raw_text": "",
       "authors": [
-        "Esser, Andre",
-        "May, Alexander"
+        "Esser, A.",
+        "May, A."
       ],
       "title": "Low weight discrete logarithm and subset sum in 2^0.65n with polynomial memory",
       "year": "2020",
-      "venue": "EUROCRYPT 2020, Part III",
+      "venue": "EUROCRYPT",
       "volume": "12107",
       "pages": "94\u2013122",
       "doi": "",
@@ -263,10 +261,10 @@
       "alpha_key": "EM20"
     },
     {
-      "key": "[13]",
-      "raw_text": "Foundation, E.: Ethereum 2.0 (2020), https://ethereum.org/en/eth2/",
+      "key": "[Fou20a]",
+      "raw_text": "",
       "authors": [
-        "Ethereum Foundation"
+        "Foundation, E."
       ],
       "title": "Ethereum 2.0",
       "year": "2020",
@@ -285,10 +283,10 @@
       "alpha_key": "Fou20"
     },
     {
-      "key": "[14]",
-      "raw_text": "Foundation, E.: Ethereum 2.0 (2020), https://github.com/ethereum/eth2.0-specs",
+      "key": "[Fou20b]",
+      "raw_text": "",
       "authors": [
-        "Ethereum Foundation"
+        "Foundation, E."
       ],
       "title": "Ethereum 2.0",
       "year": "2020",
@@ -307,16 +305,16 @@
       "alpha_key": "Fou20"
     },
     {
-      "key": "[15]",
-      "raw_text": "Fouque, P.A., Joux, A., Mavromati, C.: Multi-user collisions: Applications to discrete logarithm, Even-Mansour and PRINCE. In: Sarkar, P., Iwata, T. (eds.) ASIACRYPT 2014, Part I. LNCS, vol. 8873, pp. 420\u2013438. Springer, Heidelberg (Dec 2014)",
+      "key": "[FJM14]",
+      "raw_text": "",
       "authors": [
-        "Fouque, Pierre-Alain",
-        "Joux, Antoine",
-        "Mavromati, Chrysanthi"
+        "Fouque, P.A.",
+        "Joux, A.",
+        "Mavromati, C."
       ],
       "title": "Multi-user collisions: Applications to discrete logarithm, Even-Mansour and PRINCE",
       "year": "2014",
-      "venue": "ASIACRYPT 2014, Part I",
+      "venue": "ASIACRYPT",
       "volume": "8873",
       "pages": "420\u2013438",
       "doi": "",
@@ -329,17 +327,17 @@
       "alpha_key": "FJM14"
     },
     {
-      "key": "[16]",
-      "raw_text": "Galbraith, S.D., Wang, P., Zhang, F.: Computing elliptic curve discrete logarithms with improved baby-step giant-step algorithm. Advances in Mathematics of Communications 11(3), 453 (2017)",
+      "key": "[GWZ17]",
+      "raw_text": "",
       "authors": [
-        "Galbraith, Steven D.",
-        "Wang, Ping",
-        "Zhang, Fangguo"
+        "Galbraith, S.D.",
+        "Wang, P.",
+        "Zhang, F."
       ],
       "title": "Computing elliptic curve discrete logarithms with improved baby-step giant-step algorithm",
       "year": "2017",
       "venue": "Advances in Mathematics of Communications",
-      "volume": "11(3)",
+      "volume": "11",
       "pages": "453",
       "doi": "",
       "urls": [],
@@ -351,18 +349,18 @@
       "alpha_key": "GWZ17"
     },
     {
-      "key": "[17]",
-      "raw_text": "Grassi, L., Rechberger, C., Rotaru, D., Scholl, P., Smart, N.P.: MPC-friendly symmetric key primitives. In: Weippl, E.R., Katzenbeisser, S., Kruegel, C., Myers, A.C., Halevi, S. (eds.) ACM CCS 2016. pp. 430\u2013443. ACM Press (Oct 2016)",
+      "key": "[GRS+16]",
+      "raw_text": "",
       "authors": [
-        "Grassi, Lorenzo",
-        "Rechberger, Christian",
-        "Rotaru, Dragos",
-        "Scholl, Peter",
-        "Smart, Nigel P."
+        "Grassi, L.",
+        "Rechberger, C.",
+        "Rotaru, D.",
+        "Scholl, P.",
+        "Smart, N.P."
       ],
       "title": "MPC-friendly symmetric key primitives",
       "year": "2016",
-      "venue": "ACM CCS 2016",
+      "venue": "ACM CCS",
       "volume": "",
       "pages": "430\u2013443",
       "doi": "",
@@ -375,18 +373,18 @@
       "alpha_key": "GRR+16"
     },
     {
-      "key": "[18]",
-      "raw_text": "Ishai, Y., Kushilevitz, E., Ostrovsky, R., Sahai, A.: Zero-knowledge proofs from secure multiparty computation. SIAM Journal on Computing 39(3), 1121\u20131152 (2009)",
+      "key": "[IKOS09]",
+      "raw_text": "",
       "authors": [
-        "Ishai, Yuval",
-        "Kushilevitz, Eyal",
-        "Ostrovsky, Rafail",
-        "Sahai, Amit"
+        "Ishai, Y.",
+        "Kushilevitz, E.",
+        "Ostrovsky, R.",
+        "Sahai, A."
       ],
       "title": "Zero-knowledge proofs from secure multiparty computation",
       "year": "2009",
       "venue": "SIAM Journal on Computing",
-      "volume": "39(3)",
+      "volume": "39",
       "pages": "1121\u20131152",
       "doi": "",
       "urls": [],
@@ -398,16 +396,16 @@
       "alpha_key": "IKOS09"
     },
     {
-      "key": "[19]",
-      "raw_text": "Kaluderovic, N., Kleinjung, T., Kostic, D.: Improved key recovery on the legendre PRF (2020), https://eprint.iacr.org/2020/098",
+      "key": "[KKK20]",
+      "raw_text": "",
       "authors": [
-        "Kaluderovic, Novak",
-        "Kleinjung, Thorsten",
-        "Kostic, Dusan"
+        "Kaluderovic, N.",
+        "Kleinjung, T.",
+        "Kostic, D."
       ],
       "title": "Improved key recovery on the legendre PRF",
       "year": "2020",
-      "venue": "Cryptology ePrint Archive",
+      "venue": "",
       "volume": "",
       "pages": "",
       "doi": "",
@@ -418,14 +416,14 @@
       "arxiv_id": "",
       "isbn": "",
       "note": "",
-      "entry_type": "misc",
+      "entry_type": "techreport",
       "alpha_key": "KKK20"
     },
     {
-      "key": "[20]",
-      "raw_text": "Khovratovich, D.: Key recovery attacks on the Legendre PRFs within the birthday bound. Cryptology ePrint Archive, Report 2019/862 (2019), https://eprint.iacr.org/2019/862",
+      "key": "[Kho19]",
+      "raw_text": "",
       "authors": [
-        "Khovratovich, Dmitry"
+        "Khovratovich, D."
       ],
       "title": "Key recovery attacks on the Legendre PRFs within the birthday bound",
       "year": "2019",
@@ -439,20 +437,20 @@
       "eprint_id": "2019/862",
       "arxiv_id": "",
       "isbn": "",
-      "note": "Report 2019/862",
-      "entry_type": "misc",
+      "note": "",
+      "entry_type": "techreport",
       "alpha_key": "Kho19"
     },
     {
-      "key": "[21]",
-      "raw_text": "Kuhn, F., Struik, R.: Random walks revisited: Extensions of Pollard's rho algorithm for computing multiple discrete logarithms. In: Vaudenay, S., Youssef, A.M. (eds.) SAC 2001. LNCS, vol. 2259, pp. 212\u2013229. Springer, Heidelberg (Aug 2001)",
+      "key": "[KS01]",
+      "raw_text": "",
       "authors": [
-        "Kuhn, Fabian",
-        "Struik, Ren\u00e9"
+        "Kuhn, F.",
+        "Struik, R."
       ],
       "title": "Random walks revisited: Extensions of Pollard's rho algorithm for computing multiple discrete logarithms",
       "year": "2001",
-      "venue": "SAC 2001",
+      "venue": "SAC",
       "volume": "2259",
       "pages": "212\u2013229",
       "doi": "",
@@ -465,12 +463,12 @@
       "alpha_key": "KS01"
     },
     {
-      "key": "[22]",
-      "raw_text": "Lee, H.T., Cheon, J.H., Hong, J.: Accelerating ID-based encryption based on trapdoor DL using pre-computation. Cryptology ePrint Archive, Report 2011/187 (2011), http://eprint.iacr.org/2011/187",
+      "key": "[LCH11]",
+      "raw_text": "",
       "authors": [
-        "Lee, Hyung Tae",
-        "Cheon, Jung Hee",
-        "Hong, Jin"
+        "Lee, H.T.",
+        "Cheon, J.H.",
+        "Hong, J."
       ],
       "title": "Accelerating ID-based encryption based on trapdoor DL using pre-computation",
       "year": "2011",
@@ -484,19 +482,19 @@
       "eprint_id": "2011/187",
       "arxiv_id": "",
       "isbn": "",
-      "note": "Report 2011/187",
-      "entry_type": "misc",
+      "note": "",
+      "entry_type": "techreport",
       "alpha_key": "LCH11"
     },
     {
-      "key": "[23]",
-      "raw_text": "Mihalcik, J.P.: An analysis of algorithms for solving discrete logarithms in fixed groups. master's thesis. Naval Postgraduate School (2010)",
+      "key": "[Mih10]",
+      "raw_text": "",
       "authors": [
-        "Mihalcik, John P."
+        "Mihalcik, J.P."
       ],
       "title": "An analysis of algorithms for solving discrete logarithms in fixed groups",
       "year": "2010",
-      "venue": "Naval Postgraduate School",
+      "venue": "master's thesis",
       "volume": "",
       "pages": "",
       "doi": "",
@@ -511,15 +509,15 @@
       "alpha_key": "Mih10"
     },
     {
-      "key": "[24]",
-      "raw_text": "Peralta, R.: On the distribution of quadratic residues and non-residues modulo a prime number. Mathematics of Computation 58(197), 433\u2013440 (1992)",
+      "key": "[Per92]",
+      "raw_text": "",
       "authors": [
-        "Peralta, Ren\u00e9"
+        "Peralta, R."
       ],
       "title": "On the distribution of quadratic residues and non-residues modulo a prime number",
       "year": "1992",
       "venue": "Mathematics of Computation",
-      "volume": "58(197)",
+      "volume": "58",
       "pages": "433\u2013440",
       "doi": "",
       "urls": [],
@@ -531,15 +529,15 @@
       "alpha_key": "Per92"
     },
     {
-      "key": "[25]",
-      "raw_text": "Pollard, J.M.: Monte carlo methods for index computation (mod p). Mathematics of computation 32(143), 918\u2013924 (1978)",
+      "key": "[Pol78]",
+      "raw_text": "",
       "authors": [
-        "Pollard, John M."
+        "Pollard, J.M."
       ],
       "title": "Monte carlo methods for index computation (mod p)",
       "year": "1978",
-      "venue": "Mathematics of Computation",
-      "volume": "32(143)",
+      "venue": "Mathematics of computation",
+      "volume": "32",
       "pages": "918\u2013924",
       "doi": "",
       "urls": [],
@@ -551,16 +549,16 @@
       "alpha_key": "Pol78"
     },
     {
-      "key": "[26]",
-      "raw_text": "Russell, A., Shparlinski, I.E.: Classical and quantum function reconstruction via character evaluation. Journal of Complexity 20(2-3), 404\u2013422 (2004)",
+      "key": "[RS04]",
+      "raw_text": "",
       "authors": [
-        "Russell, Alexander",
-        "Shparlinski, Igor E."
+        "Russell, A.",
+        "Shparlinski, I.E."
       ],
       "title": "Classical and quantum function reconstruction via character evaluation",
       "year": "2004",
       "venue": "Journal of Complexity",
-      "volume": "20(2-3)",
+      "volume": "20",
       "pages": "404\u2013422",
       "doi": "",
       "urls": [],
@@ -572,16 +570,16 @@
       "alpha_key": "RS04"
     },
     {
-      "key": "[27]",
-      "raw_text": "van Oorschot, P.C., Wiener, M.J.: Parallel collision search with cryptanalytic applications. Journal of Cryptology 12(1), 1\u201328 (Jan 1999)",
+      "key": "[vOW99]",
+      "raw_text": "",
       "authors": [
-        "van Oorschot, Paul C.",
-        "Wiener, Michael J."
+        "van Oorschot, P.C.",
+        "Wiener, M.J."
       ],
       "title": "Parallel collision search with cryptanalytic applications",
       "year": "1999",
       "venue": "Journal of Cryptology",
-      "volume": "12(1)",
+      "volume": "12",
       "pages": "1\u201328",
       "doi": "",
       "urls": [],

--- a/data/markdown/eprint/2021_645/bibliography_info.json
+++ b/data/markdown/eprint/2021_645/bibliography_info.json
@@ -1,13 +1,13 @@
 {
-  "provider": "claude-code",
-  "model": "sonnet",
-  "extracted_at": "2026-03-29T16:04:27.340516+00:00",
-  "elapsed_seconds": 70.05,
+  "provider": "mistral",
+  "model": "mistral-small-latest",
+  "extracted_at": "2026-03-29T16:21:33.551027+00:00",
+  "elapsed_seconds": 15.73,
   "source_markdown": "2021_645.md",
   "markdown_sha256": "4f82afcfe3915366918a12dc02dd491fbe0860929380e05abd23190cf3d88744",
   "prompt_version": "v2",
   "reference_count": 27,
-  "input_tokens": 0,
-  "output_tokens": 0,
-  "estimated_cost_usd": 0.0
+  "input_tokens": 2455,
+  "output_tokens": 3909,
+  "estimated_cost_usd": 0.001418
 }


### PR DESCRIPTION
Extracted structured bibliography for `2021/645`.

27 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit dcdf007)
Website: https://papyrus.badaas.eu