### PR TITLE
Add bibliography.json for 2021/788

### DIFF
--- a/data/markdown/eprint/2021_788/bibliography.json
+++ b/data/markdown/eprint/2021_788/bibliography.json
@@ -1,4 +1,887 @@
 {
   "paper_id": "2021_788",
-  "references": []
+  "references": [
+    {
+      "key": "[BLS01]",
+      "raw_text": "",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "1991/ICM",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BBH+19]",
+      "raw_text": "- <span id=\"page-36-1\"></span>[BBH+19] James Bartusek, Liron Bronfman, Justin Holmgren, Fermi Ma, and Ron D. Rothblum. On the (in)security of kilian-based snargs. In Dennis Hofheinz and Alon Rosen, editors, Theory of Cryptography - 17th International Conference, TCC 2019, Nuremberg, Germany, December 1-5, 2019, Proceedings, Part II, volume 11892 of Lecture Notes in Computer Science, pages 522\u2013551. Springer, 2019. [2,](#page-3-2) [4,](#page-5-2) [6](#page-7-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2019/375",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BFLS91]",
+      "raw_text": "- <span id=\"page-36-4\"></span>[BFLS91] L\u00e1szl\u00f3 Babai, Lance Fortnow, Leonid A. Levin, and Mario Szegedy. Checking computations in polylogarithmic time. In Proceedings of the 23rd Annual ACM Symposium on Theory of Computing, May 5-8, 1991, New Orleans, Louisiana, USA, pages 21\u201331, 1991. [8](#page-9-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BHK17]",
+      "raw_text": "- <span id=\"page-36-0\"></span>[BHK17] Zvika Brakerski, Justin Holmgren, and Yael Tauman Kalai. Non-interactive delegation and batch NP verification from standard computational assumptions. In Proceedings of the 49th Annual ACM SIGACT Symposium on Theory of Computing, STOC 2017, Montreal, QC, Canada, June 19-23, 2017, pages 474\u2013482, 2017. [1,](#page-0-0) [7,](#page-8-2) [8,](#page-9-2) [10,](#page-11-2) [39](#page-40-4)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BK18]",
+      "raw_text": "- <span id=\"page-36-3\"></span>[BK18] Zvika Brakerski and Yael Tauman Kalai. Monotone batch np-delegation with applications to access control. IACR Cryptology ePrint Archive, 2018:375, 2018. [8](#page-9-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2018/375",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BKK+18]",
+      "raw_text": "- <span id=\"page-37-1\"></span>[BKK+18] Saikrishna Badrinarayanan, Yael Tauman Kalai, Dakshita Khurana, Amit Sahai, and Daniel Wichs. Succinct delegation for low-space non-deterministic computation. In Proceedings of the 50th Annual ACM SIGACT Symposium on Theory of Computing, STOC 2018, Los Angeles, CA, USA, June 25-29, 2018, pages 709\u2013721, 2018. [1,](#page-0-0) [7,](#page-8-2) [8,](#page-9-2) [11](#page-12-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[Blu86]",
+      "raw_text": "- <span id=\"page-37-7\"></span>[Blu86] Manuel Blum. How to prove a theorem so no one else can claim it. In Proceedings of the International Congress of Mathematicians, pages 1444\u20131451, 1986. [6](#page-7-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[BV11]",
+      "raw_text": "- <span id=\"page-37-9\"></span>[BV11] Zvika Brakerski and Vinod Vaikuntanathan. Efficient fully homomorphic encryption from (standard) lwe. In FOCS, pages 97\u2013106, 2011. [13](#page-14-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[CCH+19]",
+      "raw_text": "- <span id=\"page-37-6\"></span>[CCH+19] Ran Canetti, Yilei Chen, Justin Holmgren, Alex Lombardi, Guy N. Rothblum, Ron D. Rothblum, and Daniel Wichs. Fiat-shamir: from practice to theory. In Moses Charikar and Edith Cohen, editors, Proceedings of the 51st Annual ACM SIGACT Symposium on Theory of Computing, STOC 2019, Phoenix, AZ, USA, June 23-26, 2019, pages 1082\u20131090. ACM, 2019. [6](#page-7-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[CCRR18]",
+      "raw_text": "- <span id=\"page-37-5\"></span>[CCRR18] Ran Canetti, Yilei Chen, Leonid Reyzin, and Ron D. Rothblum. Fiat-shamir and correlation intractability from strong kdm-secure encryption. In Advances in Cryptology - EUROCRYPT 2018 - 37th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Tel Aviv, Israel, April 29 - May 3, 2018 Proceedings, Part I, pages 91\u2013122, 2018. [6](#page-7-2)",
+      "authors": [
+        "Last, First"
+      ],
+      "title": "",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": ""
+    },
+    {
+      "key": "[CGKS95]",
+      "raw_text": "- <span id=\"page-37-8\"></span>[CGKS95] Benny Chor, Oded Goldreich, Eyal Kushilevitz, and Madhu Sudan. Private information retrieval. In 36th Annual Symposium on Foundations of Computer Science, Milwaukee, Wisconsin, USA, 23-25 October 1995, pages 41\u201350, 1995. [12](#page-13-3)",
+      "authors": [
+        "Benny Chor",
+        "Oded Goldreich",
+        "Eyal Kushilevitz",
+        "Madhu Sudan"
+      ],
+      "title": "",
+      "year": "1995",
+      "venue": "36th Annual Symposium on Foundations of Computer Science, Milwaukee, Wisconsin, USA",
+      "volume": "",
+      "pages": "41\u201350",
+      "doi": "",
+      "urls": [
+        "http://www.cs.bgu.ac.il/~kobbi/papers/spooky_sub_crypto.pdf"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CGKS95"
+    },
+    {
+      "key": "[CJJ21]",
+      "raw_text": "- <span id=\"page-37-2\"></span>[CJJ21] Arka Rai Choudhuri, Abhishek Jain, and Zhengzhong Jin. SNARGs for P from LWE. IACR Cryptol. ePrint Arch., 2021. [3,](#page-4-1) [8,](#page-9-2) [25](#page-26-2)",
+      "authors": [
+        "Arka Rai Choudhuri",
+        "Abhishek Jain",
+        "Zhengzhong Jin"
+      ],
+      "title": "",
+      "year": "2021",
+      "venue": "IACR Cryptol. ePrint Arch.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2021/334",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "CJJ21"
+    },
+    {
+      "key": "[CMSZ21]",
+      "raw_text": "- <span id=\"page-37-3\"></span>[CMSZ21] Alessandro Chiesa, Fermi Ma, Nicholas Spooner, and Mark Zhandry. Post-quantum succinct arguments. IACR Cryptol. ePrint Arch., 2021:334, 2021. [4](#page-5-2)",
+      "authors": [
+        "Alessandro Chiesa",
+        "Fermi Ma",
+        "Nicholas Spooner",
+        "Mark Zhandry"
+      ],
+      "title": "",
+      "year": "2021",
+      "venue": "IACR Cryptol. ePrint Arch.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2021/334",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "CMSZ21"
+    },
+    {
+      "key": "[CSW20]",
+      "raw_text": "- <span id=\"page-37-4\"></span>[CSW20] Ran Canetti, Pratik Sarkar, and Xiao Wang. Triply adaptive UC NIZK. IACR Cryptol. ePrint Arch., 2020:1212, 2020. [4](#page-5-2)",
+      "authors": [
+        "Ran Canetti",
+        "Pratik Sarkar",
+        "Xiao Wang"
+      ],
+      "title": "",
+      "year": "2020",
+      "venue": "IACR Cryptol. ePrint Arch.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2020/1212",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "CSW20"
+    },
+    {
+      "key": "[DGI+19]",
+      "raw_text": "- <span id=\"page-37-10\"></span>[DGI+19] Nico D\u00f6ttling, Sanjam Garg, Yuval Ishai, Giulio Malavolta, Tamer Mour, and Rafail Ostrovsky. Trapdoor hash functions and their applications. In Alexandra Boldyreva and Daniele Micciancio, editors, Advances in Cryptology - CRYPTO 2019 - 39th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 18-22, 2019, Proceedings, Part III, volume 11694 of Lecture Notes in Computer Science, pages 3\u201332. Springer, 2019. [13](#page-14-2)",
+      "authors": [
+        "Nico D\u00f6ttling",
+        "Sanjam Garg",
+        "Yuval Ishai",
+        "Giulio Malavolta",
+        "Tamer Mour",
+        "Rafail Ostrovsky"
+      ],
+      "title": "",
+      "year": "2019",
+      "venue": "Advances in Cryptology - CRYPTO 2019 - 39th Annual International Cryptology Conference, Santa Barbara, CA, USA",
+      "volume": "11694 of Lecture Notes in Computer Science",
+      "pages": "3\u201332",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "DGI+19"
+    },
+    {
+      "key": "[DHRW16]",
+      "raw_text": "- <span id=\"page-37-0\"></span>[DHRW16] Yevgeniy Dodis, Shai Halevi, Ron D. Rothblum, and Daniel Wichs. Spooky encryption and its applications. In Advances in Cryptology - CRYPTO 2016 - 36th Annual\n\n- International Cryptology Conference, Santa Barbara, CA, USA, August 14-18, 2016, Proceedings, Part III, pages 93\u2013122, 2016. [1](#page-0-0)",
+      "authors": [
+        "Yevgeniy Dodis",
+        "Shai Halevi",
+        "Ron D. Rothblum",
+        "Daniel Wichs"
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "Advances in Cryptology - CRYPTO 2016 - 36th Annual International Cryptology Conference, Santa Barbara, CA, USA",
+      "volume": "",
+      "pages": "93\u2013122",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "DHRW16"
+    },
+    {
+      "key": "[DLN+04]",
+      "raw_text": "- <span id=\"page-38-0\"></span>[DLN+04] Cynthia Dwork, Michael Langberg, Moni Naor, Kobbi Nissim, and Omer Reingold. Succinct proofs for NP and spooky interactions. Unpublished manuscript, 2004. [http:](http://www.cs.bgu.ac.il/~kobbi/papers/spooky_sub_crypto.pdf) [//www.cs.bgu.ac.il/~kobbi/papers/spooky\\\\_sub\\\\_crypto.pdf](http://www.cs.bgu.ac.il/~kobbi/papers/spooky_sub_crypto.pdf). [1](#page-0-0)",
+      "authors": [
+        "Cynthia Dwork",
+        "Michael Langberg",
+        "Moni Naor",
+        "Kobbi Nissim",
+        "Omer Reingold"
+      ],
+      "title": "",
+      "year": "2004",
+      "venue": "Unpublished manuscript",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "http://www.cs.bgu.ac.il/~kobbi/papers/spooky_sub_crypto.pdf",
+        "http://www.cs.bgu.ac.il/~kobbi/papers/spooky\\_sub\\_crypto.pdf"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "DLN+04"
+    },
+    {
+      "key": "[GK03]",
+      "raw_text": "- <span id=\"page-38-7\"></span>[GK03] Shafi Goldwasser and Yael Tauman Kalai. On the (in)security of the fiat-shamir paradigm. In FOCS, pages 102\u2013, 2003. [6](#page-7-2)",
+      "authors": [
+        "Shafi Goldwasser",
+        "Yael Tauman Kalai"
+      ],
+      "title": "",
+      "year": "2003",
+      "venue": "FOCS",
+      "volume": "",
+      "pages": "102\u2013",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GK03"
+    },
+    {
+      "key": "[GK05]",
+      "raw_text": "- <span id=\"page-38-6\"></span>[GK05] Shafi Goldwasser and Yael Tauman Kalai. On the impossibility of obfuscation with auxiliary input. In Eva Tardos, editor, \u00b4 46th IEEE Symposium on Foundations of Computer Science (FOCS), pages 553\u2013562. IEEE Computer Society, 2005. [6](#page-7-2)",
+      "authors": [
+        "Shafi Goldwasser",
+        "Yael Tauman Kalai"
+      ],
+      "title": "",
+      "year": "2005",
+      "venue": "46th IEEE Symposium on Foundations of Computer Science (FOCS)",
+      "volume": "",
+      "pages": "553\u2013562",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GK05"
+    },
+    {
+      "key": "[GK16]",
+      "raw_text": "- <span id=\"page-38-8\"></span>[GK16] Shafi Goldwasser and Yael Tauman Kalai. Cryptographic assumptions: A position paper. In Theory of Cryptography - 13th International Conference, TCC 2016-A, Tel Aviv, Israel, January 10-13, 2016, Proceedings, Part I, pages 505\u2013522, 2016. [9](#page-10-5)",
+      "authors": [
+        "Shafi Goldwasser",
+        "Yael Tauman Kalai"
+      ],
+      "title": "",
+      "year": "2016",
+      "venue": "Theory of Cryptography - 13th International Conference, TCC 2016-A, Tel Aviv, Israel",
+      "volume": "",
+      "pages": "505\u2013522",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GK16"
+    },
+    {
+      "key": "[GKR08]",
+      "raw_text": "- <span id=\"page-38-3\"></span>[GKR08] Shafi Goldwasser, Yael Tauman Kalai, and Guy N. Rothblum. Delegating computation: interactive proofs for muggles. In STOC, pages 113\u2013122, 2008. [6](#page-7-2)",
+      "authors": [
+        "Shafi Goldwasser",
+        "Yael Tauman Kalai",
+        "Guy N. Rothblum"
+      ],
+      "title": "",
+      "year": "2008",
+      "venue": "STOC",
+      "volume": "",
+      "pages": "113\u2013122",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "GKR08"
+    },
+    {
+      "key": "[GMW91]",
+      "raw_text": "- <span id=\"page-38-4\"></span>[GMW91] Oded Goldreich, Silvio Micali, and Avi Wigderson. Proofs that yield nothing but their validity, or all languages in np have zero-knowledge proof systems. Journal of the ACM, 38(1):691\u2013729, 1991. [6](#page-7-2)",
+      "authors": [
+        "Oded Goldreich",
+        "Silvio Micali",
+        "Avi Wigderson"
+      ],
+      "title": "",
+      "year": "1991",
+      "venue": "Journal of the ACM",
+      "volume": "38(1)",
+      "pages": "691\u2013729",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "GMW91"
+    },
+    {
+      "key": "[GR05]",
+      "raw_text": "- <span id=\"page-38-9\"></span>[GR05] Craig Gentry and Zulfikar Ramzan. Single-database private information retrieval with constant communication rate. In Lu\u00eds Caires, Giuseppe F. Italiano, Lu\u00eds Monteiro, Catuscia Palamidessi, and Moti Yung, editors, Automata, Languages and Programming, 32nd International Colloquium, ICALP 2005, Lisbon, Portugal, July 11-15, 2005, Proceedings, volume 3580 of Lecture Notes in Computer Science, pages 803\u2013 815. Springer, 2005. [13](#page-14-2)",
+      "authors": [
+        "Craig Gentry",
+        "Zulfikar Ramzan"
+      ],
+      "title": "",
+      "year": "2005",
+      "venue": "Automata, Languages and Programming",
+      "volume": "3580 of Lecture Notes in Computer Science",
+      "pages": "803\u2013 815",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GR05"
+    },
+    {
+      "key": "[HL18]",
+      "raw_text": "- <span id=\"page-38-2\"></span>[HL18] Justin Holmgren and Alex Lombardi. Cryptographic hashing from strong one-way functions (or: One-way product functions and their applications). In Mikkel Thorup, editor, 59th IEEE Annual Symposium on Foundations of Computer Science, FOCS 2018, Paris, France, October 7-9, 2018, pages 850\u2013858. IEEE Computer Society, 2018. [6](#page-7-2)",
+      "authors": [
+        "Justin Holmgren",
+        "Alex Lombardi"
+      ],
+      "title": "",
+      "year": "2018",
+      "venue": "59th IEEE Annual Symposium on Foundations of Computer Science, FOCS 2018",
+      "volume": "",
+      "pages": "850\u2013858",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "HL18"
+    },
+    {
+      "key": "[HLR21]",
+      "raw_text": "- <span id=\"page-38-5\"></span>[HLR21] Justin Holmgren, Alex Lombardi, and Ron D. Rothblum. Fiat-shamir via listrecoverable codes (or: Parallel repetition of gmw is not zero-knowledge). Cryptology ePrint Archive, Report 2021/286, 2021. <https://eprint.iacr.org/2021/286>. [6](#page-7-2)",
+      "authors": [
+        "Justin Holmgren",
+        "Alex Lombardi",
+        "Ron D. Rothblum"
+      ],
+      "title": "",
+      "year": "2021",
+      "venue": "Cryptology ePrint Archive, Report 2021/286",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2021/286"
+      ],
+      "eprint_id": "2021/286",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "HLR21"
+    },
+    {
+      "key": "[HW15]",
+      "raw_text": "- <span id=\"page-38-1\"></span>[HW15] Pavel Hub\u00e1cek and Daniel Wichs. On the communication complexity of secure function evaluation with long output. In Tim Roughgarden, editor, Proceedings of the 2015 Conference on Innovations in Theoretical Computer Science, ITCS 2015, Rehovot, Israel, January 11-13, 2015, pages 163\u2013172. ACM, 2015. [2,](#page-3-2) [7,](#page-8-2) [13,](#page-14-2) [15](#page-16-2)",
+      "authors": [
+        "Pavel Hub\u00e1cek",
+        "Daniel Wichs"
+      ],
+      "title": "",
+      "year": "2015",
+      "venue": "Proceedings of the 2015 Conference on Innovations in Theoretical Computer Science, ITCS 2015",
+      "volume": "",
+      "pages": "163\u2013172",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "HW15"
+    },
+    {
+      "key": "[JKKZ20]",
+      "raw_text": "- <span id=\"page-39-4\"></span>[JKKZ20] Ruta Jawale, Yael Tauman Kalai, Dakshita Khurana, and Rachel Zhang. Snargs for bounded depth computations and PPAD hardness from sub-exponential LWE. IACR Cryptol. ePrint Arch., 2020:980, 2020. [1,](#page-0-0) [8](#page-9-2)",
+      "authors": [
+        "Ruta Jawale",
+        "Yael Tauman Kalai",
+        "Dakshita Khurana",
+        "Rachel Zhang"
+      ],
+      "title": "",
+      "year": "2020",
+      "venue": "IACR Cryptol. ePrint Arch.",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "980",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "JKKZ20"
+    },
+    {
+      "key": "[JKKZ21]",
+      "raw_text": "- <span id=\"page-39-8\"></span>[JKKZ21] Ruta Jawale, Yael Tauman Kalai, Dakshita Khurana, and Rachel Zhang. Snargs for bounded depth computations and PPAD hardness from sub-exponential LWE. 2021. [6,](#page-7-2) [30](#page-31-2)",
+      "authors": [
+        "Ruta Jawale",
+        "Yael Tauman Kalai",
+        "Dakshita Khurana",
+        "Rachel Zhang"
+      ],
+      "title": "",
+      "year": "2021",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "unknown",
+      "alpha_key": "JKKZ21"
+    },
+    {
+      "key": "[Kil92]",
+      "raw_text": "- <span id=\"page-39-0\"></span>[Kil92] Joe Kilian. A note on efficient zero-knowledge proofs and arguments (extended abstract). In STOC, pages 723\u2013732, 1992. [1,](#page-0-0) [4](#page-5-2)",
+      "authors": [
+        "Joe Kilian"
+      ],
+      "title": "",
+      "year": "1992",
+      "venue": "STOC",
+      "volume": "",
+      "pages": "723\u2013732",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Kil92"
+    },
+    {
+      "key": "[KO97]",
+      "raw_text": "- <span id=\"page-39-9\"></span>[KO97] Eyal Kushilevitz and Rafail Ostrovsky. Replication is not needed: Single database, computationally-private information retrieval. In FOCS, pages 364\u2013373, 1997. [12,](#page-13-3) [13](#page-14-2)",
+      "authors": [
+        "Eyal Kushilevitz",
+        "Rafail Ostrovsky"
+      ],
+      "title": "",
+      "year": "1997",
+      "venue": "FOCS",
+      "volume": "",
+      "pages": "364\u2013373",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "KO97"
+    },
+    {
+      "key": "[KPY19]",
+      "raw_text": "- <span id=\"page-39-5\"></span>[KPY19] Yael Tauman Kalai, Omer Paneth, and Lisa Yang. How to delegate computations publicly. In Moses Charikar and Edith Cohen, editors, Proceedings of the 51st Annual ACM SIGACT Symposium on Theory of Computing, STOC 2019, Phoenix, AZ, USA, June 23-26, 2019, pages 1115\u20131124. ACM, 2019. [1](#page-0-0)",
+      "authors": [
+        "Yael Tauman Kalai",
+        "Omer Paneth",
+        "Lisa Yang"
+      ],
+      "title": "",
+      "year": "2019",
+      "venue": "STOC 2019",
+      "volume": "",
+      "pages": "1115\u20131124",
+      "doi": "ACM, 2019",
+      "urls": [
+        "[1](#page-0-0)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KPY19"
+    },
+    {
+      "key": "[KRR13]",
+      "raw_text": "- <span id=\"page-39-2\"></span>[KRR13] Yael Tauman Kalai, Ran Raz, and Ron D. Rothblum. Delegation for bounded space. In Symposium on Theory of Computing Conference, STOC'13, Palo Alto, CA, USA, June 1-4, 2013, pages 565\u2013574, 2013. [1,](#page-0-0) [39](#page-40-4)",
+      "authors": [
+        "Yael Tauman Kalai",
+        "Ran Raz",
+        "Ron D. Rothblum"
+      ],
+      "title": "",
+      "year": "2013",
+      "venue": "STOC'13",
+      "volume": "",
+      "pages": "565\u2013574",
+      "doi": "ACM, 2013",
+      "urls": [
+        "[1,](#page-0-0)",
+        "[39](#page-40-4)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KRR13"
+    },
+    {
+      "key": "[KRR14]",
+      "raw_text": "- <span id=\"page-39-3\"></span>[KRR14] Yael Tauman Kalai, Ran Raz, and Ron D. Rothblum. How to delegate computations: the power of no-signaling proofs. In STOC, pages 485\u2013494. ACM, 2014. [1,](#page-0-0) [8,](#page-9-2) [10,](#page-11-2) [19](#page-20-3)",
+      "authors": [
+        "Yael Tauman Kalai",
+        "Ran Raz",
+        "Ron D. Rothblum"
+      ],
+      "title": "",
+      "year": "2014",
+      "venue": "STOC",
+      "volume": "",
+      "pages": "485\u2013494",
+      "doi": "ACM, 2014",
+      "urls": [
+        "[1,](#page-0-0)",
+        "[8,](#page-9-2)",
+        "[10,](#page-11-2)",
+        "[19](#page-20-3)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KRR14"
+    },
+    {
+      "key": "[KRR17]",
+      "raw_text": "- <span id=\"page-39-7\"></span>[KRR17] Yael Tauman Kalai, Guy N. Rothblum, and Ron D. Rothblum. From obfuscation to the security of fiat-shamir for proofs. In Jonathan Katz and Hovav Shacham, editors, Advances in Cryptology - CRYPTO 2017 - 37th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 20-24, 2017, Proceedings, Part II, volume 10402 of Lecture Notes in Computer Science, pages 224\u2013251. Springer, 2017. [6](#page-7-2)",
+      "authors": [
+        "Yael Tauman Kalai",
+        "Guy N. Rothblum",
+        "Ron D. Rothblum"
+      ],
+      "title": "",
+      "year": "2017",
+      "venue": "CRYPTO 2017",
+      "volume": "10402 of Lecture Notes in Computer Science",
+      "pages": "224\u2013251",
+      "doi": "Springer, 2017",
+      "urls": [
+        "[6](#page-7-2)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KRR17"
+    },
+    {
+      "key": "[Lip05]",
+      "raw_text": "- <span id=\"page-39-10\"></span>[Lip05] Helger Lipmaa. An oblivious transfer protocol with log-squared communication. In Jianying Zhou, Javier L\u00f3pez, Robert H. Deng, and Feng Bao, editors, Information Security, 8th International Conference, ISC 2005, Singapore, September 20-23, 2005, Proceedings, volume 3650 of Lecture Notes in Computer Science, pages 314\u2013 328. Springer, 2005. [13](#page-14-2)",
+      "authors": [
+        "Helger Lipmaa"
+      ],
+      "title": "",
+      "year": "2005",
+      "venue": "ISC 2005",
+      "volume": "3650 of Lecture Notes in Computer Science",
+      "pages": "314\u2013328",
+      "doi": "Springer, 2005",
+      "urls": [
+        "[13](#page-14-2)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Lip05"
+    },
+    {
+      "key": "[Mer87]",
+      "raw_text": "- <span id=\"page-39-1\"></span>[Mer87] Ralph C. Merkle. A digital signature based on a conventional encryption function. In CRYPTO, volume 293 of Lecture Notes in Computer Science, pages 369\u2013378. Springer, 1987. [1](#page-0-0)",
+      "authors": [
+        "Ralph C. Merkle"
+      ],
+      "title": "",
+      "year": "1987",
+      "venue": "CRYPTO",
+      "volume": "293 of Lecture Notes in Computer Science",
+      "pages": "369\u2013378",
+      "doi": "Springer, 1987",
+      "urls": [
+        "[1](#page-0-0)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Mer87"
+    },
+    {
+      "key": "[PR17]",
+      "raw_text": "- <span id=\"page-39-6\"></span>[PR17] Omer Paneth and Guy N. Rothblum. On zero-testable homomorphic encryption and publicly verifiable non-interactive arguments. In Theory of Cryptography - 15th International Conference, TCC 2017, Baltimore, MD, USA, November 12-15, 2017, Proceedings, Part II, pages 283\u2013315, 2017. [1](#page-0-0)",
+      "authors": [
+        "Omer Paneth",
+        "Guy N. Rothblum"
+      ],
+      "title": "",
+      "year": "2017",
+      "venue": "TCC 2017",
+      "volume": "",
+      "pages": "283\u2013315",
+      "doi": "Springer, 2017",
+      "urls": [
+        "[1](#page-0-0)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "PR17"
+    },
+    {
+      "key": "[PS19]",
+      "raw_text": "- <span id=\"page-40-4\"></span><span id=\"page-40-3\"></span>[PS19] Chris Peikert and Sina Shiehian. Noninteractive zero knowledge for NP from (plain) learning with errors. In Alexandra Boldyreva and Daniele Micciancio, editors, Advances in Cryptology - CRYPTO 2019, Proceedings, Part I, volume 11692 of Lecture Notes in Computer Science, pages 89\u2013114. Springer, 2019. [6](#page-7-2)",
+      "authors": [
+        "Chris Peikert",
+        "Sina Shiehian"
+      ],
+      "title": "",
+      "year": "2019",
+      "venue": "CRYPTO 2019",
+      "volume": "11692 of Lecture Notes in Computer Science",
+      "pages": "89\u2013114",
+      "doi": "Springer, 2019",
+      "urls": [
+        "[6](#page-7-2)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "PS19"
+    },
+    {
+      "key": "[Unr12]",
+      "raw_text": "- <span id=\"page-40-2\"></span>[Unr12] Dominique Unruh. Quantum proofs of knowledge. In David Pointcheval and Thomas Johansson, editors, Advances in Cryptology - EUROCRYPT 2012 - 31st Annual International Conference on the Theory and Applications of Cryptographic Techniques, Cambridge, UK, April 15-19, 2012. Proceedings, volume 7237 of Lecture Notes in Computer Science, pages 135\u2013152. Springer, 2012. [3](#page-4-1)",
+      "authors": [
+        "Dominique Unruh"
+      ],
+      "title": "",
+      "year": "2012",
+      "venue": "EUROCRYPT 2012",
+      "volume": "7237 of Lecture Notes in Computer Science",
+      "pages": "135\u2013152",
+      "doi": "Springer, 2012",
+      "urls": [
+        "[3](#page-4-1)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Unr12"
+    },
+    {
+      "key": "[Wat09]",
+      "raw_text": "- <span id=\"page-40-1\"></span>[Wat09] John Watrous. Zero-knowledge against quantum attacks. SIAM J. Comput., 39(1):25\u2013 58, 2009. [3](#page-4-1)",
+      "authors": [
+        "John Watrous"
+      ],
+      "title": "",
+      "year": "2009",
+      "venue": "SIAM J. Comput.",
+      "volume": "39(1)",
+      "pages": "25\u201358",
+      "doi": "Springer, 2009",
+      "urls": [
+        "[3](#page-4-1)"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Wat09"
+    }
+  ]
 }

--- a/data/markdown/eprint/2021_788/bibliography_info.json
+++ b/data/markdown/eprint/2021_788/bibliography_info.json
@@ -1,13 +1,13 @@
 {
-  "provider": "claude-code",
-  "model": "sonnet",
-  "extracted_at": "2026-03-29T16:46:44.802141+00:00",
-  "elapsed_seconds": 1200.34,
+  "provider": "ollama",
+  "model": "llama3.1:8b",
+  "extracted_at": "2026-04-02T22:40:30.852353+00:00",
+  "elapsed_seconds": 144.91,
   "source_markdown": "2021_788.md",
   "markdown_sha256": "65f5593506f7a4241c68c338c673caaf62a0c9d373a58ee999abf9f4e4096319",
   "prompt_version": "v2",
-  "reference_count": 0,
-  "input_tokens": 0,
-  "output_tokens": 0,
-  "estimated_cost_usd": 0.0
+  "reference_count": 40,
+  "input_tokens": 4769,
+  "output_tokens": 4229,
+  "estimated_cost_usd": 0.000577
 }


### PR DESCRIPTION
Extracted structured bibliography for `2021/788`.

40 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit ff943b7)
Website: https://papyrus.badaas.eu