### PR TITLE
Add bibliography.json for 2018/248

### DIFF
--- a/data/markdown/eprint/2018_248/bibliography.json
+++ b/data/markdown/eprint/2018_248/bibliography.json
@@ -1,0 +1,319 @@
+{
+  "paper_id": "2018_248",
+  "references": [
+    {
+      "key": "[BGM14]",
+      "raw_text": "",
+      "authors": [
+        "Iddo Bentov",
+        "Ariel Gabizon",
+        "Alex Mizrahi"
+      ],
+      "title": "",
+      "year": "2014",
+      "venue": "*CoRR*, abs/1406.5694",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1406.5694",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "BGM14"
+    },
+    {
+      "key": "[But14]",
+      "raw_text": "",
+      "authors": [
+        "Vitalik Buterin"
+      ],
+      "title": "",
+      "year": "2014",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "But14"
+    },
+    {
+      "key": "[Com14]",
+      "raw_text": "",
+      "authors": [
+        "The NXT Community"
+      ],
+      "title": "NXT whitepaper",
+      "year": "2014",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Com14"
+    },
+    {
+      "key": "[DGKR17]",
+      "raw_text": "",
+      "authors": [
+        "Bernardo David",
+        "Peter Gazi",
+        "Aggelos Kiayias",
+        "Alexander Russell"
+      ],
+      "title": "Ouroboros praos: An adaptively-secure, semi-synchronous proof-of-stake protocol",
+      "year": "2017",
+      "venue": "Cryptology ePrint Archive, Report 2017/573",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2017/573",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "DGKR17"
+    },
+    {
+      "key": "[Fra06]",
+      "raw_text": "",
+      "authors": [
+        "Matt Franklin"
+      ],
+      "title": "A survey of key evolving cryptosystems",
+      "year": "2006",
+      "venue": "*Int. J. Security and Networks*",
+      "volume": "1(1/2)",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Fra06"
+    },
+    {
+      "key": "[GKL15]",
+      "raw_text": "",
+      "authors": [
+        "Juan A. Garay",
+        "Aggelos Kiayias",
+        "Nikos Leonardos"
+      ],
+      "title": "The bitcoin backbone protocol: Analysis and applications",
+      "year": "2015",
+      "venue": "In Elisabeth Oswald and Marc Fischlin, editors, *EUROCRYPT 2015, Part II*, volume 9057 of *LNCS*, pages 281\u2013310. Springer, Heidelberg, April 2015.",
+      "volume": "9057",
+      "pages": "281\u2013310",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GKL15"
+    },
+    {
+      "key": "[KN12]",
+      "raw_text": "",
+      "authors": [
+        "Sunny King",
+        "Scott Nadal"
+      ],
+      "title": "Ppcoin: Peerto-peer crypto-currency with proof-of-stake",
+      "year": "2012",
+      "venue": "https://peercoin.net/assets/paper/peercoin-paper.pdf, August 2012.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "KN12"
+    },
+    {
+      "key": "[KRDO17]",
+      "raw_text": "",
+      "authors": [
+        "Aggelos Kiayias",
+        "Alexander Russell",
+        "Bernardo David",
+        "Roman Oliynykov"
+      ],
+      "title": "Ouroboros: A provably secure proof-of-stake blockchain protocol",
+      "year": "2017",
+      "venue": "In Jonathan Katz and Hovav Shacham, editors, *CRYPTO 2017, Part I*, volume 10401 of *LNCS*, pages 357\u2013388. Springer, Heidelberg, August 2017.",
+      "volume": "10401",
+      "pages": "357\u2013388",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KRDO17"
+    },
+    {
+      "key": "[Lar13]",
+      "raw_text": "",
+      "authors": [
+        "Dan Larimer"
+      ],
+      "title": "Transactions as proof-of-stake",
+      "year": "2013",
+      "venue": "[https://bravenewcoin.com/assets/Uploads/TransactionsAsProofOfStake10.pdf,](https://bravenewcoin.com/assets/Uploads/TransactionsAsProofOfStake10.pdf) November 2013.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Lar13"
+    },
+    {
+      "key": "[Lar18]",
+      "raw_text": "",
+      "authors": [
+        "Dan Larimer"
+      ],
+      "title": "Delegated proof-of-stake consensus",
+      "year": "2018",
+      "venue": "[https://bitshares.org/technology/delegated-proof-of-stake-consensus/,](https://bitshares.org/technology/delegated-proof-of-stake-consensus/) accessed 21.3.2018, 2018.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Lar18"
+    },
+    {
+      "key": "[Mic16]",
+      "raw_text": "",
+      "authors": [
+        "Silvio Micali"
+      ],
+      "title": "ALGORAND: The efficient and democratic ledger",
+      "year": "2016",
+      "venue": "*CoRR*, abs/1607.01341, 2016.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1607.01341",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Mic16"
+    },
+    {
+      "key": "[Poe14]",
+      "raw_text": "",
+      "authors": [
+        "Andrew Poelstra"
+      ],
+      "title": "Distributed consensus from proof of stake is impossible",
+      "year": "2014",
+      "venue": "https://download.wpsoftware.net/bitcoin/old-pos.pdf, May 2014.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Poe14"
+    },
+    {
+      "key": "[Poe15]",
+      "raw_text": "",
+      "authors": [
+        "Andrew Poelstra"
+      ],
+      "title": "On stake and consensus",
+      "year": "2015",
+      "venue": "https://download.wpsoftware.net/bitcoin/pos.pdf, March 2015.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Poe15"
+    },
+    {
+      "key": "[PSS17]",
+      "raw_text": "",
+      "authors": [
+        "Rafael Pass",
+        "Lior Seeman",
+        "Abhi Shelat"
+      ],
+      "title": "Analysis of the blockchain protocol in asynchronous networks",
+      "year": "2017",
+      "venue": "In Jean-Sebastien \u00b4 Coron and Jesper Buus Nielsen, editors, *EUROCRYPT 2017, Part II*, volume 10211 of *LNCS*, pages 643\u2013673. Springer, Heidelberg, May 2017.",
+      "volume": "10211",
+      "pages": "643\u2013673",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "PSS17"
+    },
+    {
+      "key": "[SL15]",
+      "raw_text": "",
+      "authors": [
+        "Fabian Schuh",
+        "Daniel Larimer"
+      ],
+      "title": "Bitshares 2.0: General overview",
+      "year": "2015",
+      "venue": "[https://bravenewcoin.com/assets/Whitepapers/bitshares-general.pdf,](https://bravenewcoin.com/assets/Whitepapers/bitshares-general.pdf) December 2015.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "SL15"
+    }
+  ]
+}

--- a/data/markdown/eprint/2018_248/bibliography_info.json
+++ b/data/markdown/eprint/2018_248/bibliography_info.json
@@ -1,0 +1,13 @@
+{
+  "provider": "ollama",
+  "model": "llama3.1:8b",
+  "extracted_at": "2026-04-02T22:27:36.780541+00:00",
+  "elapsed_seconds": 62.22,
+  "source_markdown": "2018_248.md",
+  "markdown_sha256": "283704b44d98fcf707cae9df05368f178929cffa4c93fac71d9b565395359cc2",
+  "prompt_version": "v2",
+  "reference_count": 15,
+  "input_tokens": 1565,
+  "output_tokens": 1794,
+  "estimated_cost_usd": 0.000222
+}


### PR DESCRIPTION
Extracted structured bibliography for `2018/248`.

15 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 266b14c)
Website: https://papyrus.badaas.eu