### PR TITLE
fix: repair OCR ligature artifacts in 2020/1160

### DIFF
--- a/data/markdown/eprint/2020_1160/2020_1160.md
+++ b/data/markdown/eprint/2020_1160/2020_1160.md
@@ -25,9 +25,9 @@ Together with the result of Goldreich and Oren, this characterizes when determin
 
 # 1 Introduction
 
-Goldwasser, Micali, and Racko [\[GMR89\]](#page-25-0) founded the concept of zero-knowledge proofs on two main elements: interaction and randomness. While both interaction and verier randomness are known to be essential for zero knowledge, the answer as to whether the prover must also be randomized is not as denite. Goldreich and Oren [\[GO94\]](#page-25-1) showed that prover randomness is essential in order to achieve auxiliary-input zero-knowledge for non-trivial languages. According to this notion, motivated by composition [\[GK96\]](#page-25-2), anything that a verier can learn from the proof, on top of the auxiliary information z it already possesses, can be eciently simulated given the same auxiliary information z.
+Goldwasser, Micali, and Racko [\[GMR89\]](#page-25-0) founded the concept of zero-knowledge proofs on two main elements: interaction and randomness. While both interaction and verier randomness are known to be essential for zero knowledge, the answer as to whether the prover must also be randomized is not as denite. Goldreich and Oren [\[GO94\]](#page-25-1) showed that prover randomness is essential in order to achieve auxiliary-input zero-knowledge for non-trivial languages. According to this notion, motivated by composition [\[GK96\]](#page-25-2), anything that a verier can learn from the proof, on top of the auxiliary information z it already possesses, can be efficiently simulated given the same auxiliary information z.
 
-So when is deterministic-prover zero knowledge possible? So far, deterministic prover zero knowledge have only been shown to exist in the honest-verier seing. Here Faonio, Nielsen, and Venturi [\[FNV17\]](#page-25-3) proved that any NP language L that has a witness encryption scheme [\[GGSW13\]](#page-25-4), also has a deterministicprover honest-verier (perfect) zero-knowledge argument, or proof, if the language L has a hash proof system [\[CS02\]](#page-25-5). A similar result was recently shown by Dahari and Lindell [\[DL20\]](#page-25-6). In the same work, Dahari and Lindell also show a statistically sound honest-verier zero knowledge protocol with an unbounded honest prover for all of NP assuming doubly-enhanced injective one-way functions. In the malicious verier seing, they give a protocol satisfying a non-standard distributional notion of zero knowledge. In their denition, the prover has access to a pair of witnesses sampled from a distribution, which satisfy a certain entropy guarantee.
+So when is deterministic-prover zero knowledge possible? So far, deterministic prover zero knowledge have only been shown to exist in the honest-verier seing. Here Faonio, Nielsen, and Venturi [\[FNV17\]](#page-25-3) proved that any NP language L that has a witness encryption scheme [\[GGSW13\]](#page-25-4), also has a deterministicprover honest-verier (perfect) zero-knowledge argument, or proof, if the language L has a hash proof system [\[CS02\]](#page-25-5). A similar result was recently shown by Dahari and Lindell [\[DL20\]](#page-25-6). In the same work, Dahari and Lindell also show a statistically sound honest-verier zero knowledge protocol with an unbounded honest prover for all of NP assuming doubly-enhanced injective one-way functions. In the malicious verier seing, they give a protocol satisfying a non-standard distributional notion of zero knowledge. In their definition, the prover has access to a pair of witnesses sampled from a distribution, which satisfy a certain entropy guarantee.
 
 Whether zero knowledge with a truly deterministic prover is possible considering any meaningful form of malicious veriers remains unknown.
 
@@ -39,19 +39,19 @@ eorem 1 (Informal). Assuming non-interactive witness-indistinguishable proofs an
 
 eorem 2 (Informal). Assuming also keyless hash functions that are collision-resistant against boundedauxiliary-input quasipolynomial-time aackers, there exist similar arguments for all of NP.
 
-By zero knowledge against bounded-auxiliary-input veriers we formally mean that for any polynomial bound b, there exists a corresponding deterministic-prover argument that is zero knowledge against (malicious) veriers with non-uniform auxiliary input of size at most b. is, in particular, includes the class of uniform veriers, considered in the original zero-knowledge denition of [\[GMR89\]](#page-25-0). We stress that the running time of the verier may be an arbitrary polynomial, potentially larger than b. Also, indistinguishability of simulated and real proofs holds against non-uniform distinguishers of arbitrary polynomial size. Same goes for soundness, which holds against non-uniform provers of arbitrary polynomial size.
+By zero knowledge against bounded-auxiliary-input veriers we formally mean that for any polynomial bound b, there exists a corresponding deterministic-prover argument that is zero knowledge against (malicious) veriers with non-uniform auxiliary input of size at most b. is, in particular, includes the class of uniform veriers, considered in the original zero-knowledge definition of [\[GMR89\]](#page-25-0). We stress that the running time of the verier may be an arbitrary polynomial, potentially larger than b. Also, indistinguishability of simulated and real proofs holds against non-uniform distinguishers of arbitrary polynomial size. Same goes for soundness, which holds against non-uniform provers of arbitrary polynomial size.
 
 Together with the impossibility result of Goldreich and Oren for unbounded auxiliary input, the above results give a complete picture of when exactly deterministic-prover zero knowledge is feasible. We note
 
-<span id="page-1-0"></span><sup>1</sup> Indistinguishability obfuscation implies non-interactive witness indistinguishable proofs, but with a randomized verier [\[BP15\]](#page-25-7), which is insucient for our purpose. e verier can be derandomized under a worst-case Nisan-Wigderson [\[NW94\]](#page-26-0) type derandomization assumption [\[BV17\]](#page-25-8). Non-interactive witness indistinguishable proofs with a deterministic verier are also known from standard assumptions on bilinear maps [\[GOS06\]](#page-25-9).
+<span id="page-1-0"></span><sup>1</sup> Indistinguishability obfuscation implies non-interactive witness indistinguishable proofs, but with a randomized verier [\[BP15\]](#page-25-7), which is insufficient for our purpose. e verier can be derandomized under a worst-case Nisan-Wigderson [\[NW94\]](#page-26-0) type derandomization assumption [\[BV17\]](#page-25-8). Non-interactive witness indistinguishable proofs with a deterministic verier are also known from standard assumptions on bilinear maps [\[GOS06\]](#page-25-9).
 
 {2}------------------------------------------------
 
 that two-message zero knowledge against unbounded auxiliary input is by itself known to be impossible. Our result indeed circumvents this impossibility (for bounded auxiliary input), but this was already known (with a randomized prover) [\[BCPR14\]](#page-24-0).
 
-On the Necessity of Strong Assumptions and Predictable Arguments. To demonstrate the feasibility of deterministic-prover zero knowledge, we rely on hardness assumptions that are arguably strong. We show that this is inherent. Specically, we show that deterministic prover zero-knowledge arguments for NP imply witness encryption for NP, which at this point is only known based on strong assumptions, such as indistinguishability obfuscation.
+On the Necessity of Strong Assumptions and Predictable Arguments. To demonstrate the feasibility of deterministic-prover zero knowledge, we rely on hardness assumptions that are arguably strong. We show that this is inherent. Specifically, we show that deterministic prover zero-knowledge arguments for NP imply witness encryption for NP, which at this point is only known based on strong assumptions, such as indistinguishability obfuscation.
 
-e implication to witness encryption, in fact, follows from a more general implication to predictable arguments. Predictable arguments, introduced by Faonio, Nielsen, and Venturi [\[FNV17\]](#page-25-3), are arguments where the honest verier's (private) random coins eciently determine a unique accepting transcript in order to convince the verier, the prover must be consistent with this transcript throughout the entire protocol. We prove that any deterministic-prover zero-knowledge argument against bounded-auxiliaryinput veriers can be turned into a predictable argument. e transformation, in fact, preserves the honest prover algorithm, and in particular also zero knowledge.
+e implication to witness encryption, in fact, follows from a more general implication to predictable arguments. Predictable arguments, introduced by Faonio, Nielsen, and Venturi [\[FNV17\]](#page-25-3), are arguments where the honest verier's (private) random coins efficiently determine a unique accepting transcript in order to convince the verier, the prover must be consistent with this transcript throughout the entire protocol. We prove that any deterministic-prover zero-knowledge argument against bounded-auxiliaryinput veriers can be turned into a predictable argument. e transformation, in fact, preserves the honest prover algorithm, and in particular also zero knowledge.
 
 eorem 3 (Informal). Any deterministic-prover zero-knowledge argument against bounded-auxiliary-input veriers can be made predictable.
 
@@ -75,7 +75,7 @@ We now give an overview of the main ideas and techniques behind our results.
 
 e Deterministic-Prover Zero-Knowledge Protocol. Our starting point is the protocol against honest veriers based on witness encryption [\[FNV17\]](#page-25-3). In their protocol, the verier simply sends a witness encryption of a random message u with respect to the statement x ∈ L to be proven, and expects to get u back from the prover. Witness encryption guarantees that a prover that has a corresponding witness w, can obtain u and convince the verier. However, if the statement is false, namely x /∈ L, u is hidden, and soundness is guaranteed.
 
-While honest veriers are easy to simulate in this scheme, it is not clear how to simulate malicious veriers. For this purpose, we aim to add to the protocol a trapdoor way of obtaining u. A simulator that has the code of the verier should be able to extract the message u. In contrast, a malicious prover who doesn't have the code (specically, the verier's randomness) should still fail to nd u when x /∈ L.
+While honest veriers are easy to simulate in this scheme, it is not clear how to simulate malicious veriers. For this purpose, we aim to add to the protocol a trapdoor way of obtaining u. A simulator that has the code of the verier should be able to extract the message u. In contrast, a malicious prover who doesn't have the code (specifically, the verier's randomness) should still fail to nd u when x /∈ L.
 
 Explainable Veriers. To explain the idea behind the protocol in its simplest form, let us start by assuming that the rst message v sent by verier to the prover is always explainable [\[BKP19\]](#page-24-1). at is, there exist honest verier coins r that explain this message as an honest verier message v = V(x; r). e dierence between this seing and the honest verier seing is that the explaining coins r may be distributed arbitrarily and also computationally hard to nd.
 
@@ -83,27 +83,27 @@ Our basic idea is for the verier to send the prover yet another witness encrypti
 
 "ere exists a program Π of size b + λ (namely short) that outputs R."
 
-To argue that the protocol remains sound, we note that except with negligible probability 2 <sup>−</sup><sup>λ</sup> over the choice of r, such a short program does not exist. In this case, witness encryption will guarantee that u remains hidden and soundness is preserved. Furthermore, a simulator in possession of the b-size code V ∗ of the malicious verier can now use it to simulate. Specically, let ` be the amount of coins r <sup>∗</sup> used by V ∗ , then the simulator will sample r <sup>∗</sup> using a pseudorandom generator that stretches a seed s <sup>∗</sup> of length ≈ λ to a pseudorandom r <sup>∗</sup> of length `. Looking at the string R that V ∗ (x; r ∗ ) outputs, the simulator now possesses a size-(b + λ) program Π that computes R — the code of V <sup>∗</sup> with the seed s <sup>∗</sup> hardwired. is in turn leads to valid simulation.
+To argue that the protocol remains sound, we note that except with negligible probability 2 <sup>−</sup><sup>λ</sup> over the choice of r, such a short program does not exist. In this case, witness encryption will guarantee that u remains hidden and soundness is preserved. Furthermore, a simulator in possession of the b-size code V ∗ of the malicious verier can now use it to simulate. Specifically, let ` be the amount of coins r <sup>∗</sup> used by V ∗ , then the simulator will sample r <sup>∗</sup> using a pseudorandom generator that stretches a seed s <sup>∗</sup> of length ≈ λ to a pseudorandom r <sup>∗</sup> of length `. Looking at the string R that V ∗ (x; r ∗ ) outputs, the simulator now possesses a size-(b + λ) program Π that computes R — the code of V <sup>∗</sup> with the seed s <sup>∗</sup> hardwired. is in turn leads to valid simulation.
 
-Witness Encryption for Unbounded NP Relations and IO. One thing to notice about the laer protocol is that in fact the existence of program Π that outputs R is not an NP statement, unless we restrict the running time of Π to some specic polynomial. However, while the non-uniform description size (equivalently, auxiliary input size) of the malicious verier V ∗ is a-priori bounded, its running time is not bounded by any specic polynomial.
+Witness Encryption for Unbounded NP Relations and IO. One thing to notice about the laer protocol is that in fact the existence of program Π that outputs R is not an NP statement, unless we restrict the running time of Π to some specific polynomial. However, while the non-uniform description size (equivalently, auxiliary input size) of the malicious verier V ∗ is a-priori bounded, its running time is not bounded by any specific polynomial.
 
-Accordingly, we need a strong notion of witness encryption for unbounded non-deterministic relations. Specically, encryption under a statement x should take time polynomial in |x| (and the security parameter), and not depend on the time required to verify a witness for x. In contrast, decrypting with a witness w should take time proportional to the time required to verify w. Such witness encryption schemes directly follow from known indistinguishability obfuscation (IO) schemes for Turing Machines, which are in turn constructed from subexponentially-secure IO for circuits [\[KLW15,](#page-26-1) [BCG](#page-24-3)+18, [GS18\]](#page-25-11).
+Accordingly, we need a strong notion of witness encryption for unbounded non-deterministic relations. Specifically, encryption under a statement x should take time polynomial in |x| (and the security parameter), and not depend on the time required to verify a witness for x. In contrast, decrypting with a witness w should take time proportional to the time required to verify w. Such witness encryption schemes directly follow from known indistinguishability obfuscation (IO) schemes for Turing Machines, which are in turn constructed from subexponentially-secure IO for circuits [\[KLW15,](#page-26-1) [BCG](#page-24-3)+18, [GS18\]](#page-25-11).
 
 {4}------------------------------------------------
 
 Malicious Veriers. Having constructed a protocol against explainable veriers, we use compilers from the literature to turn it into a protocol against arbitrary veriers. ese compilers use non-interactive witness-indistinguishable proofs (NIWIs) in order to enforce explainable behavior on the verier's side. Being non-interactive verifying, these proofs require no randomness from the honest zero-knowledge prover.
 
-e rst such compiler [\[BKP19\]](#page-24-1) works for NP∩coNP and requires no additional hardness assumptions. e second compiler is taken from [\[BP04\]](#page-25-12) (where it was used in a dierent context) and relies in addition on keyless hash functions that are collision resistant against aackers with bounded auxiliary input and quasipolynomial running time, as well as subexponentially secure commitments (which in turn follow from subexponentially secure IO and one-way functions). In the body, we reanalyze these compilers to show that they can be used to enforce robust explainability, which roughly means that the verier's messages are almost always explainable on any eciently samplable distribution on its coins, a property required for our simulation strategy. See more details in Section [3.](#page-10-0)
+e rst such compiler [\[BKP19\]](#page-24-1) works for NP∩coNP and requires no additional hardness assumptions. e second compiler is taken from [\[BP04\]](#page-25-12) (where it was used in a different context) and relies in addition on keyless hash functions that are collision resistant against aackers with bounded auxiliary input and quasipolynomial running time, as well as subexponentially secure commitments (which in turn follow from subexponentially secure IO and one-way functions). In the body, we reanalyze these compilers to show that they can be used to enforce robust explainability, which roughly means that the verier's messages are almost always explainable on any efficiently samplable distribution on its coins, a property required for our simulation strategy. See more details in Section [3.](#page-10-0)
 
 From Deterministic-Prover Zero Knowledge to Predictable Arguments. We now explain how deterministic-prover zero knowledge implies predictable arguments, which in turn imply witness encryption (as well as the additional properties stated in Corollary [2\)](#page-2-0). We start with an oversimplied transformation that captures the main idea, but does not fully work, and then explain how to augment it. is oversimplied transformation, in fact, starts from deterministic-prover honest-verier zero knowledge.
 
 Let (P, V) be our argument, and let Sim be the honest-verier simulator. We consider a new verier V 0 that works as follows. It applies the simulator Sim(x) to obtain simulated randomness r˜ for the honest verier along with simulated prover messages p˜1, . . . , p˜k. e verier V 0 then certies that the prover messages lead to an accepting transcript with respect to the verier coins r. If they do not lead to an accepting transcript, V 0 automatically rejects; otherwise, it interacts with the prover, and rejects the moment it receives a message p<sup>i</sup> 6= p˜<sup>i</sup> . e described protocol is predictable by construction. Also, since we do not change the honest prover, it is zero knowledge against the same class of veriers as the original protocol. We now turn to argue that the protocol is complete and sound.
 
-To see that the protocol has almost perfect completeness, consider a distinguisher that has the witness w hardwired. Given a transcript p1, . . . , p<sup>k</sup> and verier coins r, it can perfectly emulate a conversation between the deterministic prover P(x, w) and honest verier V(x; r) and check whether the produced prover messages are consistent with the input transcript p1, . . . , pk, and that the transcript is accepting. We deduce that with overwhelming probability the simulator produces simulated messages p˜1, . . . , p˜k, and randomness r, such that the honest prover would produce the same messages, and the transcript will be accepting. To see soundness, notice that if the simulated coins r are pseudorandom and the simulated prover messages p˜1, . . . , p˜<sup>k</sup> are accepting, then by the soundness of the original protocol (P, V), it should be hard for an ecient prover to produce messages consistent with p˜1, . . . , p˜<sup>k</sup> (or with any accepting transcript).
+To see that the protocol has almost perfect completeness, consider a distinguisher that has the witness w hardwired. Given a transcript p1, . . . , p<sup>k</sup> and verier coins r, it can perfectly emulate a conversation between the deterministic prover P(x, w) and honest verier V(x; r) and check whether the produced prover messages are consistent with the input transcript p1, . . . , pk, and that the transcript is accepting. We deduce that with overwhelming probability the simulator produces simulated messages p˜1, . . . , p˜k, and randomness r, such that the honest prover would produce the same messages, and the transcript will be accepting. To see soundness, notice that if the simulated coins r are pseudorandom and the simulated prover messages p˜1, . . . , p˜<sup>k</sup> are accepting, then by the soundness of the original protocol (P, V), it should be hard for an efficient prover to produce messages consistent with p˜1, . . . , p˜<sup>k</sup> (or with any accepting transcript).
 
-Above, when proving soundness we actually made the implicit assumption that the honest verier simulator Sim(x) produces pseudorandom verier coins, even when given a no instance x /∈ L. Indeed, with respect to random, or pseudorandom, coins, we can argue that it is hard to nd accepting transcripts. While this is a natural property, it does not follow directly from honest verier zero knowledge. To circumvent this diculty, we slightly augment the above transformation, while relying on zero-knowledge against (not necessarily honest) bounded-auxiliary-input veriers.
+Above, when proving soundness we actually made the implicit assumption that the honest verier simulator Sim(x) produces pseudorandom verier coins, even when given a no instance x /∈ L. Indeed, with respect to random, or pseudorandom, coins, we can argue that it is hard to nd accepting transcripts. While this is a natural property, it does not follow directly from honest verier zero knowledge. To circumvent this difficulty, we slightly augment the above transformation, while relying on zero-knowledge against (not necessarily honest) bounded-auxiliary-input veriers.
 
-Specically, the verier V <sup>0</sup> uses a pseudorandom generator to sample coins r for the honest verier V, using a short seed s. It then applies the same procedure as above, except that it runs the simulator 
+Specifically, the verier V <sup>0</sup> uses a pseudorandom generator to sample coins r for the honest verier V, using a short seed s. It then applies the same procedure as above, except that it runs the simulator 
 
 {5}------------------------------------------------
 
@@ -113,9 +113,9 @@ A Word on Two-Message Laconic Arguments. As stated in Corollary [2,](#page-2-0) 
 
 On Deterministic Prover Zero-Knowledge Proofs. While our results (in conjunction with prior works) provide a complete picture of deterministic zero-knowledge arguments, our results do not have any bearing on deterministic zero-knowledge proofs, where soundness is required to hold against unbounded provers. Completing the picture for proofs remains an interesting open problem.
 
-# 2 Denitions
+# 2 Definitions
 
-In this work, we will consider PPT machines with both, bounded and unbounded non-uniform auxiliary input. For simplicity of notation, rather than considering explicit auxiliary input in our denitions, we consider two basic notions of non-uniformity. e corresponding zero knowledge denition will in particular capture the auxiliary input seing. See Remark [1.](#page-6-0)
+In this work, we will consider PPT machines with both, bounded and unbounded non-uniform auxiliary input. For simplicity of notation, rather than considering explicit auxiliary input in our definitions, we consider two basic notions of non-uniformity. e corresponding zero knowledge definition will in particular capture the auxiliary input seing. See Remark [1.](#page-6-0)
 
 - 1. non-uniform PPT: this is the standard notion of non-uniform PPT machines. Formally, a nonuniform PPT M = {M<sup>λ</sup> }<sup>λ</sup> is a family of probabilistic Turing machines (one for each λ), where there exists a polynomial poly, such that the description size |Mλ| and the running time of M<sup>λ</sup> are bounded by poly(λ).
 - 2. b-non-uniform PPT: ese are PPT machines with non-uniform description of size b(λ) and arbitrary polynomial running time (possibly larger than b(λ)). Formally, a b-non-uniform PPT M = {M<sup>λ</sup> }<sup>λ</sup> is a family of probabilistic Turing machines (one for each λ), where |Mλ| ≤ b(λ) and there exists a polynomial poly, such that the running time of M<sup>λ</sup> is bounded by poly(λ).
@@ -218,7 +218,7 @@ We note that the above scheme can be extended to encrypt strings, rather than ju
 
 ### 2.4 Non-interactive Witness Indistinguishability (NIWI)
 
-Denition 6 ([\[BOV03\]](#page-25-13)). A non-interactive witness-indistinguishable proof system NIWI = (NIWI.Prov, NIWI.Ver) for an NP relation R<sup>L</sup> consists of two polynomial-time algorithms:
+Definition 6 ([\[BOV03\]](#page-25-13)). A non-interactive witness-indistinguishable proof system NIWI = (NIWI.Prov, NIWI.Ver) for an NP relation R<sup>L</sup> consists of two polynomial-time algorithms:
 
 - a probabilistic prover NIWI.Prov(x, w, 1 λ ) that given an instance x, witness w, and security parameter 1 λ , produces a proof π.
 - a deterministic verier NIWI.Ver(x, π) that veries the proof.
@@ -243,11 +243,11 @@ where λ ∈ N, x ∈ {0, 1} λ , w0, w<sup>1</sup> ∈ RL(x).
 
 #### 2.5 Collision Resistance against Bounded Non-uniform Adversaries
 
-We describe here the notion of keyless collision resistance against quasi-polynomial b-non-uniform adversaries, extending the denition in [\[BP04\]](#page-25-12).
+We describe here the notion of keyless collision resistance against quasi-polynomial b-non-uniform adversaries, extending the definition in [\[BP04\]](#page-25-12).
 
 Syntax. A keyless collision resistance hash function is associated with an input function `(λ) > λ and a polynomial time algorithm H such that H(1<sup>λ</sup> , X) is a deterministic algorithm that takes as input an X ∈ {0, 1} `(λ) and outputs a hash Y ∈ {0, 1} λ .
 
-Denition 7. We say that H is collision-resistant against quasi-polynomial adversaries if for any b-nonuniform probabilistic 2 poly(log λ) -time A, there exists a negligible function negl, such that for any λ ∈ N,
+Definition 7. We say that H is collision-resistant against quasi-polynomial adversaries if for any b-nonuniform probabilistic 2 poly(log λ) -time A, there exists a negligible function negl, such that for any λ ∈ N,
 
 $$\Pr\left[ (x_1, x_2) \leftarrow \mathcal{A}(1^{\lambda}) : x_1 \neq x_2, \mathsf{H}(1^{\lambda}, x_1) = \mathsf{H}(1^{\lambda}, x_2) \right] \leq \mathsf{negl}(\lambda) .$$
 
@@ -257,7 +257,7 @@ $$\Pr\left[ (x_1, x_2) \leftarrow \mathcal{A}(1^{\lambda}) : x_1 \neq x_2, \math
 
 We dene below bit commitment schemes
 
-Denition 8 (Non-interactive Bit Commitment Schemes). A polynomial time computable function: Com : {0, 1} × {0, 1} λ 7→ {0, 1} `(λ) is a bit commitment if it satises the properties below:
+Definition 8 (Non-interactive Bit Commitment Schemes). A polynomial time computable function: Com : {0, 1} × {0, 1} λ 7→ {0, 1} `(λ) is a bit commitment if it satisfies the properties below:
 
 Binding: For any r, r<sup>0</sup> ∈ {0, 1} λ , b, b<sup>0</sup> ∈ {0, 1}, if Com(b; r) = Com(b 0 ; r 0 ) then b = b 0 .
 
@@ -271,20 +271,20 @@ We note that the above scheme can be extended to commit to strings, rather than 
 
 ### 2.7 Explainable Veriers
 
-We dene here the a variant of the notion of explainable veriers [\[BKP19\]](#page-24-1) called robustly-explainable veriers. Roughly speaking, explainable veriers are ones whose messages almost always lie in the support of the honest verier messages (or are abort). Robustly-explainable veriers are such where this occurs when they use random coins sampled from an arbitrary ecient sampler (and not necessarily the uniform distribution).
+We dene here the a variant of the notion of explainable veriers [\[BKP19\]](#page-24-1) called robustly-explainable veriers. Roughly speaking, explainable veriers are ones whose messages almost always lie in the support of the honest verier messages (or are abort). Robustly-explainable veriers are such where this occurs when they use random coins sampled from an arbitrary efficient sampler (and not necessarily the uniform distribution).
 
-Denition 9 (Explainable Message). Let hP, Vi be a two-message protocol. We say that a given message m is explainable with respect to x, if there exist honest verier coins r such that m ∈ {V (x; r), ⊥}.
+Definition 9 (Explainable Message). Let hP, Vi be a two-message protocol. We say that a given message m is explainable with respect to x, if there exist honest verier coins r such that m ∈ {V (x; r), ⊥}.
 
-Denition 10 (Robustly-Explainable Verier). Let hP, Vi be a protocol. A b-non-uniform PPT verier V ∗ using `(λ)random coins is robustly-explainable if for any PPT sampler R on `(λ) bits, there exists a negligible negl(λ) such that for any λ ∈ N and x ∈ λ,
+Definition 10 (Robustly-Explainable Verier). Let hP, Vi be a protocol. A b-non-uniform PPT verier V ∗ using `(λ)random coins is robustly-explainable if for any PPT sampler R on `(λ) bits, there exists a negligible negl(λ) such that for any λ ∈ N and x ∈ λ,
 
 $$\Pr\left[r \leftarrow R(1^{\lambda}), m = \mathsf{V}^*(x; r) : m \text{ is explainable}\right] \ge 1 - \mathsf{negl}(\lambda)$$
 .
 
 #### 2.8 Pseudorandom Generators
 
-Denition 11 (Psedudorandom Generators). A deterministic function PRG : {0, 1} <sup>λ</sup> → {0, 1} p(λ) is called a pseudorandom generator (PRG) if:
+Definition 11 (Psedudorandom Generators). A deterministic function PRG : {0, 1} <sup>λ</sup> → {0, 1} p(λ) is called a pseudorandom generator (PRG) if:
 
-- 1. (eciency): PRG can be computed in polynomial time,
+- 1. (efficiency): PRG can be computed in polynomial time,
 - 2. (expansion): p(λ) > λ,
 - 3. x ← {0, 1} λ : PRG(x) ≈<sup>c</sup> Up(λ) , where Up(λ) is the uniform distribution over p(λ) bits.
 
@@ -450,10 +450,10 @@ Completeness. Completeness follows directly from the completeness of the underly
 
 Zero Knowledge. We show how any b-non-uniform malicious verier V ∗ for the above protocol can be converted to a robustly-explainable b + O(1)-non-uniform verier against the original protocol.
 
-<span id="page-14-0"></span>Claim 1. ere exist an ecient simulator S and a verier eV ∗ such that
+<span id="page-14-0"></span>Claim 1. ere exist an efficient simulator S and a verier eV ∗ such that
 
 - 1. eV ∗ is a robustly explainable verier against heP, eVi.
-- 2. eV ∗ is (b + O(1))-non-uniform and eciently constructable from eV ∗ .
+- 2. eV ∗ is (b + O(1))-non-uniform and efficiently constructable from eV ∗ .
 - 3. For every x ∈ L,
 
 $$\mathsf{View}_{\mathsf{V}^*}\langle\mathsf{P}(x,w),\mathsf{V}^*\rangle \equiv \mathsf{S}(\mathsf{View}_{e\mathsf{V}^*}\langle e\mathsf{P}(x,w),e\mathsf{V}^*\rangle)$$
@@ -473,7 +473,7 @@ S:
 - 1. Outputs the randomness of the emulated V ∗ (can be derived from the randomness of eV ∗ ,
 - 2. as well as the received prover message p (possibly ⊥).
 
-e third property asserted in the claim follows by construction of S, eV ∗ and the fact that the prover P checks on its own whether the verier's proof is accepting. It is le to see that eV ∗ is robustly explainable, (b + O(1))-non-uniform, and eciently constructable from V ∗ . Robust explainability follows directly by the (unconditional) soundness of the NIWI — eV ∗ either outputs an explainable message or ⊥. (b+O(1)) non-uniformity and ecient construction follow from the fact that V ∗ is b-non-uniform and eV <sup>∗</sup> uses it as a black box and described by the four code lines above.
+e third property asserted in the claim follows by construction of S, eV ∗ and the fact that the prover P checks on its own whether the verier's proof is accepting. It is le to see that eV ∗ is robustly explainable, (b + O(1))-non-uniform, and efficiently constructable from V ∗ . Robust explainability follows directly by the (unconditional) soundness of the NIWI — eV ∗ either outputs an explainable message or ⊥. (b+O(1)) non-uniformity and efficient construction follow from the fact that V ∗ is b-non-uniform and eV <sup>∗</sup> uses it as a black box and described by the four code lines above.
 
 Claim [1](#page-14-0) directly gives rise to a zero knowledge Sim for the protocol (P, V). In what follows, let eSim be the simulator of the underlying DPZK protocol against robustly-explainable veriers.
 
@@ -576,9 +576,9 @@ Remark 2. We emphasize that for soundness, we require that all the underlying pr
 
 In this section, we show that any deterministic-prover zero-knowledge (DPZK) argument against boundednon-uniform verier can be made predictable. e notion of predictable arguments was introduced in [\[FNV17\]](#page-25-3), where it is in particular shown to imply witness encryption. In the next section, we address additional properties of DPZK that follow from this connection.
 
-We start by recalling the denition of predictable arguments (PA) [\[FNV17\]](#page-25-3). While they also address predictable argument of knowledge, we restrict aention to predictable arguments that are only sound.
+We start by recalling the definition of predictable arguments (PA) [\[FNV17\]](#page-25-3). While they also address predictable argument of knowledge, we restrict aention to predictable arguments that are only sound.
 
-Denition 12 (Predictable Argument). A ρ-round predictable argument is an argument specied by a tuple of algorithms (Chal, Resp) as described below:
+Definition 12 (Predictable Argument). A ρ-round predictable argument is an argument specified by a tuple of algorithms (Chal, Resp) as described below:
 
 1. The verifier PA.V samples 
 $$(\vec{c}, \vec{b}) \leftarrow \mathsf{Chal}(1^{\lambda}, x)$$
@@ -624,7 +624,7 @@ Proof of eorem [4.](#page-18-0) Let (P, V) be a ρ-round DPZK argument for L aga
 
 e transformed verier V 0 is presented in Figure [4.](#page-19-0)
 
-First, note that the protocol satises the structural requirement of a predictable argument. We now move to prove completeness and soundness with respect to the new verier V 0 .
+First, note that the protocol satisfies the structural requirement of a predictable argument. We now move to prove completeness and soundness with respect to the new verier V 0 .
 
 {19}------------------------------------------------
 
@@ -674,9 +674,9 @@ Proof. We prove the proposition in two steps. First, we show that the transforma
 
 To prove the rst part, let V <sup>∗</sup> be a b-non-uniform verier. We show the following claim.
 
-<span id="page-20-2"></span>Claim 2. ere exist an ecient simulator S and a verier V 0∗ against hP 0 , V 0 i such that
+<span id="page-20-2"></span>Claim 2. ere exist an efficient simulator S and a verier V 0∗ against hP 0 , V 0 i such that
 
-- 1. V 0∗ is (b + O(1))-non-uniform and eciently constructable from V ∗ .
+- 1. V 0∗ is (b + O(1))-non-uniform and efficiently constructable from V ∗ .
 - 2. For every x ∈ L,
 
 $$\mathsf{View}_{\mathsf{V}^*}\langle\mathsf{P}(x,w),\mathsf{V}^*\rangle \equiv \mathsf{S}(\mathsf{View}_{\mathsf{V}'^*}\langle\mathsf{P}'(x,w),\mathsf{V}'^*\rangle)$$
@@ -718,7 +718,7 @@ Proof of Claim. We construct S, V 0∗ .
 - 1. Outputs the randomness of the emulated V ∗ (can be derived from the randomness of V 0∗),
 - 2. as well as the received prover messages p1, . . . , p<sup>i</sup> ∗ .
 
-e second property asserted in the claim follows by construction of S, V 0∗ and the construction of P from P 0 in Figure [5.](#page-21-0) It is le to see that V 0∗ is (b + O(1))-non-uniform and eciently constructable from 
+e second property asserted in the claim follows by construction of S, V 0∗ and the construction of P from P 0 in Figure [5.](#page-21-0) It is le to see that V 0∗ is (b + O(1))-non-uniform and efficiently constructable from 
 
 {22}------------------------------------------------
 
@@ -759,7 +759,7 @@ This complete the proof of Proposition 3.
 
 #### 5.2 Laconic Prover Messages
 
-As in the previous section, we start by recalling the laconic prover transformation from [\[FNV17\]](#page-25-3). In what follows, let (P 0 , V 0 ) be a one round predictable argument, the following transformation provides a laconic prover predictable argument (P, V) with a soundness error negligibly close to 1/2, where the prover sends only a single bit. Roughly, the verier samples a suciently large random string γ and sends it to the prover along with the verier message. e prover responds with a single bit corresponding to the inner product of γ and its own response to the verier message, with the verier accepting if only if the bit matches its own computed inner product of γ with the predicted prover message.
+As in the previous section, we start by recalling the laconic prover transformation from [\[FNV17\]](#page-25-3). In what follows, let (P 0 , V 0 ) be a one round predictable argument, the following transformation provides a laconic prover predictable argument (P, V) with a soundness error negligibly close to 1/2, where the prover sends only a single bit. Roughly, the verier samples a sufficiently large random string γ and sends it to the prover along with the verier message. e prover responds with a single bit corresponding to the inner product of γ and its own response to the verier message, with the verier accepting if only if the bit matches its own computed inner product of γ with the predicted prover message.
 
 ```
 Protocol: Laconic Prover (P, V)
@@ -782,17 +782,17 @@ P's auxiliary input: witness w such that (x, w) ∈ R<sup>L</sup>
 
 Figure 6: Laconic prover transformation.
 
-In [\[FNV17\]](#page-25-3), it is proven that this protocol has soundness error at most <sup>1</sup> <sup>2</sup> +negl(λ). As we have seen in the previous subsection (Claim [3\)](#page-22-0), the soundness can be amplied in a manner that preserves zero knowledge. Specically, ` repetitions yields a protocol with soundness error at most 2 <sup>−</sup>` + negl(λ). erefore, we focus on proving that a single instance of the above transformation preserves zero knowledge.
+In [\[FNV17\]](#page-25-3), it is proven that this protocol has soundness error at most <sup>1</sup> <sup>2</sup> +negl(λ). As we have seen in the previous subsection (Claim [3\)](#page-22-0), the soundness can be amplified in a manner that preserves zero knowledge. Specifically, ` repetitions yields a protocol with soundness error at most 2 <sup>−</sup>` + negl(λ). erefore, we focus on proving that a single instance of the above transformation preserves zero knowledge.
 
 <span id="page-23-0"></span>Proposition 4. e round collapsing transformation preserves zero knowledge against b-non-uniform veri ers.
 
 Proof. Let V <sup>∗</sup> be a b-non-uniform verier. We show the following claim.
 
-Claim 4. ere exist an ecient simulator S and a verier V 0∗ against hP 0 , V 0 i such that
+Claim 4. ere exist an efficient simulator S and a verier V 0∗ against hP 0 , V 0 i such that
 
 {24}------------------------------------------------
 
-- 1. V 0∗ is (b + O(1))-non-uniform and eciently constructable from V ∗ .
+- 1. V 0∗ is (b + O(1))-non-uniform and efficiently constructable from V ∗ .
 - 2. For every x ∈ L,
 
 $$\mathsf{View}_{\mathsf{V}^*}\langle\mathsf{P}(x,w),\mathsf{V}^*\rangle \equiv \mathsf{S}(\mathsf{View}_{\mathsf{V}'^*}\langle\mathsf{P}'(x,w),\mathsf{V}'^*\rangle)$$
@@ -812,7 +812,7 @@ S:
 - 1. Outputs the randomness of the emulated V ∗ (can be derived from the randomness of V 0∗),
 - 2. as well as hp, γi, where p is the received prover message and γ is derived from the randomness of V ∗ .
 
-e proof is similar to that of Claim [2](#page-20-2) in the previous subsection. e second property asserted in the claim follows by construction of S, V 0∗ and the construction of P from P 0 . It is le to see that V 0∗ is (b + O(1))-non-uniform and eciently constructable from V ∗ . (b + O(1))-non-uniformity and ecient construction follow from the fact that V ∗ is b-non-uniform and V 0∗ uses it as a black box and described by the two code lines above.
+e proof is similar to that of Claim [2](#page-20-2) in the previous subsection. e second property asserted in the claim follows by construction of S, V 0∗ and the construction of P from P 0 . It is le to see that V 0∗ is (b + O(1))-non-uniform and efficiently constructable from V ∗ . (b + O(1))-non-uniformity and efficient construction follow from the fact that V ∗ is b-non-uniform and V 0∗ uses it as a black box and described by the two code lines above.
 
 is completes the proof of Proposition [4.](#page-23-0)
 
@@ -836,7 +836,7 @@ is completes the proof of Proposition [4.](#page-23-0)
 - <span id="page-25-4"></span>[GGSW13] Sanjam Garg, Craig Gentry, Amit Sahai, and Brent Waters. Witness encryption and its applications. In Dan Boneh, Tim Roughgarden, and Joan Feigenbaum, editors, 45th ACM STOC, pages 467–476. ACM Press, June 2013.
 - <span id="page-25-2"></span>[GK96] Oded Goldreich and Hugo Krawczyk. On the composition of zero-knowledge proof systems. SIAM J. Comput., 25(1):169–192, 1996.
 - <span id="page-25-0"></span>[GMR89] Sha Goldwasser, Silvio Micali, and Charles Racko. e knowledge complexity of interactive proof systems. SIAM Journal on Computing, 18(1):186–208, 1989.
-- <span id="page-25-1"></span>[GO94] Oded Goldreich and Yair Oren. Denitions and properties of zero-knowledge proof systems. Journal of Cryptology, 7(1):1–32, December 1994.
+- <span id="page-25-1"></span>[GO94] Oded Goldreich and Yair Oren. Definitions and properties of zero-knowledge proof systems. Journal of Cryptology, 7(1):1–32, December 1994.
 - <span id="page-25-9"></span>[GOS06] Jens Groth, Rafail Ostrovsky, and Amit Sahai. Non-interactive zaps and new techniques for NIZK. In Cynthia Dwork, editor, CRYPTO 2006, volume 4117 of LNCS, pages 97–111. Springer, Heidelberg, August 2006.
 - <span id="page-25-11"></span>[GS18] Sanjam Garg and Akshayaram Srinivasan. A simple construction of iO for turing machines. In Amos Beimel and Stefan Dziembowski, editors, TCC 2018, Part II, volume 11240 of LNCS, pages 425–454. Springer, Heidelberg, November 2018.
 - <span id="page-25-10"></span>[GVW01] Oded Goldreich, Salil P. Vadhan, and Avi Wigderson. On interactive proofs with a laconic prover. In Fernando Orejas, Paul G. Spirakis, and Jan van Leeuwen, editors, ICALP 2001, volume 2076 of LNCS, pages 334–345. Springer, Heidelberg, July 2001.


### PR DESCRIPTION
Fix broken OCR ligatures in `2020/1160`.

48 ligature-breakage artifacts repaired (fi, fl, ff, ffi, ffl).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 562215b)
Website: https://papyrus.badaas.eu