### PR TITLE
Add bibliography.json for 2021/870

### DIFF
--- a/data/markdown/eprint/2021_870/bibliography_info.json
+++ b/data/markdown/eprint/2021_870/bibliography_info.json
@@ -1,13 +1,13 @@
 {
-  "provider": "claude-code",
-  "model": "sonnet",
-  "extracted_at": "2026-03-29T17:47:07.131087+00:00",
-  "elapsed_seconds": 1200.34,
+  "provider": "ollama",
+  "model": "qwen2.5-coder:7b",
+  "extracted_at": "2026-04-03T07:16:28.344966+00:00",
+  "elapsed_seconds": 11.9,
   "source_markdown": "2021_870.md",
   "markdown_sha256": "c97f3686dfa22870f7655c822e1d054bab1e3e676aa505a4b8df0058be525050",
   "prompt_version": "v2",
   "reference_count": 0,
-  "input_tokens": 0,
-  "output_tokens": 0,
+  "input_tokens": 4096,
+  "output_tokens": 19,
   "estimated_cost_usd": 0.0
 }


### PR DESCRIPTION
Extracted structured bibliography for `2021/870`.

0 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 32acf7b)
Website: https://papyrus.badaas.eu