### PR TITLE
fix: repair OCR ligature artifacts in 2020/1219

### DIFF
--- a/data/markdown/eprint/2020_1219/2020_1219.md
+++ b/data/markdown/eprint/2020_1219/2020_1219.md
@@ -18,7 +18,7 @@ Keywords: Aggregate signature *·* Digital signature *·* Group testing.
 
 Background and Related Work. Digital signature is a fundamental and important primitive in modern cryptography, and it has a wide range of applications that require integrity of data. In the era of IoT (Internet of Things), it is important to ensure integrity of data gathered from many and various IoT devices, however, it is often the case where a total amount of size of signatures for checking validity of big data is too large. From this viewpoint, we study techniques for the purpose of reducing a total amount of signature-size for many and various data, in particular, techniques of compressing (or aggregating) multiple signatures on data.
 
-For the purpose mentioned above, Boneh et al. [4] proposed aggregate signatures and proposed a pairing-based scheme in the random oracle model (ROM). Assuming the weaker security model (i.e., certied-key model) in which signers have to prove knowledge of the secret key at key-registration, Rückert and Schröder gave an aggregate signature scheme using multilinear maps in the standard model [38]. Gentry and Ramzan proposed an identity-based aggregate 
+For the purpose mentioned above, Boneh et al. [4] proposed aggregate signatures and proposed a pairing-based scheme in the random oracle model (ROM). Assuming the weaker security model (i.e., certified-key model) in which signers have to prove knowledge of the secret key at key-registration, Rückert and Schröder gave an aggregate signature scheme using multilinear maps in the standard model [38]. Gentry and Ramzan proposed an identity-based aggregate 
 
 {1}------------------------------------------------
 
@@ -28,7 +28,7 @@ On the other hand, Katz and Lindell [26] proposed the aggregate message authenti
 
 In this paper, we comprehensively study aggregate signatures with detecting functionality, that have functionality of both keyless aggregation of multiple signatures and identifying an invalid message from the aggregate signature, in order to reduce a total amount of signature-size for lots of messages. Our purpose is to formalize strong security notions considering related work mentioned above, especially for [21, 22, 40, 41], and to construct aggregate signatures with the functionality from group testing-protocols [10] in a generic and comprehensive way.
 
-Contribution. The purpose of this paper is to formalize the model and security notions for both non-interactive and interactive protocols of aggregate signatures with detecting functionality, that have functionality of both keyless aggregation of multiple signatures and identifying an invalid message from the aggregate signature. In addition, we provide construction methodology for both protocols from group-testing protocols in a generic and comprehensive way. Specically, the contribution of this paper is as follows.
+Contribution. The purpose of this paper is to formalize the model and security notions for both non-interactive and interactive protocols of aggregate signatures with detecting functionality, that have functionality of both keyless aggregation of multiple signatures and identifying an invalid message from the aggregate signature. In addition, we provide construction methodology for both protocols from group-testing protocols in a generic and comprehensive way. Specifically, the contribution of this paper is as follows.
 
 1. We propose a formal model and security formalization of (non-interactive) aggregate signatures with detecting functionality (D-ASIG) that have functionality of both keyless aggregation of multiple signatures and identifying an invalid message from the aggregate signature. This kind of functionality was already proposed in fault-tolerant aggregate signatures in [21], however, the functionality of fault-tolerant aggregate signatures guarantees that valid messages must be regarded as valid from the aggregate signature even if some fault occurs, just like the property of error-correcting codes. On the other hand, D-ASIG in this paper guarantees that, from the aggregate signature,
 
@@ -862,7 +862,7 @@ By Proposition 4 and Theorems 7 and 8, we can see that, if  $(G_1, G_2)$  is a b
 
 ### 6 Conclusion
 
-In this paper, we comprehensively studied aggregate signatures with detecting functionality, that had functionality of both keyless aggregation of multiple signatures and identifying an invalid message from the aggregate signature, in order to reduce a total amount of signature-size for lots of messages. Specically, we formalized the model and security notions for both non-interactive and interactive protocols of aggregate signatures with detecting functionality, and we provided construction methodology for both protocols from group-testing protocols in a generic and comprehensive way. As instantiations, pairing-based constructions were provided.
+In this paper, we comprehensively studied aggregate signatures with detecting functionality, that had functionality of both keyless aggregation of multiple signatures and identifying an invalid message from the aggregate signature, in order to reduce a total amount of signature-size for lots of messages. Specifically, we formalized the model and security notions for both non-interactive and interactive protocols of aggregate signatures with detecting functionality, and we provided construction methodology for both protocols from group-testing protocols in a generic and comprehensive way. As instantiations, pairing-based constructions were provided.
 
 As explained in [21], aggregate signatures have interesting applications including sensor networks, secure logging, and authenticating software. We would like to expect that aggregate signatures with detecting functionality would be useful primitives for such applications in the era of IoT.
 
@@ -870,12 +870,12 @@ Acknowledgements. This paper is based on results obtained from a project, JPNP16
 
 ### References
 
-- 1. Ahn, J.H., Green, M., Hohenberger, S.: Synchronized aggregate signatures: new denitions, constructions and applications. In: ACM Conference on Computer and Communications Security. pp. 473484. ACM (2010)
+- 1. Ahn, J.H., Green, M., Hohenberger, S.: Synchronized aggregate signatures: new definitions, constructions and applications. In: ACM Conference on Computer and Communications Security. pp. 473484. ACM (2010)
 - 2. Ben-Sasson, E., Chiesa, A., Tromer, E., Virza, M.: Succinct non-interactive zero knowledge for a von neumann architecture. In: USENIX Security Symposium. pp. 781796. USENIX Association (2014)
 - 3. Boldyreva, A., Gentry, C., O'Neill, A., Yum, D.H.: Ordered multisignatures and identity-based sequential aggregate signatures, with applications to secure routing. In: ACM Conference on Computer and Communications Security. pp. 276285. ACM (2007)
 - 4. Boneh, D., Gentry, C., Lynn, B., Shacham, H.: Aggregate and veriably encrypted signatures from bilinear maps. In: EUROCRYPT. Lecture Notes in Computer Science, vol. 2656, pp. 416432. Springer (2003)
 - 5. Boneh, D., Lynn, B., Shacham, H.: Short signatures from the weil pairing. J. Cryptology 17(4), 297319 (2004)
-- 6. Brogle, K., Goldberg, S., Reyzin, L.: Sequential aggregate signatures with lazy verication from trapdoor permutations - (extended abstract). In: ASIACRYPT. Lecture Notes in Computer Science, vol. 7658, pp. 644662. Springer (2012)
+- 6. Brogle, K., Goldberg, S., Reyzin, L.: Sequential aggregate signatures with lazy verification from trapdoor permutations - (extended abstract). In: ASIACRYPT. Lecture Notes in Computer Science, vol. 7658, pp. 644662. Springer (2012)
 - 7. Campanelli, M., Fiore, D., Querol, A.: Legosnark: Modular design and composition of succinct zero-knowledge proofs. In: ACM Conference on Computer and Communications Security. pp. 20752092. ACM (2019)
 - 8. Danezis, G., Fournet, C., Groth, J., Kohlweiss, M.: Square span programs with applications to succinct NIZK arguments. In: ASIACRYPT (1). Lecture Notes in Computer Science, vol. 8873, pp. 532550. Springer (2014)
 - 9. Dorfman, R.: The detection of defective members of large populations. The Annals of Mathematical Statistics Vol. 14, No. 4, 436440 (1943)
@@ -887,7 +887,7 @@ Acknowledgements. This paper is based on results obtained from a project, JPNP16
 - 12. Fischlin, M., Lehmann, A., Schröder, D.: History-free sequential aggregate signatures. In: SCN. Lecture Notes in Computer Science, vol. 7485, pp. 113130. Springer (2012)
 - 13. Gennaro, R., Gentry, C., Parno, B., Raykova, M.: Quadratic span programs and succinct nizks without pcps. In: EUROCRYPT. Lecture Notes in Computer Science, vol. 7881, pp. 626645. Springer (2013)
 - 14. Gennaro, R., Minelli, M., Nitulescu, A., Orrù, M.: Lattice-based zk-snarks from square span programs. In: ACM Conference on Computer and Communications Security. pp. 556573. ACM (2018)
-- 15. Gentry, C., O'Neill, A., Reyzin, L.: A unied framework for trapdoor-permutationbased sequential aggregate signatures. In: Public Key Cryptography (2). Lecture Notes in Computer Science, vol. 10770, pp. 3457. Springer (2018)
+- 15. Gentry, C., O'Neill, A., Reyzin, L.: A unified framework for trapdoor-permutationbased sequential aggregate signatures. In: Public Key Cryptography (2). Lecture Notes in Computer Science, vol. 10770, pp. 3457. Springer (2018)
 - 16. Gentry, C., Ramzan, Z.: Identity-based aggregate signatures. In: Public Key Cryptography. Lecture Notes in Computer Science, vol. 3958, pp. 257273. Springer (2006)
 - 17. Gentry, C., Wichs, D.: Separating succinct non-interactive arguments from all falsiable assumptions. In: STOC. pp. 99108. ACM (2011)
 - 18. Groth, J.: On the size of pairing-based non-interactive arguments. In: EURO-CRYPT (2). Lecture Notes in Computer Science, vol. 9666, pp. 305326. Springer (2016)
@@ -908,9 +908,9 @@ Acknowledgements. This paper is based on results obtained from a project, JPNP16
 - 30. Lu, S., Ostrovsky, R., Sahai, A., Shacham, H., Waters, B.: Sequential aggregate signatures and multisignatures without random oracles. In: EUROCRYPT. Lecture Notes in Computer Science, vol. 4004, pp. 465485. Springer (2006)
 - 31. Lysyanskaya, A., Micali, S., Reyzin, L., Shacham, H.: Sequential aggregate signatures from trapdoor permutations. In: EUROCRYPT. Lecture Notes in Computer Science, vol. 3027, pp. 7490. Springer (2004)
 - 32. Maller, M., Bowe, S., Kohlweiss, M., Meiklejohn, S.: Sonic: Zero-knowledge snarks from linear-size universal and updatable structured reference strings. In: ACM Conference on Computer and Communications Security. pp. 21112128. ACM (2019)
-- 33. Minematsu, K.: Ecient message authentication codes with combinatorial group testing. In: ESORICS (1). Lecture Notes in Computer Science, vol. 9326, pp. 185 202. Springer (2015)
+- 33. Minematsu, K.: Efficient message authentication codes with combinatorial group testing. In: ESORICS (1). Lecture Notes in Computer Science, vol. 9326, pp. 185 202. Springer (2015)
 - 34. Minematsu, K., Kamiya, N.: Symmetric-key corruption detection: When xor-macs meet combinatorial group testing. In: ESORICS 2019, Part I. Lecture Notes in Computer Science, vol. 11735, pp. 595615. Springer (2019)
-- 35. Neven, G.: Ecient sequential aggregate signed data. In: EUROCRYPT. Lecture Notes in Computer Science, vol. 4965, pp. 5269. Springer (2008)
+- 35. Neven, G.: Efficient sequential aggregate signed data. In: EUROCRYPT. Lecture Notes in Computer Science, vol. 4965, pp. 5269. Springer (2008)
 - 36. Ogawa, Y., Sato, S., Shikata, J., Imai, H.: Aggregate message authentication codes with detecting functionality from biorthogonal codes. In: 2020 IEEE International Symposium on Information Theory (ISIT 2020). IEEE (2020)
 - 37. Porat, E., Rothschild, A.: Explicit non-adaptive combinatorial group testing schemes. In: ICALP (1). Lecture Notes in Computer Science, vol. 5125, pp. 748 759. Springer (2008)
 - 38. Rückert, M., Schröder, D.: Aggregate and veriably encrypted signatures from multilinear maps without random oracles. In: ISA. Lecture Notes in Computer Science, vol. 5576, pp. 750759. Springer (2009)
@@ -921,7 +921,7 @@ Acknowledgements. This paper is based on results obtained from a project, JPNP16
 
 # Appendix A: Succinct Non-Interactive Argument of Knowledge
 
-In this section, we give the denition of succinct non-interactive argument of knowledge (SNARK) and a concrete construction in [18].
+In this section, we give the definition of succinct non-interactive argument of knowledge (SNARK) and a concrete construction in [18].
 
 {33}------------------------------------------------
 


### PR DESCRIPTION
Fix broken OCR ligatures in `2020/1219`.

9 ligature-breakage artifacts repaired (fi, fl, ff, ffi, ffl).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 562215b)
Website: https://papyrus.badaas.eu