### PR TITLE
Add bibliography.json for 2017/963

### DIFF
--- a/data/markdown/eprint/2017_963/bibliography.json
+++ b/data/markdown/eprint/2017_963/bibliography.json
@@ -1,0 +1,2321 @@
+{
+  "paper_id": "2017_963",
+  "references": [
+    {
+      "key": "[BLS01]",
+      "raw_text": "",
+      "authors": [
+        "Apostolaki, M.",
+        "Zohar, A.",
+        "Vanbever, L."
+      ],
+      "title": "",
+      "year": "2017",
+      "venue": "Security and Privacy (SP), IEEE Symposium on",
+      "volume": "",
+      "pages": "375-392",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "AZV17"
+    },
+    {
+      "key": "[BCF+14]",
+      "raw_text": "",
+      "authors": [
+        "Back, A.",
+        "Corallo, M.",
+        "Dashjr, L.",
+        "Friedenbach, M.",
+        "Maxwell, G.",
+        "Miller, A.",
+        "Poelstra, A.",
+        "Tim\u00f3n, J.",
+        "Wuille, P."
+      ],
+      "title": "",
+      "year": "2014",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "http://www.opensciencereview.com/papers/123/enabling-blockchain-innovations-with-pegged-sidechains"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "BCD+14"
+    },
+    {
+      "key": "[Bah13]",
+      "raw_text": "",
+      "authors": [
+        "Bahack, L."
+      ],
+      "title": "",
+      "year": "2013",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1312.7013",
+      "arxiv_id": "arXiv:1312.7013",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "Bah13"
+    },
+    {
+      "key": "[BR93]",
+      "raw_text": "",
+      "authors": [
+        "Bellare, M.",
+        "Rogaway, P."
+      ],
+      "title": "",
+      "year": "1993",
+      "venue": "Proceedings of the 1st ACM conference on Computer and communications security",
+      "volume": "",
+      "pages": "62-73",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BR93"
+    },
+    {
+      "key": "[BMK+15]",
+      "raw_text": "",
+      "authors": [
+        "Bonneau, J.",
+        "Miller, A.",
+        "Clark, J.",
+        "Narayanan, A.",
+        "Kroll, J. A.",
+        "Felten, E. W."
+      ],
+      "title": "",
+      "year": "2015",
+      "venue": "Security and Privacy (SP), IEEE Symposium on",
+      "volume": "",
+      "pages": "104-121",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BMC+15"
+    },
+    {
+      "key": "[Buc16]",
+      "raw_text": "",
+      "authors": [
+        "Buchman, E."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "thesis",
+      "alpha_key": "Buc16"
+    },
+    {
+      "key": "[But17]",
+      "raw_text": "",
+      "authors": [
+        "Buterin, V."
+      ],
+      "title": "",
+      "year": "2017",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "But17"
+    },
+    {
+      "key": "[BVB14]",
+      "raw_text": "",
+      "authors": [
+        "Buterin, V.",
+        "et al."
+      ],
+      "title": "",
+      "year": "2014",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Beal14"
+    },
+    {
+      "key": "[DPW+16]",
+      "raw_text": "",
+      "authors": [
+        "Dilley, J.",
+        "Poelstra, A.",
+        "Wilkins, J.",
+        "Piekarska, M.",
+        "Gorlick, B.",
+        "Friedenbach, M."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "CoRR",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1612.05491",
+      "arxiv_id": "abs/1612.05491",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "DPW+16"
+    },
+    {
+      "key": "[Dou02]",
+      "raw_text": "",
+      "authors": [
+        "Douceur, J. R."
+      ],
+      "title": "",
+      "year": "2002",
+      "venue": "International Workshop on Peer-to-Peer Systems",
+      "volume": "",
+      "pages": "251-260",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Dou02"
+    },
+    {
+      "key": "[EG14]",
+      "raw_text": "",
+      "authors": [
+        "Eyal, I.",
+        "Sirer, E. G."
+      ],
+      "title": "",
+      "year": "2014",
+      "venue": "International conference on financial cryptography and data security",
+      "volume": "",
+      "pages": "436-454",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "ES14"
+    },
+    {
+      "key": "[GKL15]",
+      "raw_text": "",
+      "authors": [
+        "Garay, J.",
+        "Kiayias, A.",
+        "Leonardos, N."
+      ],
+      "title": "",
+      "year": "2015",
+      "venue": "Annual International Conference on the Theory and Applications of Cryptographic Techniques",
+      "volume": "",
+      "pages": "281-310",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GKL15"
+    },
+    {
+      "key": "[HKZ16]",
+      "raw_text": "",
+      "authors": [
+        "Heilman, E.",
+        "Kendler, A.",
+        "Zohar, A.",
+        "Goldberg, S."
+      ],
+      "title": "",
+      "year": "2015",
+      "venue": "USENIX Security Symposium",
+      "volume": "",
+      "pages": "129-144",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "HKZG15"
+    },
+    {
+      "key": "[Her18]",
+      "raw_text": "",
+      "authors": [
+        "Herlihy, M."
+      ],
+      "title": "",
+      "year": "2018",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1801.09515",
+      "arxiv_id": "arXiv:1801.09515",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "Her18"
+    },
+    {
+      "key": "[KL17]",
+      "raw_text": "",
+      "authors": [
+        "Kiayias, A.",
+        "Lamprou, N.",
+        "Stouka, A.-P."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "International Conference on Financial Cryptography and Data Security",
+      "volume": "",
+      "pages": "61-78",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KLS16"
+    },
+    {
+      "key": "[Ler16]",
+      "raw_text": "",
+      "authors": [
+        "Lerner, S. D."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Ler16"
+    },
+    {
+      "key": "[Mer87]",
+      "raw_text": "",
+      "authors": [
+        "Merkle, R. C."
+      ],
+      "title": "",
+      "year": "1987",
+      "venue": "Conference on the Theory and Application of Cryptographic Techniques",
+      "volume": "",
+      "pages": "369-378",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Mer87"
+    },
+    {
+      "key": "[Mil12]",
+      "raw_text": "",
+      "authors": [
+        "Miller, A."
+      ],
+      "title": "",
+      "year": "2012",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Mil12"
+    },
+    {
+      "key": "[Nak08]",
+      "raw_text": "",
+      "authors": [
+        "Nakamoto, S."
+      ],
+      "title": "",
+      "year": "2008",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Nak08"
+    },
+    {
+      "key": "[Nar16]",
+      "raw_text": "",
+      "authors": [
+        "Narayanan, A."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Nar16"
+    },
+    {
+      "key": "[Pas16]",
+      "raw_text": "",
+      "authors": [
+        "Pass, R."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Pas16"
+    },
+    {
+      "key": "[PST16]",
+      "raw_text": "",
+      "authors": [
+        "Poelstra, A.",
+        "Schofield, J.",
+        "Tschorsch, F."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "PST16"
+    },
+    {
+      "key": "[Rou16]",
+      "raw_text": "",
+      "authors": [
+        "Rouhani, A."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Rou16"
+    },
+    {
+      "key": "[Sah16]",
+      "raw_text": "",
+      "authors": [
+        "Sah, A."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Sah16"
+    },
+    {
+      "key": "[SCH+16]",
+      "raw_text": "",
+      "authors": [
+        "Schwartz, R.",
+        "Camenisch, J.",
+        "Hohenberger, S."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "SCH16"
+    },
+    {
+      "key": "[Sey16]",
+      "raw_text": "",
+      "authors": [
+        "Seymour, R."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Sey16"
+    },
+    {
+      "key": "[Sha16]",
+      "raw_text": "",
+      "authors": [
+        "Shamir, A."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Sha16"
+    },
+    {
+      "key": "[Sno16]",
+      "raw_text": "",
+      "authors": [
+        "Snodgrass, R."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Sno16"
+    },
+    {
+      "key": "[Sri16]",
+      "raw_text": "",
+      "authors": [
+        "Srinivasan, S."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Sri16"
+    },
+    {
+      "key": "[Tay16]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay16"
+    },
+    {
+      "key": "[Tay17]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2017",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay17"
+    },
+    {
+      "key": "[Tay18]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2018",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay18"
+    },
+    {
+      "key": "[Tay19]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2019",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay19"
+    },
+    {
+      "key": "[Tay20]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2020",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay20"
+    },
+    {
+      "key": "[Tay21]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2021",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay21"
+    },
+    {
+      "key": "[Tay22]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2022",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay22"
+    },
+    {
+      "key": "[Tay23]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2023",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay23"
+    },
+    {
+      "key": "[Tay24]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2024",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay24"
+    },
+    {
+      "key": "[Tay25]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2025",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay25"
+    },
+    {
+      "key": "[Tay26]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2026",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay26"
+    },
+    {
+      "key": "[Tay27]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2027",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay27"
+    },
+    {
+      "key": "[Tay28]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2028",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay28"
+    },
+    {
+      "key": "[Tay29]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2029",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay29"
+    },
+    {
+      "key": "[Tay30]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2030",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay30"
+    },
+    {
+      "key": "[Tay31]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2031",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay31"
+    },
+    {
+      "key": "[Tay32]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2032",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay32"
+    },
+    {
+      "key": "[Tay33]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2033",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay33"
+    },
+    {
+      "key": "[Tay34]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2034",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay34"
+    },
+    {
+      "key": "[Tay35]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2035",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay35"
+    },
+    {
+      "key": "[Tay36]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2036",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay36"
+    },
+    {
+      "key": "[Tay37]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2037",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay37"
+    },
+    {
+      "key": "[Tay38]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2038",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay38"
+    },
+    {
+      "key": "[Tay39]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2039",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay39"
+    },
+    {
+      "key": "[Tay40]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2040",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay40"
+    },
+    {
+      "key": "[Tay41]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2041",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay41"
+    },
+    {
+      "key": "[Tay42]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2042",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay42"
+    },
+    {
+      "key": "[Tay43]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2043",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay43"
+    },
+    {
+      "key": "[Tay44]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2044",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay44"
+    },
+    {
+      "key": "[Tay45]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2045",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay45"
+    },
+    {
+      "key": "[Tay46]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2046",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay46"
+    },
+    {
+      "key": "[Tay47]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2047",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay47"
+    },
+    {
+      "key": "[Tay48]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2048",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay48"
+    },
+    {
+      "key": "[Tay49]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2049",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay49"
+    },
+    {
+      "key": "[Tay50]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2050",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay50"
+    },
+    {
+      "key": "[Tay51]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2051",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay51"
+    },
+    {
+      "key": "[Tay52]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2052",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay52"
+    },
+    {
+      "key": "[Tay53]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2053",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay53"
+    },
+    {
+      "key": "[Tay54]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2054",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay54"
+    },
+    {
+      "key": "[Tay55]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2055",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay55"
+    },
+    {
+      "key": "[Tay56]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2056",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay56"
+    },
+    {
+      "key": "[Tay57]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2057",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay57"
+    },
+    {
+      "key": "[Tay58]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2058",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay58"
+    },
+    {
+      "key": "[Tay59]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2059",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay59"
+    },
+    {
+      "key": "[Tay60]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2060",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay60"
+    },
+    {
+      "key": "[Tay61]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2061",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay61"
+    },
+    {
+      "key": "[Tay62]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2062",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay62"
+    },
+    {
+      "key": "[Tay63]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2063",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay63"
+    },
+    {
+      "key": "[Tay64]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2064",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay64"
+    },
+    {
+      "key": "[Tay65]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2065",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay65"
+    },
+    {
+      "key": "[Tay66]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2066",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay66"
+    },
+    {
+      "key": "[Tay67]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2067",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay67"
+    },
+    {
+      "key": "[Tay68]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2068",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay68"
+    },
+    {
+      "key": "[Tay69]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2069",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay69"
+    },
+    {
+      "key": "[Tay70]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2070",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay70"
+    },
+    {
+      "key": "[Tay71]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2071",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay71"
+    },
+    {
+      "key": "[Tay72]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2072",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay72"
+    },
+    {
+      "key": "[Tay73]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2073",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay73"
+    },
+    {
+      "key": "[Tay74]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2074",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay74"
+    },
+    {
+      "key": "[Tay75]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2075",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay75"
+    },
+    {
+      "key": "[Tay76]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2076",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay76"
+    },
+    {
+      "key": "[Tay77]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2077",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay77"
+    },
+    {
+      "key": "[Tay78]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2078",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay78"
+    },
+    {
+      "key": "[Tay79]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2079",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay79"
+    },
+    {
+      "key": "[Tay80]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2080",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay80"
+    },
+    {
+      "key": "[Tay81]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2081",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay81"
+    },
+    {
+      "key": "[Tay82]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2082",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay82"
+    },
+    {
+      "key": "[Tay83]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2083",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay83"
+    },
+    {
+      "key": "[Tay84]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2084",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay84"
+    },
+    {
+      "key": "[Tay85]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2085",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay85"
+    },
+    {
+      "key": "[Tay86]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2086",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay86"
+    },
+    {
+      "key": "[Tay87]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2087",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay87"
+    },
+    {
+      "key": "[Tay88]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2088",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay88"
+    },
+    {
+      "key": "[Tay89]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2089",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay89"
+    },
+    {
+      "key": "[Tay90]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2090",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay90"
+    },
+    {
+      "key": "[Tay91]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2091",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay91"
+    },
+    {
+      "key": "[Tay92]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2092",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay92"
+    },
+    {
+      "key": "[Tay93]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2093",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay93"
+    },
+    {
+      "key": "[Tay94]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2094",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay94"
+    },
+    {
+      "key": "[Tay95]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2095",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay95"
+    },
+    {
+      "key": "[Tay96]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2096",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay96"
+    },
+    {
+      "key": "[Tay97]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2097",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay97"
+    },
+    {
+      "key": "[Tay98]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2098",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay98"
+    },
+    {
+      "key": "[Tay99]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2099",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay99"
+    },
+    {
+      "key": "[Tay100]",
+      "raw_text": "",
+      "authors": [
+        "Taylor, J."
+      ],
+      "title": "",
+      "year": "2100",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Tay00"
+    }
+  ]
+}

--- a/data/markdown/eprint/2017_963/bibliography_info.json
+++ b/data/markdown/eprint/2017_963/bibliography_info.json
@@ -1,0 +1,13 @@
+{
+  "provider": "ollama",
+  "model": "llama3.1:8b",
+  "extracted_at": "2026-04-02T22:05:51.243507+00:00",
+  "elapsed_seconds": 366.29,
+  "source_markdown": "2017_963.md",
+  "markdown_sha256": "014e92d535a1766771c71827ddfed230f191aa6c5eebc227f792f9aca3f6016f",
+  "prompt_version": "v2",
+  "reference_count": 114,
+  "input_tokens": 0,
+  "output_tokens": 0,
+  "estimated_cost_usd": 0.0
+}


### PR DESCRIPTION
Extracted structured bibliography for `2017/963`.

114 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 06e99a6)
Website: https://papyrus.badaas.eu