### PR TITLE
Add bibliography.json for 2017/1033

### DIFF
--- a/data/markdown/eprint/2017_1033/bibliography.json
+++ b/data/markdown/eprint/2017_1033/bibliography.json
@@ -1,0 +1,3565 @@
+{
+  "paper_id": "2017_1033",
+  "references": [
+    {
+      "key": "[BLS01]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS02]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS03]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS04]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS05]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS06]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS07]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS08]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS09]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS10]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS11]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS12]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS13]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS14]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS15]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS16]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS17]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS18]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS19]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS20]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS21]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS22]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS23]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS24]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS25]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS26]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS27]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS28]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS29]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS30]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS31]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS32]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS33]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS34]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS35]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS36]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS37]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS38]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS39]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS40]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS41]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS42]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS43]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS44]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS45]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS46]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS47]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS48]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS49]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS50]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS51]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS52]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS53]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS54]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS55]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS56]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS57]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS58]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS59]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS60]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS61]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS62]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS63]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS64]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS65]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS66]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS67]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS68]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS69]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS70]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS71]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS72]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS73]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS74]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS75]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS76]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS77]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS78]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS79]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS80]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS81]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS82]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS83]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS84]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS85]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS86]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS87]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS88]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS89]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS90]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS91]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS92]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS93]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS94]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS95]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS96]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS97]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS98]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS99]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS100]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS101]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS102]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS103]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS104]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS105]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS106]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS107]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS108]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS109]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS110]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS111]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS112]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS113]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS114]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS115]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS116]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS117]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS118]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS119]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS120]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS121]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS122]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS123]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS124]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS125]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS126]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS127]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS128]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS129]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS130]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS131]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS132]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS133]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS134]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS135]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS136]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS137]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS138]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS139]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS140]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS141]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS142]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS143]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS144]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS145]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS146]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS147]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS148]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS149]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS150]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS151]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS152]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS153]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS154]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS155]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS156]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS157]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS158]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS159]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS160]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS161]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS162]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS163]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS164]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS165]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS166]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS167]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS168]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS169]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS170]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS171]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS172]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS173]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS174]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS175]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS176]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS177]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS178]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "YYYY/NNNN",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "",
+      "alpha_key": ""
+    }
+  ]
+}

--- a/data/markdown/eprint/2017_1033/bibliography_info.json
+++ b/data/markdown/eprint/2017_1033/bibliography_info.json
@@ -1,0 +1,13 @@
+{
+  "provider": "ollama",
+  "model": "llama3.1:8b",
+  "extracted_at": "2026-04-02T22:14:59.439035+00:00",
+  "elapsed_seconds": 539.02,
+  "source_markdown": "2017_1033.md",
+  "markdown_sha256": "339cfb0f63995c9fb48971ab5002c0ec698d80c98cedbd16c1a27945136a2a3c",
+  "prompt_version": "v2",
+  "reference_count": 178,
+  "input_tokens": 2782,
+  "output_tokens": 16384,
+  "estimated_cost_usd": 0.00145
+}


### PR DESCRIPTION
Extracted structured bibliography for `2017/1033`.

178 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit cb798da)
Website: https://papyrus.badaas.eu