### PR TITLE
Add bibliography.json for 2018/262

### DIFF
--- a/data/markdown/eprint/2018_262/bibliography.json
+++ b/data/markdown/eprint/2018_262/bibliography.json
@@ -1,0 +1,345 @@
+{
+  "paper_id": "2018_262",
+  "references": [
+    {
+      "key": "[BLS01]",
+      "raw_text": "",
+      "authors": [
+        "Herlihy"
+      ],
+      "title": "Atomic cross-chain swaps",
+      "year": "2018",
+      "venue": "CoRR",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1801.09515",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Her18"
+    },
+    {
+      "key": "[BLS03]",
+      "raw_text": "",
+      "authors": [
+        "Kiayias, Lamprou, Stouka"
+      ],
+      "title": "Proofs of proofs of work with sublinear complexity",
+      "year": "2016",
+      "venue": "Financial Cryptography and Data Security - FC 2016 International Workshops",
+      "volume": "",
+      "pages": "61\u201378",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Kia16"
+    },
+    {
+      "key": "[BLS04]",
+      "raw_text": "",
+      "authors": [
+        ""
+      ],
+      "title": "Cardano",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS05]",
+      "raw_text": "",
+      "authors": [
+        ""
+      ],
+      "title": "Chainweb: A proof-of-work parallel-chain architecture for massive throughput (draft v15)",
+      "year": "2018",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS06]",
+      "raw_text": "",
+      "authors": [
+        "Nakamoto"
+      ],
+      "title": "Bitcoin: A peer-to-peer electronic cash system",
+      "year": "2008",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Nak08"
+    },
+    {
+      "key": "[BLS07]",
+      "raw_text": "",
+      "authors": [
+        "Buterin"
+      ],
+      "title": "Ethereum: A next generation smart contract & decentralized application platform",
+      "year": "2014",
+      "venue": "Ethereum Project White Paper",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "But14"
+    },
+    {
+      "key": "[BLS08]",
+      "raw_text": "",
+      "authors": [
+        "Wood"
+      ],
+      "title": "Ethereum: A secure decentralised generalised transaction ledger",
+      "year": "2014",
+      "venue": "Ethereum Project Yellow Paper",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Woo14"
+    },
+    {
+      "key": "[BLS09]",
+      "raw_text": "",
+      "authors": [
+        "Buterin"
+      ],
+      "title": "Thoughts on utxos",
+      "year": "2016",
+      "venue": "Medium.com",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "But16"
+    },
+    {
+      "key": "[BLS10]",
+      "raw_text": "",
+      "authors": [
+        "Hearn"
+      ],
+      "title": "Rationale for and tradeoffs in adopting a utxo-style model",
+      "year": "2016",
+      "venue": "Corda Blog",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Hea16"
+    },
+    {
+      "key": "[BLS11]",
+      "raw_text": "",
+      "authors": [
+        "Dai"
+      ],
+      "title": "Why qtum chose utxo model and the benefits",
+      "year": "2017",
+      "venue": "8BTC",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Dai17"
+    },
+    {
+      "key": "[BLS12]",
+      "raw_text": "",
+      "authors": [
+        ""
+      ],
+      "title": "Design rationale: Blockchain-level protocol: Account and not utxos",
+      "year": "2017",
+      "venue": "Ethereum Wiki",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS13]",
+      "raw_text": "",
+      "authors": [
+        ""
+      ],
+      "title": "Utxo model vs. account/balance model (forum thread)",
+      "year": "2017",
+      "venue": "StackExchange: Bitcoin",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS14]",
+      "raw_text": "",
+      "authors": [
+        "Vogesteller, Buterin"
+      ],
+      "title": "ERC-20 token standard",
+      "year": "2015",
+      "venue": "EIPs",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Vog15"
+    },
+    {
+      "key": "[BLS15]",
+      "raw_text": "",
+      "authors": [
+        "Popov"
+      ],
+      "title": "The tangle",
+      "year": "2017",
+      "venue": "IOTA White Paper",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Pop17"
+    },
+    {
+      "key": "[BLS16]",
+      "raw_text": "",
+      "authors": [
+        ""
+      ],
+      "title": "Transaction",
+      "year": "July 2017",
+      "venue": "Bitcoin Wiki",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BLS17]",
+      "raw_text": "",
+      "authors": [
+        "White"
+      ],
+      "title": "A theory for lightweight cryptocurrency ledgers",
+      "year": "2015",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Whi15"
+    },
+    {
+      "key": "[BLS19]",
+      "raw_text": "",
+      "authors": [
+        ""
+      ],
+      "title": "The transaction graph for \u00b4 modeling blockchain semantics",
+      "year": "2017",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    }
+  ]
+}

--- a/data/markdown/eprint/2018_262/bibliography_info.json
+++ b/data/markdown/eprint/2018_262/bibliography_info.json
@@ -1,0 +1,13 @@
+{
+  "provider": "ollama",
+  "model": "llama3.1:8b",
+  "extracted_at": "2026-04-02T22:28:56.379419+00:00",
+  "elapsed_seconds": 71.11,
+  "source_markdown": "2018_262.md",
+  "markdown_sha256": "c7ea22787c9aa08b64619ef1d239699ea20a95d94d1e50e73b05563b8cd01dce",
+  "prompt_version": "v2",
+  "reference_count": 17,
+  "input_tokens": 2174,
+  "output_tokens": 2045,
+  "estimated_cost_usd": 0.000272
+}


### PR DESCRIPTION
Extracted structured bibliography for `2018/262`.

17 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 266b14c)
Website: https://papyrus.badaas.eu