### PR TITLE
Add bibliography.json for 2018/380

### DIFF
--- a/data/markdown/eprint/2018_380/bibliography.json
+++ b/data/markdown/eprint/2018_380/bibliography.json
@@ -1,0 +1,4 @@
+{
+  "paper_id": "2018_380",
+  "references": []
+}

--- a/data/markdown/eprint/2018_380/bibliography_info.json
+++ b/data/markdown/eprint/2018_380/bibliography_info.json
@@ -1,0 +1,13 @@
+{
+  "provider": "ollama",
+  "model": "llama3.1:8b",
+  "extracted_at": "2026-04-02T22:30:25.836536+00:00",
+  "elapsed_seconds": 80.45,
+  "source_markdown": "2018_380.md",
+  "markdown_sha256": "28876ab96a164a0582a23d8b96c59368b3e7e83318e10183a156cfc923b71106",
+  "prompt_version": "v2",
+  "reference_count": 0,
+  "input_tokens": 4096,
+  "output_tokens": 2131,
+  "estimated_cost_usd": 0.000375
+}


### PR DESCRIPTION
Extracted structured bibliography for `2018/380`.

0 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 266b14c)
Website: https://papyrus.badaas.eu