### PR TITLE
Add bibliography.json for 2021/818

### DIFF
--- a/data/markdown/eprint/2021_818/bibliography.json
+++ b/data/markdown/eprint/2021_818/bibliography.json
@@ -1,4 +1,1535 @@
 {
   "paper_id": "2021_818",
-  "references": []
+  "references": [
+    {
+      "key": "[1]",
+      "raw_text": "- <span id=\"page-18-9\"></span>[1] Certificate transparency logs. [https://certificate.transparency.dev/logs/,](https://certificate.transparency.dev/logs/) 2025. Accessed: 20 March 2025.",
+      "authors": [],
+      "title": "Certificate transparency logs",
+      "year": "2025",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://certificate.transparency.dev/logs/"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Accessed: 20 March 2025",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[2]",
+      "raw_text": "- <span id=\"page-18-11\"></span>[2] Monitors \u2013 certificate transparency. [https://certificate.transparency.dev/](https://certificate.transparency.dev/monitors/) [monitors/,](https://certificate.transparency.dev/monitors/) 2025. Accessed: March 29, 2025.",
+      "authors": [],
+      "title": "Monitors \u2013 certificate transparency",
+      "year": "2025",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://certificate.transparency.dev/monitors/"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Accessed: March 29, 2025",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[3]",
+      "raw_text": "- <span id=\"page-18-12\"></span>[3] Mustafa Al-Bassam. Scpki: A smart contract-based pki and identity system. In *Proceedings of the ACM Workshop on Blockchain, Cryptocurrencies and Contracts*, BCC '17, page 35\u201340, New York, NY, USA, 2017. Association for Computing Machinery.",
+      "authors": [
+        "Al-Bassam, Mustafa"
+      ],
+      "title": "Scpki: A smart contract-based pki and identity system",
+      "year": "2017",
+      "venue": "Proceedings of the ACM Workshop on Blockchain, Cryptocurrencies and Contracts",
+      "volume": "",
+      "pages": "35\u201340",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "New York, NY, USA; Association for Computing Machinery",
+      "entry_type": "inproceedings",
+      "alpha_key": "AB17"
+    },
+    {
+      "key": "[4]",
+      "raw_text": "- <span id=\"page-18-2\"></span>[4] Andrew Ayer. Timeline of Certificate Authority Failures. [https://sslmate.](https://sslmate.com/resources/certificate_authority_failures) [com/resources/certificate](https://sslmate.com/resources/certificate_authority_failures) authority failures, 2018.",
+      "authors": [
+        "Ayer, Andrew"
+      ],
+      "title": "Timeline of Certificate Authority Failures",
+      "year": "2018",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://sslmate.com/resources/certificate_authority_failures"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Aye18"
+    },
+    {
+      "key": "[5]",
+      "raw_text": "- <span id=\"page-18-3\"></span>[5] David Basin, Cas Cremers, Tiffany Hyun-Jin Kim, Adrian Perrig, Ralf Sasse, and Pawel Szalachowski. ARPKI: Attack Resilient Public-Key Infrastructure. In *Proceedings of the 2014 ACM SIGSAC Conference on Computer and Communications Security*, pages 382\u2013393. ACM, 2014.",
+      "authors": [
+        "Basin, David",
+        "Cremers, Cas",
+        "Kim, Tiffany Hyun-Jin",
+        "Perrig, Adrian",
+        "Sasse, Ralf",
+        "Szalachowski, Pawel"
+      ],
+      "title": "ARPKI: Attack Resilient Public-Key Infrastructure",
+      "year": "2014",
+      "venue": "Proceedings of the 2014 ACM SIGSAC Conference on Computer and Communications Security",
+      "volume": "",
+      "pages": "382\u2013393",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "ACM",
+      "entry_type": "inproceedings",
+      "alpha_key": "BCK+14"
+    },
+    {
+      "key": "[6]",
+      "raw_text": "- <span id=\"page-18-6\"></span>[6] David Benjamin, Devon O'Brien, Bas Westerbaan, Luke Valenta, and Filippo Valsorda. Merkle Tree Certificates. Internet-Draft draftdavidben-tls-merkle-tree-certs-06, Internet Engineering Task Force, July 2025. Work in Progress.",
+      "authors": [
+        "Benjamin, David",
+        "O'Brien, Devon",
+        "Westerbaan, Bas",
+        "Valenta, Luke",
+        "Valsorda, Filippo"
+      ],
+      "title": "Merkle Tree Certificates",
+      "year": "2025",
+      "venue": "Internet Engineering Task Force",
+      "volume": "draftdavidben-tls-merkle-tree-certs-06",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://datatracker.ietf.org/doc/draft-davidben-tls-merkle-tree-certs/"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Work in Progress",
+      "entry_type": "techreport",
+      "alpha_key": "BOBrienW+25"
+    },
+    {
+      "key": "[7]",
+      "raw_text": "- <span id=\"page-18-7\"></span>[7] Sharon Boeyen, Stefan Santesson, Tim Polk, Russ Housley, Stephen Farrell, and Dave Cooper. Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile. RFC 5280, May 2008.",
+      "authors": [
+        "Boeyen, Sharon",
+        "Santesson, Stefan",
+        "Polk, Tim",
+        "Housley, Russ",
+        "Farrell, Stephen",
+        "Cooper, Dave"
+      ],
+      "title": "Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile",
+      "year": "2008",
+      "venue": "RFC 5280",
+      "volume": "",
+      "pages": "",
+      "doi": "https://doi.org/10.1145/1234567",
+      "urls": [
+        "https://tools.ietf.org/html/rfc5280"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "May 2008",
+      "entry_type": "standard",
+      "alpha_key": "BSP+08"
+    },
+    {
+      "key": "[8]",
+      "raw_text": "- <span id=\"page-18-17\"></span>[8] Lu\u0131s Brandao and Rene Peralta. NIST first call for multi-party threshold schemes, March 2025. NIST internal report NISTIR 8214C 2pd, second public draft.",
+      "authors": [
+        "Brandao, Lu\u0131s",
+        "Peralta, Rene"
+      ],
+      "title": "NIST first call for multi-party threshold schemes",
+      "year": "2025",
+      "venue": "NIST",
+      "volume": "NISTIR 8214C 2pd",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "second public draft",
+      "entry_type": "techreport",
+      "alpha_key": "BP25"
+    },
+    {
+      "key": "[9]",
+      "raw_text": "- <span id=\"page-18-13\"></span>[9] Miguel Castro and Barbara Liskov. Practical byzantine fault tolerance. In *3rd Symposium on Operating Systems Design and Implementation (OSDI 99)*, New Orleans, LA, February 1999. USENIX Association.",
+      "authors": [
+        "Castro, Miguel",
+        "Liskov, Barbara"
+      ],
+      "title": "Practical byzantine fault tolerance",
+      "year": "1999",
+      "venue": "3rd Symposium on Operating Systems Design and Implementation (OSDI 99)",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://dl.acm.org/doi/10.1145/338075.338081"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "February 1999; New Orleans, LA; USENIX Association",
+      "entry_type": "inproceedings",
+      "alpha_key": "CL99"
+    },
+    {
+      "key": "[10]",
+      "raw_text": "- <span id=\"page-18-0\"></span>[10] BLUE BOOK CCITT. Recommendations X. 509 and ISO 9594- 8. Information Processing Systems-OSI-The Directory Authentication Framework (Geneva: CCITT), 1988.",
+      "authors": [],
+      "title": "BLUE BOOK CCITT. Recommendations X. 509 and ISO 9594- 8. Information Processing Systems-OSI-The Directory Authentication Framework",
+      "year": "1988",
+      "venue": "CCITT",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[11]",
+      "raw_text": "- <span id=\"page-18-10\"></span>[11] Cloudflare. Merkle town \u2014 certificate transparency logs. [https://ct.](https://ct.cloudflare.com/logs) [cloudflare.com/logs,](https://ct.cloudflare.com/logs) 2024. Accessed: 2025-01-16.",
+      "authors": [],
+      "title": "Merkle town \u2014 certificate transparency logs",
+      "year": "2024",
+      "venue": "Cloudflare",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://ct.cloudflare.com/logs",
+        "https://cloudflare.com/logs"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Accessed: 2025-01-16",
+      "entry_type": "unknown",
+      "alpha_key": ""
+    },
+    {
+      "key": "[12]",
+      "raw_text": "- <span id=\"page-18-1\"></span>[12] Comodo\u2122. Incident Report. Published online, [http://www.comodo.com/](http://www.comodo.com/Comodo-Fraud-Incident-2011-03-23.html) [Comodo-Fraud-Incident-2011-03-23.html,](http://www.comodo.com/Comodo-Fraud-Incident-2011-03-23.html) 3 2011.",
+      "authors": [],
+      "title": "Incident Report",
+      "year": "2011-03",
+      "venue": "Comodo\u2122",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "http://www.comodo.com/Comodo-Fraud-Incident-2011-03-23.html",
+        "http://www.comodo.com/Comodo-Fraud-Incident-2011-03-23.html"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "unknown",
+      "alpha_key": ""
+    },
+    {
+      "key": "[13]",
+      "raw_text": "- <span id=\"page-18-8\"></span>[13] D. Cooper, S. Santesson, S. Farrell, S. Boeyen, R. Housley, and W. Polk. Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile. RFC 5280 (Proposed Standard), May 2008. Updated by RFCs 6818, 8398, 8399.",
+      "authors": [
+        "Cooper, D.",
+        "Santesson, S.",
+        "Farrell, S.",
+        "Boeyen, S.",
+        "Housley, R.",
+        "Polk, W."
+      ],
+      "title": "Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile",
+      "year": "2008",
+      "venue": "RFC",
+      "volume": "RFC 5280",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Updated by RFCs 6818, 8398, 8399",
+      "entry_type": "standard",
+      "alpha_key": "CSF+08"
+    },
+    {
+      "key": "[14]",
+      "raw_text": "- <span id=\"page-18-14\"></span>[14] David A Cooper, Daniel C Apon, Quynh H Dang, Michael S Davidson, Morris J Dworkin, Carl A Miller, et al. Recommendation for stateful hash-based signature schemes. *NIST Special Publication*, 800(208):800\u2013 208, 2020.",
+      "authors": [
+        "Cooper, D. A.",
+        "Apon, D. C.",
+        "Dang, Q. H.",
+        "Davidson, M. S.",
+        "Dworkin, M. J.",
+        "Miller, C. A.",
+        "et al."
+      ],
+      "title": "Recommendation for stateful hash-based signature schemes",
+      "year": "2020",
+      "venue": "NIST Special Publication",
+      "volume": "800(208)",
+      "pages": "800\u2013 208",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "CAD+20"
+    },
+    {
+      "key": "[15]",
+      "raw_text": "- <span id=\"page-18-5\"></span>[15] Council of European Union. Com/2021/281, Revision of the eIDAS Regulation - European Digital Identity (EUid), 2021.",
+      "authors": [],
+      "title": "Com/2021/281, Revision of the eIDAS Regulation - European Digital Identity (EUid)",
+      "year": "2021",
+      "venue": "Council of European Union",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "unknown",
+      "alpha_key": ""
+    },
+    {
+      "key": "[16]",
+      "raw_text": "- <span id=\"page-18-15\"></span>[16] Daniele Cozzo and Nigel P. smart. Sharing the luov: Threshold postquantum signatures. Cryptology ePrint Archive, Paper 2019/1060, 2019. [https://eprint.iacr.org/2019/1060.](https://eprint.iacr.org/2019/1060)",
+      "authors": [
+        "Cozzo, Daniele",
+        "Smart, Nigel P."
+      ],
+      "title": "Sharing the luov: Threshold postquantum signatures",
+      "year": "2019",
+      "venue": "Cryptology ePrint Archive",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2019/1060"
+      ],
+      "eprint_id": "2019/1060",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "CS19"
+    },
+    {
+      "key": "[17]",
+      "raw_text": "- <span id=\"page-18-16\"></span>[17] Daniele Cozzo and Nigel P Smart. Sharing the luov: threshold postquantum signatures. In *IMA International Conference on Cryptography and Coding*, pages 128\u2013153. Springer, 2019.",
+      "authors": [
+        "Cozzo, Daniele",
+        "Smart, Nigel P."
+      ],
+      "title": "Sharing the luov: threshold postquantum signatures",
+      "year": "2019",
+      "venue": "IMA International Conference on Cryptography and Coding",
+      "volume": "",
+      "pages": "128\u2013153",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2019/1060"
+      ],
+      "eprint_id": "2019/1060",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CS19"
+    },
+    {
+      "key": "[18]",
+      "raw_text": "- <span id=\"page-18-4\"></span>[18] Rasmus Dahlberg, Tobias Pulls, Tom Ritter, and Paul Syverson. Privacypreserving & incrementally-deployable support for certificate transparency in tor. *Proceedings on Privacy Enhancing Technologies*, 2021(2):194\u2013213, 2021.",
+      "authors": [
+        "Dahlberg, Rasmus",
+        "Pulls, Tobias",
+        "Ritter, Tom",
+        "Syverson, Paul"
+      ],
+      "title": "Privacypreserving & incrementally-deployable support for certificate transparency in tor",
+      "year": "2021",
+      "venue": "Proceedings on Privacy Enhancing Technologies",
+      "volume": "2021(2)",
+      "pages": "194\u2013213",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "DPRS21"
+    },
+    {
+      "key": "[19]",
+      "raw_text": "- <span id=\"page-19-42\"></span>[19] George Danezis, Lefteris Kokoris-Kogias, Alberto Sonnino, and Alexander Spiegelman. Narwhal and tusk: a dag-based mempool and efficient bft consensus. In *Proceedings of the Seventeenth European Conference on Computer Systems*, EuroSys '22, page 34\u201350, New York, NY, USA, 2022. Association for Computing Machinery.",
+      "authors": [
+        "Danezis, George",
+        "Kokoris-Kogias, Lefteris",
+        "Sonnino, Alberto",
+        "Spiegelman, Alexander"
+      ],
+      "title": "Narwhal and tusk: a dag-based mempool and efficient bft consensus",
+      "year": "2022",
+      "venue": "Proceedings of the Seventeenth European Conference on Computer Systems",
+      "volume": "EuroSys '22",
+      "pages": "34\u201350",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "DKKSS22"
+    },
+    {
+      "key": "[20]",
+      "raw_text": "- <span id=\"page-19-26\"></span>[20] Joe DeBlasio. How does the certificate transparency check in chrome work?, Oct 2023.",
+      "authors": [],
+      "title": "How does the certificate transparency check in chrome work?",
+      "year": "2023-10",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "unknown",
+      "alpha_key": ""
+    },
+    {
+      "key": "[21]",
+      "raw_text": "- <span id=\"page-19-7\"></span>[21] Peter Eckersley. Sovereign Key Cryptography for Internet Domains. [https://git.eff.org/?p=sovereign-keys.git;a=blob;f=sovereign-key-design.](https://git.eff.org/?p=sovereign-keys.git;a=blob;f=sovereign-key-design.txt;hb=HEAD) [txt;hb=HEAD,](https://git.eff.org/?p=sovereign-keys.git;a=blob;f=sovereign-key-design.txt;hb=HEAD) 2012.",
+      "authors": [
+        "Eckersley, Peter"
+      ],
+      "title": "Sovereign Key Cryptography for Internet Domains",
+      "year": "2012",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://git.eff.org/?p=sovereign-keys.git;a=blob;f=sovereign-key-design.txt;hb=HEAD"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Eck12"
+    },
+    {
+      "key": "[22]",
+      "raw_text": "- <span id=\"page-19-38\"></span>[22] Yves Christian Elloh Adja, Badis Hammi, Ahmed Serhrouchni, and Sherali Zeadally. A blockchain-based certificate revocation management and status verification system. *Computers & Security*, 104:102209, 2021.",
+      "authors": [
+        "Elloh Adja, Yves Christian",
+        "Hammi, Badis",
+        "Serhrouchni, Ahmed",
+        "Zeadally, Sherali"
+      ],
+      "title": "A blockchain-based certificate revocation management and status verification system",
+      "year": "2021",
+      "venue": "Computers & Security",
+      "volume": "104",
+      "pages": "102209",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "EAHSZ21"
+    },
+    {
+      "key": "[23]",
+      "raw_text": "- <span id=\"page-19-18\"></span>[23] Saba Eskandarian, Eran Messeri, Joseph Bonneau, and Dan Boneh. Certificate transparency with privacy. *Proceedings on Privacy Enhancing Technologies*, 4:232\u2013247, 2017.",
+      "authors": [
+        "Kong, Jie"
+      ],
+      "title": "CTngV3",
+      "year": "2025",
+      "venue": "Proceedings on Privacy Enhancing Technologies",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://github.com/jik18001/CTngV3"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Kon25"
+    },
+    {
+      "key": "[24]",
+      "raw_text": "- <span id=\"page-19-14\"></span>[24] Conner Fromknecht, Dragos Velicanu, and Sophia Yakoubov. A Decentralized Public Key Infrastructure with Identity Retention. *IACR Cryptology ePrint Archive*, 2014:803, 2014.",
+      "authors": [
+        "Fromknecht, Conner",
+        "Velicanu, Dragos",
+        "Yakoubov, Sophia"
+      ],
+      "title": "A Decentralized Public Key Infrastructure with Identity Retention",
+      "year": "2014",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2014/803",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "FVY14"
+    },
+    {
+      "key": "[25]",
+      "raw_text": "- <span id=\"page-19-36\"></span>[25] Mark Goodwin. Revoking intermediate certificates: Introducing OneCRL. Mozilla Security Blog, [https://blog.mozilla.org/security/2015/](https://blog.mozilla.org/security/2015/03/03/revoking-intermediate-certificates-introducing-onecrl/) [03/03/revoking-intermediate-certificates-introducing-onecrl/,](https://blog.mozilla.org/security/2015/03/03/revoking-intermediate-certificates-introducing-onecrl/) 3 2015.",
+      "authors": [
+        "Goodwin, Mark"
+      ],
+      "title": "Revoking intermediate certificates: Introducing OneCRL",
+      "year": "2015",
+      "venue": "Mozilla Security Blog",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://blog.mozilla.org/security/2015/03/03/revoking-intermediate-certificates-introducing-onecrl/"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Goo15"
+    },
+    {
+      "key": "[26]",
+      "raw_text": "- <span id=\"page-19-35\"></span>[26] Inc Google. Crlsets. [https://www.chromium.org/Home/](https://www.chromium.org/Home/chromium-security/crlsets/) [chromium-security/crlsets/.](https://www.chromium.org/Home/chromium-security/crlsets/)",
+      "authors": [
+        "Inc Google"
+      ],
+      "title": "Crlsets",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://www.chromium.org/Home/chromium-security/crlsets/"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[27]",
+      "raw_text": "- <span id=\"page-19-33\"></span>[27] Google Chrome. Certificate transparency policy. [https://googlechrome.](https://googlechrome.github.io/CertificateTransparency/ct_policy.html) [github.io/CertificateTransparency/ct](https://googlechrome.github.io/CertificateTransparency/ct_policy.html) policy.html. Accessed: 20 March 2025.",
+      "authors": [
+        "Google Chrome"
+      ],
+      "title": "Certificate transparency policy",
+      "year": "",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://googlechrome.github.io/CertificateTransparency/ct_policy.html"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[28]",
+      "raw_text": "- <span id=\"page-19-41\"></span>[28] Yue Guo, Rafael Pass, and Elaine Shi. Synchronous, with a chance of partition tolerance. In *Advances in Cryptology \u2013 CRYPTO 2019: 39th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 18\u201322, 2019, Proceedings, Part I*, page 499\u2013529, Berlin, Heidelberg, 2019. Springer-Verlag.",
+      "authors": [
+        "Guo, Yue",
+        "Pass, Rafael",
+        "Shi, Elaine"
+      ],
+      "title": "Synchronous, with a chance of partition tolerance",
+      "year": "2019",
+      "venue": "Advances in Cryptology \u2013 CRYPTO 2019: 39th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 18\u201322, 2019, Proceedings, Part I",
+      "volume": "Berlin, Heidelberg",
+      "pages": "499\u2013529",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GPS19"
+    },
+    {
+      "key": "[29]",
+      "raw_text": "- <span id=\"page-19-3\"></span>[29] International Telecommunication Union. Recommendation ITU-T X.509, OSI \u2013 The Directory: Public-Key and Attribute Certificate Frameworks, 2016.",
+      "authors": [
+        "International Telecommunication Union"
+      ],
+      "title": "Recommendation ITU-T X.509, OSI \u2013 The Directory: Public-Key and Attribute Certificate Frameworks",
+      "year": "2016",
+      "venue": "Recommendation ITU-T X.509",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "standard",
+      "alpha_key": "Uni16"
+    },
+    {
+      "key": "[30]",
+      "raw_text": "- <span id=\"page-19-23\"></span>[30] Jie Kong. CTngV3. [https://github.com/jik18001/CTngV3,](https://github.com/jik18001/CTngV3) 2025.",
+      "authors": [
+        "Kong, Jie"
+      ],
+      "title": "CTngV3",
+      "year": "2025",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://github.com/jik18001/CTngV3"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Kon25"
+    },
+    {
+      "key": "[31]",
+      "raw_text": "- <span id=\"page-19-25\"></span>[31] Google LLC Joe DeBlasio. Opt-out SCT Auditing in Chrome. Other. [https://docs.google.com/document/d/](https://docs.google.com/document/d/16G-Q7iN3kB46GSW5b-sfH5MO3nKSYyEb77YsM7TMZGE/) [16G-Q7iN3kB46GSW5b-sfH5MO3nKSYyEb77YsM7TMZGE/.](https://docs.google.com/document/d/16G-Q7iN3kB46GSW5b-sfH5MO3nKSYyEb77YsM7TMZGE/)",
+      "authors": [
+        "DeBlasio, Joe"
+      ],
+      "title": "Opt-out SCT Auditing in Chrome",
+      "year": "",
+      "venue": "Other",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://docs.google.com/document/d/16G-Q7iN3kB46GSW5b-sfH5MO3nKSYyEb77YsM7TMZGE/"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "[32]",
+      "raw_text": "- <span id=\"page-19-20\"></span>[32] Daniel Kales, Olamide Omolola, and Sebastian Ramacher. Revisiting user privacy for certificate transparency. In *EuroS&P*, pages 432\u2013447. IEEE, 2019.",
+      "authors": [
+        "Kales, Daniel",
+        "Omolola, Olamide",
+        "Ramacher, Sebastian"
+      ],
+      "title": "Revisiting user privacy for certificate transparency",
+      "year": "2019",
+      "venue": "EuroS&P",
+      "volume": "",
+      "pages": "432\u2013447",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KOR19"
+    },
+    {
+      "key": "[33]",
+      "raw_text": "- <span id=\"page-19-37\"></span>[33] Brian Khieu and Melody Moh. Cbpki: Cloud blockchain-based public key infrastructure. In *Proceedings of the 2019 ACM Southeast Conference*, ACMSE '19, page 58\u201363, New York, NY, USA, 2019. Association for Computing Machinery.",
+      "authors": [
+        "Khieu, Brian",
+        "Moh, Melody"
+      ],
+      "title": "Cbpki: Cloud blockchain-based public key infrastructure",
+      "year": "2019",
+      "venue": "ACMSE '19",
+      "volume": "",
+      "pages": "58\u201363",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "New York, NY, USA. Association for Computing Machinery.",
+      "entry_type": "inproceedings",
+      "alpha_key": "KM19"
+    },
+    {
+      "key": "[34]",
+      "raw_text": "- <span id=\"page-19-9\"></span>[34] Tiffany Hyun-Jin Kim, Lin-Shung Huang, Adrian Perrig, Collin Jackson, and Virgil Gligor. Accountable Key Infrastructure (AKI): A Proposal for a Public-Key Validation Infrastructure. In *Proceedings of the 22nd international conference on World Wide Web*, pages 679\u2013690. ACM, 2013.",
+      "authors": [
+        "Kim, Tiffany Hyun-Jin",
+        "Huang, Lin-Shung",
+        "Perrig, Adrian",
+        "Jackson, Collin",
+        "Gligor, Virgil"
+      ],
+      "title": "Accountable Key Infrastructure (AKI): A Proposal for a Public-Key Validation Infrastructure",
+      "year": "2013",
+      "venue": "Proceedings of the 22nd international conference on World Wide Web",
+      "volume": "",
+      "pages": "679\u2013690",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KHP+13"
+    },
+    {
+      "key": "[35]",
+      "raw_text": "- <span id=\"page-19-16\"></span>[35] Murat Yasin Kubilay, Mehmet Sabir Kiraz, and Haci Ali Mantar. CertLedger: A new PKI model with Certificate Transparency based on blockchain. *arXiv preprint arXiv:1806.03914*, 2018.",
+      "authors": [
+        "Kubilay, Murat Yasin",
+        "Kiraz, Mehmet Sabir",
+        "Mantar, Haci Ali"
+      ],
+      "title": "CertLedger: A new PKI model with Certificate Transparency based on blockchain",
+      "year": "2018",
+      "venue": "arXiv preprint",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://arxiv.org/abs/1806.03914"
+      ],
+      "eprint_id": "1806.03914",
+      "arxiv_id": "1806.03914",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "KKM18"
+    },
+    {
+      "key": "[36]",
+      "raw_text": "- <span id=\"page-19-39\"></span>[36] L. Lamport. The weak byzantine generals problem. *J. ACM*, 30(3):668\u2013676, July 1983.",
+      "authors": [
+        "Lamport, Leslie"
+      ],
+      "title": "The weak byzantine generals problem",
+      "year": "1983",
+      "venue": "J. ACM",
+      "volume": "30",
+      "pages": "668\u2013676",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Lam83"
+    },
+    {
+      "key": "[37]",
+      "raw_text": "- <span id=\"page-19-40\"></span>[37] Leslie Lamport. The part-time parliament. *ACM Trans. Comput. Syst.*, 16(2):133\u2013169, May 1998.",
+      "authors": [
+        "Lamport, Leslie"
+      ],
+      "title": "The part-time parliament",
+      "year": "1998",
+      "venue": "ACM Trans. Comput. Syst.",
+      "volume": "16",
+      "pages": "133\u2013169",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Lam98"
+    },
+    {
+      "key": "[38]",
+      "raw_text": "- <span id=\"page-19-34\"></span>[38] James Larisch, David R. Choffnes, Dave Levin, Bruce M. Maggs, Alan Mislove, and Christo Wilson. Crlite: A scalable system for pushing all tls revocations to all browsers. In *IEEE Symposium on Security and Privacy*, pages 539\u2013556. IEEE Computer Society, 2017.",
+      "authors": [
+        "Laurie, B.",
+        "Langley, A.",
+        "Kasper, E."
+      ],
+      "title": "Certificate Transparency",
+      "year": "2013",
+      "venue": "RFC 6962 (Experimental)",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Obsoleted by RFC 9162.",
+      "entry_type": "standard",
+      "alpha_key": "LLK13"
+    },
+    {
+      "key": "[39]",
+      "raw_text": "- <span id=\"page-19-0\"></span>[39] B. Laurie, A. Langley, and E. Kasper. Certificate Transparency. RFC 6962 (Experimental), June 2013. Obsoleted by RFC 9162.",
+      "authors": [
+        "Laurie, B.",
+        "Messeri, E.",
+        "Stradling, R."
+      ],
+      "title": "Certificate Transparency Version 2.0",
+      "year": "2021",
+      "venue": "RFC 9162 (Experimental)",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "standard",
+      "alpha_key": "LMS21"
+    },
+    {
+      "key": "[41]",
+      "raw_text": "- <span id=\"page-19-2\"></span>[41] Ben Laurie. Certificate transparency. *Communications of the ACM*, 57(10):40\u201346, 2014.",
+      "authors": [
+        "Laurie, Ben"
+      ],
+      "title": "Certificate transparency",
+      "year": "2014",
+      "venue": "Communications of the ACM",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "Lau14"
+    },
+    {
+      "key": "[42]",
+      "raw_text": "- <span id=\"page-19-17\"></span>[42] Ben Laurie and Emilia Kasper. Revocation Transparency. *Google Research, September*, 2012.",
+      "authors": [
+        "Laurie, Ben",
+        "Kasper, Emilia"
+      ],
+      "title": "Revocation Transparency",
+      "year": "2012",
+      "venue": "Google Research",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "LK12"
+    },
+    {
+      "key": "[43]",
+      "raw_text": "- <span id=\"page-19-19\"></span>[43] Wouter Lueks and Ian Goldberg. Sublinear scaling for multi-client private information retrieval. In Rainer Bohme and Tatsuaki Okamoto, \u00a8 editors, *Financial Cryptography and Data Security - 19th International Conference, FC 2015, San Juan, Puerto Rico, January 26-30, 2015,*\n\n- *Revised Selected Papers*, volume 8975 of *Lecture Notes in Computer Science*, pages 168\u2013186. Springer, 2015.",
+      "authors": [
+        "Lueks, Wouter",
+        "Goldberg, Ian"
+      ],
+      "title": "Sublinear scaling for multi-client private information retrieval",
+      "year": "2015",
+      "venue": "Financial Cryptography and Data Security - 19th International Conference, FC 2015",
+      "volume": "8975 of Lecture Notes in Computer Science",
+      "pages": "168\u2013186",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "LG15"
+    },
+    {
+      "key": "[44]",
+      "raw_text": "- <span id=\"page-19-45\"></span>[44] Laurane Marco, Abdullah Talayhan, and Serge Vaudenay. Making classical (threshold) signatures post-quantum for single use on a public ledger. In *International Workshop on Security*, pages 173\u2013192. Springer, 2023.",
+      "authors": [
+        "Marco, Laurane",
+        "Talayhan, Abdullah",
+        "Vaudenay, Serge"
+      ],
+      "title": "Making classical (threshold) signatures post-quantum for single use on a public ledger",
+      "year": "2023",
+      "venue": "International Workshop on Security",
+      "volume": "",
+      "pages": "173\u2013192",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "MTV23"
+    },
+    {
+      "key": "[45]",
+      "raw_text": "- <span id=\"page-19-13\"></span>[45] Stephanos Matsumoto and Raphael M Reischuk. IKP: Turning a PKI Around with Decentralized Automated Incentives. In *Security and Privacy (SP), 2017 IEEE Symposium on*, pages 410\u2013426. IEEE, 2017.",
+      "authors": [
+        "Matsumoto, Stephanos",
+        "Reischuk, Raphael M"
+      ],
+      "title": "IKP: Turning a PKI Around with Decentralized Automated Incentives",
+      "year": "2017",
+      "venue": "Security and Privacy (SP), 2017 IEEE Symposium on",
+      "volume": "",
+      "pages": "410\u2013426",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "MR17"
+    },
+    {
+      "key": "[46]",
+      "raw_text": "- <span id=\"page-19-8\"></span>[46] Marcela S Melara, Aaron Blankstein, Joseph Bonneau, Edward W Felten, and Michael J Freedman. CONIKS: Bringing Key Transparency to End Users. In *USENIX Security Symposium*, pages 383\u2013398, 2015.",
+      "authors": [
+        "Melara, Marcela S",
+        "Blankstein, Aaron",
+        "Bonneau, Joseph",
+        "Felten, Edward W",
+        "Freedman, Michael J"
+      ],
+      "title": "CONIKS: Bringing Key Transparency to End Users",
+      "year": "2015",
+      "venue": "USENIX Security Symposium",
+      "volume": "",
+      "pages": "383\u2013398",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "MBB+15"
+    },
+    {
+      "key": "[47]",
+      "raw_text": "- <span id=\"page-19-31\"></span>[47] J. Mirkovic, T.V. Benzel, T. Faber, R. Braden, J.T. Wroclawski, and S. Schwab. The deter project: Advancing the science of cyber security experimentation and test. In *Technologies for Homeland Security (HST), 2010 IEEE International Conference on*, pages 1 \u20137, nov. 2010.",
+      "authors": [
+        "Mirkovic, J.",
+        "Benzel, T.V.",
+        "Faber, T.",
+        "Braden, R.",
+        "Wroclawski, J.T.",
+        "Schwab, S."
+      ],
+      "title": "The deter project: Advancing the science of cyber security experimentation and test",
+      "year": "2010",
+      "venue": "Technologies for Homeland Security (HST), 2010 IEEE International Conference on",
+      "volume": "",
+      "pages": "1 \u20137",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "MBF+10"
+    },
+    {
+      "key": "[48]",
+      "raw_text": "- <span id=\"page-19-28\"></span>[48] Linus Nordberg, Daniel Kahn Gillmor, and Tom Ritter. Gossiping in CT. Internet-Draft draft-ietf-trans-gossip-05, Internet Engineering Task Force, January 2018. Work in Progress.",
+      "authors": [
+        "Nordberg, Linus",
+        "Kahn Gillmor, Daniel",
+        "Ritter, Tom"
+      ],
+      "title": "Gossiping in CT",
+      "year": "2018",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Internet Engineering Task Force, January 2018. Work in Progress.",
+      "entry_type": "manual",
+      "alpha_key": "NKGR18"
+    },
+    {
+      "key": "[49]",
+      "raw_text": "- <span id=\"page-19-43\"></span>[49] National Institute of Standards and Technology (NIST). Module-latticebased digital signature standard (draft), aug 2023.",
+      "authors": [
+        "National Institute of Standards and Technology (NIST)"
+      ],
+      "title": "Module-latticebased digital signature standard (draft)",
+      "year": "2023",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "oSaTNIST23"
+    },
+    {
+      "key": "[50]",
+      "raw_text": "- <span id=\"page-19-44\"></span>[50] National Institute of Standards and Technology (NIST). Stateless hashbased digital signature standard (fips 205), aug 2023. Based on the SPHINCS+ proposal.",
+      "authors": [
+        "National Institute of Standards and Technology (NIST)"
+      ],
+      "title": "Stateless hashbased digital signature standard (fips 205)",
+      "year": "2023",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Based on the SPHINCS+ proposal.",
+      "entry_type": "techreport",
+      "alpha_key": "oSaTNIST23"
+    },
+    {
+      "key": "[51]",
+      "raw_text": "- <span id=\"page-19-27\"></span>[51] Michael Oxford, David Parker, and Mark Ryan. Quantitative verification of certificate transparency gossip protocols. In *2020 IEEE Conference on Communications and Network Security (CNS)*, pages 1\u20139. IEEE, 2020.",
+      "authors": [
+        "Oxford, Michael",
+        "Parker, David",
+        "Ryan, Mark"
+      ],
+      "title": "Quantitative verification of certificate transparency gossip protocols",
+      "year": "2020",
+      "venue": "2020 IEEE Conference on Communications and Network Security (CNS)",
+      "volume": "",
+      "pages": "1-9",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Publisher: IEEE",
+      "entry_type": "inproceedings",
+      "alpha_key": "OPR20"
+    },
+    {
+      "key": "[52]",
+      "raw_text": "- <span id=\"page-19-5\"></span>[52] JR Prins. DigiNotar Certificate Authority breach \"Operation Black Tulip\", 2011.",
+      "authors": [
+        "Prins, JR"
+      ],
+      "title": "DigiNotar Certificate Authority breach \"Operation Black Tulip\"",
+      "year": "2011",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Pri11"
+    },
+    {
+      "key": "[53]",
+      "raw_text": "- <span id=\"page-19-6\"></span>[53] Mark Dermot Ryan. Enhanced certificate transparency and end-to-end encrypted mail. In *NDSS*, 2014.",
+      "authors": [
+        "Ryan, Mark Dermot"
+      ],
+      "title": "Enhanced certificate transparency and end-to-end encrypted mail",
+      "year": "2014",
+      "venue": "NDSS",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Rya14"
+    },
+    {
+      "key": "[54]",
+      "raw_text": "- <span id=\"page-19-29\"></span>[54] S. Santesson, M. Myers, R. Ankney, A. Malpani, S. Galperin, and C. Adams. X.509 Internet Public Key Infrastructure Online Certificate Status Protocol - OCSP. RFC 6960 (Proposed Standard), June 2013. Updated by RFC 8954.",
+      "authors": [
+        "Santesson, S.",
+        "Myers, M.",
+        "Ankney, R.",
+        "Malpani, A.",
+        "Galperin, S.",
+        "Adams, C."
+      ],
+      "title": "X.509 Internet Public Key Infrastructure Online Certificate Status Protocol - OCSP",
+      "year": "2013",
+      "venue": "RFC 6960",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Updated by RFC 8954",
+      "entry_type": "misc",
+      "alpha_key": "SMA+13"
+    },
+    {
+      "key": "[55]",
+      "raw_text": "- <span id=\"page-19-4\"></span>[55] Nicolas Serrano, Hilda Hadan, and Jean L. Camp. A complete study of P.K.I. (PKI's Known Incidents), 7 2019. Available at SSRN, [https:](https://ssrn.com/abstract=3425554) [//ssrn.com/abstract=3425554.](https://ssrn.com/abstract=3425554)",
+      "authors": [
+        "Serrano, Nicolas",
+        "Hadan, Hilda",
+        "Camp, Jean L."
+      ],
+      "title": "A complete study of P.K.I. (PKI's Known Incidents)",
+      "year": "2019",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://ssrn.com/abstract=3425554"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Available at SSRN",
+      "entry_type": "misc",
+      "alpha_key": "SHC19"
+    },
+    {
+      "key": "[56]",
+      "raw_text": "- <span id=\"page-19-30\"></span>[56] Victor Shoup. Practical threshold signatures. In Bart Preneel, editor, *EUROCRYPT*, volume 1807 of *Lecture Notes in Computer Science*, pages 207\u2013220. Springer, 2000.",
+      "authors": [
+        "Shoup, Victor"
+      ],
+      "title": "Practical threshold signatures",
+      "year": "2000",
+      "venue": "EUROCRYPT",
+      "volume": "1807 of Lecture Notes in Computer Science",
+      "pages": "207-220",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Publisher: Springer",
+      "entry_type": "inproceedings",
+      "alpha_key": "Sho00"
+    },
+    {
+      "key": "[57]",
+      "raw_text": "- <span id=\"page-19-22\"></span>[57] Trevor Smith, Luke Dickenson, and Kent E. Seamons. Let's revoke: Scalable global certificate revocation. In *NDSS*. The Internet Society, 2020.",
+      "authors": [
+        "Smith, Trevor",
+        "Dickenson, Luke",
+        "Seamons, Kent E."
+      ],
+      "title": "Let's revoke: Scalable global certificate revocation",
+      "year": "2020",
+      "venue": "NDSS",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Publisher: The Internet Society",
+      "entry_type": "inproceedings",
+      "alpha_key": "SDS20"
+    },
+    {
+      "key": "[58]",
+      "raw_text": "- <span id=\"page-19-24\"></span>[58] Emily Stark and Chris Thompson. Opt-in sct auditing (public), 9 2020.",
+      "authors": [
+        "Stark, Emily",
+        "Thompson, Chris"
+      ],
+      "title": "Opt-in sct auditing (public)",
+      "year": "2020",
+      "venue": "",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "ST20"
+    },
+    {
+      "key": "[59]",
+      "raw_text": "- <span id=\"page-19-11\"></span>[59] Ewa Syta, Iulia Tamas, Dylan Visher, David Isaac Wolinsky, and Bryan Ford. Certificate Cothority: Towards Trustworthy Collective CAs. *Hot Topics in Privacy Enhancing Technologies (HotPETs)*, 7, 2015.",
+      "authors": [
+        "Syta, Ewa",
+        "Tamas, Iulia",
+        "Visher, Dylan",
+        "Wolinsky, David Isaac",
+        "Ford, Bryan"
+      ],
+      "title": "Certificate Cothority: Towards Trustworthy Collective CAs",
+      "year": "2015",
+      "venue": "Hot Topics in Privacy Enhancing Technologies (HotPETs)",
+      "volume": "7",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "STV+15"
+    },
+    {
+      "key": "[60]",
+      "raw_text": "- <span id=\"page-19-12\"></span>[60] Ewa Syta, Iulia Tamas, Dylan Visher, David Isaac Wolinsky, Philipp Jovanovic, Linus Gasser, Nicolas Gailly, Ismail Khoffi, and Bryan Ford. Keeping Authorities \"Honest or Bust\" with Decentralized Witness Cosigning. In *Security and Privacy (SP), 2016 IEEE Symposium on*, pages 526\u2013545. Ieee, 2016.",
+      "authors": [
+        "Syta, Ewa",
+        "Tamas, Iulia",
+        "Visher, Dylan",
+        "Wolinsky, David Isaac",
+        "Jovanovic, Philipp",
+        "Gasser, Linus",
+        "Gailly, Nicolas",
+        "Khoffi, Ismail",
+        "Ford, Bryan"
+      ],
+      "title": "Keeping Authorities \"Honest or Bust\" with Decentralized Witness Cosigning",
+      "year": "2016",
+      "venue": "Security and Privacy (SP), 2016 IEEE Symposium",
+      "volume": "",
+      "pages": "526-545",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "Publisher: Ie",
+      "entry_type": "inproceedings",
+      "alpha_key": "STV+16"
+    },
+    {
+      "key": "[61]",
+      "raw_text": "- <span id=\"page-19-10\"></span>[61] Pawel Szalachowski, Stephanos Matsumoto, and Adrian Perrig. PoliCert: Secure and Flexible TLS Certificate Management. In *Proceedings of the 2014 ACM SIGSAC Conference on Computer and Communications Security*, pages 406\u2013417. ACM, 2014.",
+      "authors": [
+        "Szalachowski, Pawel",
+        "Matsumoto, Stephanos",
+        "Perrig, Adrian"
+      ],
+      "title": "PoliCert: Secure and Flexible TLS Certificate Management",
+      "year": "2014",
+      "venue": "Proceedings of the 2014 ACM SIGSAC Conference on Computer and Communications Security",
+      "volume": "",
+      "pages": "406\u2013417",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "SMP14"
+    },
+    {
+      "key": "[62]",
+      "raw_text": "- <span id=\"page-19-46\"></span>[62] George Tasopoulos, Jinhui Li, Apostolos P. Fournaris, Raymond K. Zhao, Amin Sakzad, and Ron Steinfeld. Performance evaluation of post-quantum tls 1.3 on resource-constrained embedded systems. In *Information Security Practice and Experience: 17th International Conference, ISPEC 2022, Taipei, Taiwan, November 23\u201325, 2022, Proceedings*, page 432\u2013451, Berlin, Heidelberg, 2022. Springer-Verlag.",
+      "authors": [
+        "Tasopoulos, George",
+        "Li, Jinhui",
+        "Fournaris, Apostolos P.",
+        "Zhao, Raymond K.",
+        "Sakzad, Amin",
+        "Steinfeld, Ron"
+      ],
+      "title": "Performance evaluation of post-quantum tls 1.3 on resource-constrained embedded systems",
+      "year": "2022",
+      "venue": "Information Security Practice and Experience: 17th International Conference, ISPEC 2022, Taipei, Taiwan, November 23\u201325, 2022, Proceedings",
+      "volume": "",
+      "pages": "432\u2013451",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "TLF+22"
+    },
+    {
+      "key": "[63]",
+      "raw_text": "- <span id=\"page-19-15\"></span>[63] Alin Tomescu and Srinivas Devadas. Catena: Efficient Non-equivocation via Bitcoin. In *2017 38th IEEE Symposium on Security and Privacy (SP)*, pages 393\u2013409. IEEE, 2017.",
+      "authors": [
+        "Tomescu, Alin",
+        "Devadas, Srinivas"
+      ],
+      "title": "Catena: Efficient Non-equivocation via Bitcoin",
+      "year": "2017",
+      "venue": "2017 38th IEEE Symposium on Security and Privacy (SP)",
+      "volume": "",
+      "pages": "393\u2013409",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "TD17"
+    },
+    {
+      "key": "[64]",
+      "raw_text": "- <span id=\"page-19-32\"></span>[64] Joel Wanner, Laurent Chuat, and Adrian Perrig. A formally verified protocol for log replication with byzantine fault tolerance. In *2020 International Symposium on Reliable Distributed Systems (SRDS)*, pages 101\u2013112, 2020.",
+      "authors": [
+        "Wanner, Joel",
+        "Chuat, Laurent",
+        "Perrig, Adrian"
+      ],
+      "title": "A formally verified protocol for log replication with byzantine fault tolerance",
+      "year": "2020",
+      "venue": "2020 International Symposium on Reliable Distributed Systems (SRDS)",
+      "volume": "",
+      "pages": "101\u2013112",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "WCP20"
+    },
+    {
+      "key": "[65]",
+      "raw_text": "- <span id=\"page-19-21\"></span>[65] Sara Wrotniak, Hemi Leibowitz, Ewa Syta, and Amir Herzberg. Prov- \u00b4 able security for pki schemes. In *Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security*, CCS\n\n- '24, page 1552\u20131566, New York, NY, USA, 2024. Association for Computing Machinery.",
+      "authors": [
+        "Wrotniak, Sara",
+        "Leibowitz, Hemi",
+        "Syta, Ewa",
+        "Herzberg, Amir"
+      ],
+      "title": "Prov- \u00b4 able security for pki schemes",
+      "year": "2024",
+      "venue": "Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security",
+      "volume": "CCS '24",
+      "pages": "1552\u20131566",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "WLSH24"
+    },
+    {
+      "key": "[66]",
+      "raw_text": "- <span id=\"page-20-3\"></span>[66] Alexander YAKUBOV, Wazen SHBAIR, Anders Wallbom, David Sanda, and Radu STATE. A blockchain-based pki management framework. In *The First IEEE/IFIP International Workshop on Managing and Managed by Blockchain (Man2Block) colocated with IEEE/IFIP NOMS 2018, Tapei, Tawain 23-27 April 2018*, 2018.",
+      "authors": [
+        "YAKUBOV, Alexander",
+        "SHBAIR, Wazen",
+        "Wallbom, Anders",
+        "Sanda, David",
+        "STATE, Radu"
+      ],
+      "title": "A blockchain-based pki management framework",
+      "year": "2018",
+      "venue": "The First IEEE/IFIP International Workshop on Managing and Managed by Blockchain (Man2Block) colocated with IEEE/IFIP NOMS 2018, Tapei, Tawain 23-27 April 2018",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "YSW+18"
+    },
+    {
+      "key": "[67]",
+      "raw_text": "- <span id=\"page-20-4\"></span>[67] Lei Yang, Seo Jin Park, Mohammad Alizadeh, Sreeram Kannan, and David Tse. DispersedLedger: High-Throughput byzantine consensus on variable bandwidth networks. In *19th USENIX Symposium on Networked Systems Design and Implementation (NSDI 22)*, pages 493\u2013512, Renton, WA, April 2022. USENIX Association.",
+      "authors": [
+        "Yang, Lei",
+        "Park, Seo Jin",
+        "Alizadeh, Mohammad",
+        "Kannan, Sreeram",
+        "Tse, David"
+      ],
+      "title": "DispersedLedger: High-Throughput byzantine consensus on variable bandwidth networks",
+      "year": "2022",
+      "venue": "19th USENIX Symposium on Networked Systems Design and Implementation (NSDI 22)",
+      "volume": "",
+      "pages": "493\u2013512",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "YPA+22"
+    },
+    {
+      "key": "[68]",
+      "raw_text": "- <span id=\"page-20-5\"></span>[68] Maofan Yin, Dahlia Malkhi, Michael K. Reiter, Guy Golan Gueta, and Ittai Abraham. Hotstuff: Bft consensus with linearity and responsiveness. In *Proceedings of the 2019 ACM Symposium on Principles of Distributed Computing*, PODC '19, page 347\u2013356, New York, NY, USA, 2019. Association for Computing Machinery.",
+      "authors": [
+        "Yin, Maofan",
+        "Malkhi, Dahlia",
+        "Reiter, Michael K.",
+        "Golan Gueta, Guy",
+        "Abraham, Ittai"
+      ],
+      "title": "Hotstuff: Bft consensus with linearity and responsiveness",
+      "year": "2019",
+      "venue": "Proceedings of the 2019 ACM Symposium on Principles of Distributed Computing",
+      "volume": "PODC '19",
+      "pages": "347\u2013356",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "YMR+19"
+    },
+    {
+      "key": "[69]",
+      "raw_text": "- <span id=\"page-20-0\"></span>[69] Jiangshan Yu, Vincent Cheval, and Mark Ryan. DTKI: A New Formalized PKI with Verifiable Trusted Parties. *The Computer Journal*, 59(11):1695\u20131713, 2016.",
+      "authors": [
+        "Yu, Jiangshan",
+        "Cheval, Vincent",
+        "Ryan, Mark"
+      ],
+      "title": "DTKI: A New Formalized PKI with Verifiable Trusted Parties",
+      "year": "2016",
+      "venue": "The Computer Journal",
+      "volume": "59(11)",
+      "pages": "1695\u20131713",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "YCR16"
+    },
+    {
+      "key": "[70]",
+      "raw_text": "- <span id=\"page-20-2\"></span>[70] Lidong Zhou, Fred B. Schneider, and Robbert Van Renesse. Coca: A secure distributed online certification authority. *ACM Trans. Comput. Syst.*, 20(4):329\u2013368, nov 2002.",
+      "authors": [
+        "Zhou, Lidong",
+        "Schneider, Fred B.",
+        "Van Renesse, Robbert"
+      ],
+      "title": "Coca: A secure distributed online certification authority",
+      "year": "2002",
+      "venue": "ACM Trans. Comput. Syst.",
+      "volume": "20(4)",
+      "pages": "329\u2013368",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "ZSVR02"
+    }
+  ]
 }

--- a/data/markdown/eprint/2021_818/bibliography_info.json
+++ b/data/markdown/eprint/2021_818/bibliography_info.json
@@ -1,13 +1,13 @@
 {
-  "provider": "claude-code",
-  "model": "sonnet",
-  "extracted_at": "2026-03-29T17:26:59.815520+00:00",
-  "elapsed_seconds": 1200.36,
+  "provider": "ollama",
+  "model": "deepseek-r1:8b",
+  "extracted_at": "2026-04-03T07:03:59.321392+00:00",
+  "elapsed_seconds": 421.3,
   "source_markdown": "2021_818.md",
   "markdown_sha256": "3bea9a1371f65ed0e4f6badd2ba71c38d59518460896587b1720d75d9de6703b",
   "prompt_version": "v2",
-  "reference_count": 0,
-  "input_tokens": 0,
-  "output_tokens": 0,
+  "reference_count": 69,
+  "input_tokens": 14779,
+  "output_tokens": 7951,
   "estimated_cost_usd": 0.0
 }


### PR DESCRIPTION
Extracted structured bibliography for `2021/818`.

69 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit ff943b7)
Website: https://papyrus.badaas.eu