### PR TITLE
Add bibliography.json for 2021/934

### DIFF
--- a/data/markdown/eprint/2021_934/bibliography.json
+++ b/data/markdown/eprint/2021_934/bibliography.json
@@ -1,4 +1,1274 @@
 {
   "paper_id": "2021_934",
-  "references": []
+  "references": [
+    {
+      "key": "AC20",
+      "raw_text": "",
+      "authors": [
+        "Attema, T.",
+        "Cramer, R."
+      ],
+      "title": "Compressed \\Sigma -protocol theory and practical application to plug & play secure algorithmics",
+      "year": "2020",
+      "venue": "CRYPTO 2020, Part III",
+      "volume": "12172",
+      "pages": "513\u2013543",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2020/753"
+      ],
+      "eprint_id": "2020/753",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "AC20"
+    },
+    {
+      "key": "ACF20",
+      "raw_text": "",
+      "authors": [
+        "Attema, T.",
+        "Cramer, R.",
+        "Fehr, S."
+      ],
+      "title": "Compressing proofs of k-out-of-n partial knowledge",
+      "year": "2020",
+      "venue": "Cryptology ePrint Archive, Report 2020/753",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2020/753"
+      ],
+      "eprint_id": "2020/753",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "ACF20"
+    },
+    {
+      "key": "ACK21",
+      "raw_text": "",
+      "authors": [
+        "Attema, T.",
+        "Cramer, R.",
+        "Kohl, L."
+      ],
+      "title": "A compressed \\Sigma -protocol theory for lattices",
+      "year": "2021",
+      "venue": "Cryptology ePrint Archive, Report 2021/307",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2021/307"
+      ],
+      "eprint_id": "2021/307",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "ACK21"
+    },
+    {
+      "key": "ACR20",
+      "raw_text": "",
+      "authors": [
+        "Attema, T.",
+        "Cramer, R.",
+        "Rambaud, M."
+      ],
+      "title": "Compressed \\Sigma -protocols for bilinear group arithmetic circuits and applications",
+      "year": "2020",
+      "venue": "Cryptology ePrint Archive, Report 2020/1447",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2020/1447"
+      ],
+      "eprint_id": "2020/1447",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "ACR20"
+    },
+    {
+      "key": "AGM18",
+      "raw_text": "",
+      "authors": [
+        "Agrawal, S.",
+        "Ganesh, C.",
+        "Mohassel, P."
+      ],
+      "title": "Non-interactive zero-knowledge proofs for composite statements",
+      "year": "2018",
+      "venue": "CRYPTO 2018, Part III",
+      "volume": "10993",
+      "pages": "643\u2013673",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "AGM18"
+    },
+    {
+      "key": "BBB+18",
+      "raw_text": "",
+      "authors": [
+        "B\u00fcnz, B.",
+        "Bootle, J.",
+        "Boneh, D.",
+        "Poelstra, A.",
+        "Wuille, P.",
+        "Maxwell, G."
+      ],
+      "title": "Bulletproofs: Short proofs for confidential transactions and more",
+      "year": "2018",
+      "venue": "2018 IEEE Symposium on Security and Privacy",
+      "volume": "",
+      "pages": "315\u2013334",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BBB+18"
+    },
+    {
+      "key": "BCF+21",
+      "raw_text": "",
+      "authors": [
+        "Benarroch, D.",
+        "Campanelli, M.",
+        "Fiore, D.",
+        "Kim, J.",
+        "Lee, J.",
+        "Oh, H.",
+        "Querol, A."
+      ],
+      "title": "Proposal: Commitand-prove zero-knowledge proof systems and extensions",
+      "year": "2021",
+      "venue": "4th ZKProof Workshop",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://docs.zkproof.org/pages/standards/accepted-workshop4/proposal-commit.pdf"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "BCF+21"
+    },
+    {
+      "key": "BCG+13",
+      "raw_text": "",
+      "authors": [
+        "Ben-Sasson, E.",
+        "Chiesa, A.",
+        "Genkin, D.",
+        "Tromer, E.",
+        "Virza, M."
+      ],
+      "title": "SNARKs for C: Verifying program executions succinctly and in zero knowledge",
+      "year": "2013",
+      "venue": "CRYPTO 2013, Part II",
+      "volume": "8043",
+      "pages": "90\u2013108",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BSCG+13"
+    },
+    {
+      "key": "BCG+14",
+      "raw_text": "",
+      "authors": [
+        "Ben-Sasson, E.",
+        "Chiesa, A.",
+        "Garman, C.",
+        "Green, M.",
+        "Miers, I.",
+        "Tromer, E.",
+        "Virza, M."
+      ],
+      "title": "Zerocash: Decentralized anonymous payments from bitcoin",
+      "year": "2014",
+      "venue": "2014 IEEE Symposium on Security and Privacy",
+      "volume": "",
+      "pages": "459\u2013474",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BSCG+14"
+    },
+    {
+      "key": "BCI+13",
+      "raw_text": "",
+      "authors": [
+        "Bitansky, N.",
+        "Chiesa, A.",
+        "Ishai, Y.",
+        "Ostrovsky, R.",
+        "Paneth, O."
+      ],
+      "title": "Succinct non-interactive arguments via linear interactive proofs",
+      "year": "2013",
+      "venue": "TCC 2013",
+      "volume": "7785",
+      "pages": "315\u2013333",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BCI+13"
+    },
+    {
+      "key": "BCR+19",
+      "raw_text": "",
+      "authors": [
+        "Ben-Sasson, E.",
+        "Chiesa, A.",
+        "Riabzev, M.",
+        "Spooner, N.",
+        "Virza, M.",
+        "Ward, N. P."
+      ],
+      "title": "Aurora: Transparent succinct arguments for R1CS",
+      "year": "2019",
+      "venue": "EUROCRYPT 2019, Part I",
+      "volume": "11476",
+      "pages": "103\u2013128",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2019/555",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BSCR+19"
+    },
+    {
+      "key": "BCTV14",
+      "raw_text": "",
+      "authors": [
+        "Ben-Sasson, E.",
+        "Chiesa, A.",
+        "Tromer, E.",
+        "Virza, M."
+      ],
+      "title": "Succinct non-interactive zero knowledge for a von neumann architecture",
+      "year": "2014",
+      "venue": "USENIX Security 2014",
+      "volume": "",
+      "pages": "781\u2013796",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BSCTV14"
+    },
+    {
+      "key": "BDFG20",
+      "raw_text": "",
+      "authors": [
+        "Boneh, D.",
+        "Drake, J.",
+        "Fisch, B.",
+        "Gabizon, A."
+      ],
+      "title": "Efficient polynomial commitment schemes for multiple points and polynomials",
+      "year": "2020",
+      "venue": "Cryptology ePrint Archive, Report 2020/081",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2020/081"
+      ],
+      "eprint_id": "2020/081",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "BDFG20"
+    },
+    {
+      "key": "BFS20",
+      "raw_text": "",
+      "authors": [
+        "B\u00fcnz, B.",
+        "Fisch, B.",
+        "Szepieniec, A."
+      ],
+      "title": "Transparent SNARKs from DARK compilers",
+      "year": "2020",
+      "venue": "EURO-CRYPT 2020, Part I",
+      "volume": "12105",
+      "pages": "677\u2013706",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BFS20"
+    },
+    {
+      "key": "BGM17",
+      "raw_text": "",
+      "authors": [
+        "Bowe, S.",
+        "Gabizon, A.",
+        "Miers, I."
+      ],
+      "title": "Scalable multi-party computation for zk-SNARK parameters in the random beacon model",
+      "year": "2017",
+      "venue": "Cryptology ePrint Archive, Report 2017/1050",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2017/1050"
+      ],
+      "eprint_id": "2017/1050",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "BGM17"
+    },
+    {
+      "key": "BHH+19",
+      "raw_text": "",
+      "authors": [
+        "Backes, M.",
+        "Hanzlik, L.",
+        "Herzberg, A.",
+        "Kate, A.",
+        "Pryvalov, I."
+      ],
+      "title": "Efficient non-interactive zero-knowledge proofs in cross-domains without trusted setup",
+      "year": "2019",
+      "venue": "PKC 2019, Part I",
+      "volume": "11442",
+      "pages": "286\u2013313",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "BHH+19"
+    },
+    {
+      "key": "CDG+17",
+      "raw_text": "",
+      "authors": [
+        "Chase, M.",
+        "Derler, D.",
+        "Goldfeder, S.",
+        "Orlandi, C.",
+        "Ramacher, S.",
+        "Rechberger, C.",
+        "Slamanig, D.",
+        "Zaverucha, G."
+      ],
+      "title": "Post-quantum zero-knowledge and signatures from symmetric-key primitives",
+      "year": "2017",
+      "venue": "ACM CCS 2017",
+      "volume": "",
+      "pages": "1825\u20131842",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CDG+17"
+    },
+    {
+      "key": "CDS94",
+      "raw_text": "",
+      "authors": [
+        "Cramer, R.",
+        "Damg\u00e5rd, I.",
+        "Schoenmakers, B."
+      ],
+      "title": "Proofs of partial knowledge and simplified design of witness hiding protocols",
+      "year": "1994",
+      "venue": "CRYPTO'94",
+      "volume": "839",
+      "pages": "174\u2013187",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CDS94"
+    },
+    {
+      "key": "CFF+20",
+      "raw_text": "",
+      "authors": [
+        "Campanelli, M.",
+        "Faonio, A.",
+        "Fiore, D.",
+        "Querol, A.",
+        "Rodr\u00edguez, H."
+      ],
+      "title": "Lunar: a toolbox for more efficient universal and updatable zksnarks and commit-and-prove extensions",
+      "year": "2020",
+      "venue": "Cryptology ePrint Archive, Report 2020/1069",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2020/1069"
+      ],
+      "eprint_id": "2020/1069",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "techreport",
+      "alpha_key": "CFF+20"
+    },
+    {
+      "key": "CFH+15",
+      "raw_text": "",
+      "authors": [
+        "Costello, C.",
+        "Fournet, C.",
+        "Howell, J.",
+        "Kohlweiss, M.",
+        "Kreuter, B.",
+        "Naehrig, M.",
+        "Parno, B.",
+        "Zahur, S."
+      ],
+      "title": "Geppetto: Versatile verifiable computation",
+      "year": "2015",
+      "venue": "2015 IEEE Symposium on Security and Privacy",
+      "volume": "",
+      "pages": "253\u2013270",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CFH+15"
+    },
+    {
+      "key": "CFQ19",
+      "raw_text": "",
+      "authors": [
+        "Campanelli, M.",
+        "Fiore, D.",
+        "Querol, A."
+      ],
+      "title": "LegoSNARK: Modular design and composition of succinct zero-knowledge proofs",
+      "year": "2019",
+      "venue": "ACM CCS 2019",
+      "volume": "",
+      "pages": "2075\u20132092",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "2021/327",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CFQ19"
+    },
+    {
+      "key": "CGM16",
+      "raw_text": "",
+      "authors": [
+        "Chase, M.",
+        "Ganesh, C.",
+        "Mohassel, P."
+      ],
+      "title": "Efficient zero-knowledge proof of algebraic and non-algebraic statements with applications to privacy preserving credentials",
+      "year": "2016",
+      "venue": "CRYPTO 2016, Part III",
+      "volume": "9816",
+      "pages": "499\u2013530",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CGM16"
+    },
+    {
+      "key": "CHA21",
+      "raw_text": "",
+      "authors": [
+        "Campanelli, M.",
+        "Hall-Andersen, M."
+      ],
+      "title": "Veksel: Simple, efficient, anonymous payments with large anonymity sets from well-studied assumptions",
+      "year": "2021",
+      "venue": "Cryptology ePrint Archive, Report 2020/1069",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2021/327"
+      ],
+      "eprint_id": "2021/327",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "CHA21"
+    },
+    {
+      "key": "CHM+20",
+      "raw_text": "",
+      "authors": [
+        "Chiesa, A.",
+        "Hu, Y.",
+        "Maller, M.",
+        "Mishra, P.",
+        "Vesely, N.",
+        "Ward, N. P."
+      ],
+      "title": "Marlin: Preprocessing zkSNARKs with universal and updatable SRS",
+      "year": "2020",
+      "venue": "EUROCRYPT 2020, Part I",
+      "volume": "12105",
+      "pages": "738\u2013768",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CHM+20"
+    },
+    {
+      "key": "CS97",
+      "raw_text": "",
+      "authors": [
+        "Camenisch, J.",
+        "Stadler, M."
+      ],
+      "title": "Efficient group signature schemes for large groups (extended abstract)",
+      "year": "1997",
+      "venue": "CRYPTO'97",
+      "volume": "1294",
+      "pages": "410\u2013424",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "CS97"
+    },
+    {
+      "key": "DFKP16",
+      "raw_text": "",
+      "authors": [
+        "Delignat-Lavaud, A.",
+        "Fournet, C.",
+        "Kohlweiss, M.",
+        "Parno, B."
+      ],
+      "title": "Cinderella: Turning shabby X.509 certificates into elegant anonymous credentials with the magic of verifiable computation",
+      "year": "2016",
+      "venue": "2016 IEEE Symposium on Security and Privacy",
+      "volume": "",
+      "pages": "235\u2013254",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "DLFKP16"
+    },
+    {
+      "key": "DGK+21",
+      "raw_text": "",
+      "authors": [
+        "Damg\u00e5rd, I.",
+        "Ganesh, C.",
+        "Khoshakhlagh, H.",
+        "Orlandi, C.",
+        "Siniscalchi, L."
+      ],
+      "title": "Balancing privacy and accountability in blockchain identity management",
+      "year": "2021",
+      "venue": "CT-RSA 2021",
+      "volume": "12704",
+      "pages": "552\u2013576",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "DGK+21"
+    },
+    {
+      "key": "FKL18",
+      "raw_text": "",
+      "authors": [
+        "Fuchsbauer, G.",
+        "Kiltz, E.",
+        "Loss, J."
+      ],
+      "title": "The algebraic group model and its applications",
+      "year": "2018",
+      "venue": "CRYPTO 2018, Part II",
+      "volume": "10992",
+      "pages": "33\u201362",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "FKL18"
+    },
+    {
+      "key": "FS87",
+      "raw_text": "",
+      "authors": [
+        "Fiat, A.",
+        "Shamir, A."
+      ],
+      "title": "How to prove yourself: Practical solutions to identification and signature problems",
+      "year": "1987",
+      "venue": "CRYPTO'86",
+      "volume": "263",
+      "pages": "186\u2013194",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "FS87"
+    },
+    {
+      "key": "GGPR13",
+      "raw_text": "",
+      "authors": [
+        "Gennaro, R.",
+        "Gentry, C.",
+        "Parno, B.",
+        "Raykova, M."
+      ],
+      "title": "Quadratic span programs and succinct NIZKs without PCPs",
+      "year": "2013",
+      "venue": "EUROCRYPT 2013",
+      "volume": "7881",
+      "pages": "626\u2013645",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GGPR13"
+    },
+    {
+      "key": "GKM+18",
+      "raw_text": "",
+      "authors": [
+        "Groth, J.",
+        "Kohlweiss, M.",
+        "Maller, M.",
+        "Meiklejohn, S.",
+        "Miers, I."
+      ],
+      "title": "Updatable and universal common reference strings with applications to zk-SNARKs",
+      "year": "2018",
+      "venue": "CRYPTO 2018, Part III",
+      "volume": "10993",
+      "pages": "698\u2013728",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "18/544",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GKM+18"
+    },
+    {
+      "key": "GMO16",
+      "raw_text": "",
+      "authors": [
+        "Giacomelli, I.",
+        "Madsen, J.",
+        "Orlandi, C."
+      ],
+      "title": "ZKBoo: Faster zero-knowledge for Boolean circuits",
+      "year": "2016",
+      "venue": "USENIX Security 2016",
+      "volume": "",
+      "pages": "1069\u20131083",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GMO16"
+    },
+    {
+      "key": "GMR85",
+      "raw_text": "",
+      "authors": [
+        "Goldwasser, S.",
+        "Micali, S.",
+        "Rackoff, C."
+      ],
+      "title": "The knowledge complexity of interactive proof-systems (extended abstract)",
+      "year": "1985",
+      "venue": "17th ACM STOC",
+      "volume": "",
+      "pages": "291\u2013304",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GMR85"
+    },
+    {
+      "key": "GQ88",
+      "raw_text": "",
+      "authors": [
+        "Guillou, L. C.",
+        "Quisquater, J.-J."
+      ],
+      "title": "A practical zero-knowledge protocol fitted to security microprocessor minimizing both trasmission and memory",
+      "year": "1988",
+      "venue": "EUROCRYPT'88",
+      "volume": "330",
+      "pages": "123\u2013128",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "GQ88"
+    },
+    {
+      "key": "Gro10",
+      "raw_text": "",
+      "authors": [
+        "Groth, J."
+      ],
+      "title": "Short pairing-based non-interactive zero-knowledge arguments",
+      "year": "2010",
+      "venue": "ASIACRYPT 2010",
+      "volume": "6477",
+      "pages": "321\u2013340",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Gro10"
+    },
+    {
+      "key": "Gro16",
+      "raw_text": "",
+      "authors": [
+        "Groth, J."
+      ],
+      "title": "On the size of pairing-based non-interactive arguments",
+      "year": "2016",
+      "venue": "EUROCRYPT 2016, Part II",
+      "volume": "9666",
+      "pages": "305\u2013326",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Gro16"
+    },
+    {
+      "key": "GWC19",
+      "raw_text": "",
+      "authors": [
+        "Gabizon, A.",
+        "Williamson, Z. J.",
+        "Ciobotaru, O."
+      ],
+      "title": "Plonk: Permutations over lagrange-bases for oecumenical noninteractive arguments of knowledge",
+      "year": "2019",
+      "venue": "Cryptology ePrint Archive, Report 2019/953",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2019/953"
+      ],
+      "eprint_id": "19/953",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "GWC19"
+    },
+    {
+      "key": "IKO07",
+      "raw_text": "",
+      "authors": [
+        "Ishai, Y.",
+        "Kushilevitz, E.",
+        "Ostrovsky, R."
+      ],
+      "title": "Efficient arguments without short pcps",
+      "year": "2007",
+      "venue": "Twenty-Second Annual IEEE Conference on Computational Complexity (CCC'07)",
+      "volume": "",
+      "pages": "278\u2013291",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "IKO07"
+    },
+    {
+      "key": "JKO13",
+      "raw_text": "",
+      "authors": [
+        "Jawurek, M.",
+        "Kerschbaum, F.",
+        "Orlandi, C."
+      ],
+      "title": "Zero-knowledge using garbled circuits: how to prove non-algebraic statements efficiently",
+      "year": "2013",
+      "venue": "ACM CCS 2013",
+      "volume": "",
+      "pages": "955\u2013966",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "JKO13"
+    },
+    {
+      "key": "jub17",
+      "raw_text": "",
+      "authors": [],
+      "title": "What is Jubjub?",
+      "year": "2017",
+      "venue": "z.cash/technology/jubjub",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://z.cash/technology/jubjub"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "[Online; accessed 14-September-2021]",
+      "entry_type": "misc",
+      "alpha_key": ""
+    },
+    {
+      "key": "KPV19",
+      "raw_text": "",
+      "authors": [
+        "A. Kattis",
+        "K. Panarin",
+        "A. Vlasov"
+      ],
+      "title": "Redshift: Transparent snarks from list polynomial commitment iops",
+      "year": "2019",
+      "venue": "Cryptology ePrint Archive, Report 2019/1400",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2019/1400"
+      ],
+      "eprint_id": "2019/1400",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "KPV19"
+    },
+    {
+      "key": "KZG10",
+      "raw_text": "",
+      "authors": [
+        "A. Kate",
+        "G. M. Zaverucha",
+        "I. Goldberg"
+      ],
+      "title": "Constant-size commitments to polynomials and their applications",
+      "year": "2010",
+      "venue": "ASIACRYPT 2010, vol. 6477 of LNCS, pp. 177\u2013194",
+      "volume": "6477",
+      "pages": "177\u2013194",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "KZG10"
+    },
+    {
+      "key": "KZM+15",
+      "raw_text": "",
+      "authors": [
+        "A. Kosba",
+        "Z. Zhao",
+        "A. Miller",
+        "Y. Qian",
+        "H. Chan",
+        "C. Papamanthou",
+        "R. Pass",
+        "a. shelat",
+        "E. Shi"
+      ],
+      "title": "How to use SNARKs in universally composable protocols",
+      "year": "2015",
+      "venue": "Cryptology ePrint Archive, Report 2015/1093",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2015/1093"
+      ],
+      "eprint_id": "2015/1093",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "KZM+15"
+    },
+    {
+      "key": "LCKO19",
+      "raw_text": "",
+      "authors": [
+        "J. Lee",
+        "J. Choi",
+        "J. Kim",
+        "H. Oh"
+      ],
+      "title": "Saver: Snark-friendly, additively-homomorphic, and verifiable encryption and decryption with rerandomization",
+      "year": "2019",
+      "venue": "Cryptology ePrint Archive, Report 2019/1270",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://eprint.iacr.org/2019/1270"
+      ],
+      "eprint_id": "2019/1270",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "article",
+      "alpha_key": "LCKO19"
+    },
+    {
+      "key": "Lip12",
+      "raw_text": "",
+      "authors": [
+        "H. Lipmaa"
+      ],
+      "title": "Progression-free sets and sublinear pairing-based non-interactive zero-knowledge arguments",
+      "year": "2012",
+      "venue": "TCC 2012, vol. 7194 of LNCS, pp. 169\u2013189",
+      "volume": "7194",
+      "pages": "169\u2013189",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Lip12"
+    },
+    {
+      "key": "Lip13",
+      "raw_text": "",
+      "authors": [
+        "H. Lipmaa"
+      ],
+      "title": "Succinct non-interactive zero knowledge arguments from span programs and linear errorcorrecting codes",
+      "year": "2013",
+      "venue": "ASIACRYPT 2013, Part I, vol. 8269 of LNCS, pp. 41\u201360",
+      "volume": "8269",
+      "pages": "41\u201360",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Lip13"
+    },
+    {
+      "key": "Lip16",
+      "raw_text": "",
+      "authors": [
+        "H. Lipmaa"
+      ],
+      "title": "Prover-efficient commit-and-prove zero-knowledge SNARKs",
+      "year": "2016",
+      "venue": "AFRICACRYPT 16, vol. 9646 of LNCS, pp. 185\u2013206",
+      "volume": "9646",
+      "pages": "185\u2013206",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Lip16"
+    },
+    {
+      "key": "Max15",
+      "raw_text": "",
+      "authors": [
+        "G. Maxwell"
+      ],
+      "title": "Confidential transactions",
+      "year": "2015",
+      "venue": "URL: https://people.xiph.org/greg/confidential values.txt",
+      "volume": "",
+      "pages": "",
+      "doi": "",
+      "urls": [
+        "https://people.xiph.org/greg/confidential values.txt"
+      ],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "misc",
+      "alpha_key": "Max15"
+    },
+    {
+      "key": "MBKM19",
+      "raw_text": "",
+      "authors": [
+        "M. Maller",
+        "S. Bowe",
+        "M. Kohlweiss",
+        "S. Meiklejohn"
+      ],
+      "title": "Sonic: Zero-knowledge SNARKs from linear-size universal and updatable structured reference strings",
+      "year": "2019",
+      "venue": "ACM CCS 2019, pp. 2111\u20132128",
+      "volume": "",
+      "pages": "2111\u20132128",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "MBKM19"
+    },
+    {
+      "key": "Ped92",
+      "raw_text": "",
+      "authors": [
+        "T. P. Pedersen"
+      ],
+      "title": "Non-interactive and information-theoretic secure verifiable secret sharing",
+      "year": "1992",
+      "venue": "CRYPTO'91, vol. 576 of LNCS, pp. 129\u2013140",
+      "volume": "576",
+      "pages": "129\u2013140",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Ped92"
+    },
+    {
+      "key": "PHGR13",
+      "raw_text": "",
+      "authors": [
+        "Parno, B.",
+        "Howell, J.",
+        "Gentry, C.",
+        "Raykova, M."
+      ],
+      "title": "Pinocchio: Nearly practical verifiable computation",
+      "year": "2013",
+      "venue": "IEEE Symposium on Security and Privacy",
+      "volume": "",
+      "pages": "238\u2013252",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "PHGR13"
+    },
+    {
+      "key": "Sch90",
+      "raw_text": "",
+      "authors": [
+        "Schnorr, C.-P."
+      ],
+      "title": "Efficient identification and signatures for smart cards",
+      "year": "1990",
+      "venue": "CRYPTO'89",
+      "volume": "435",
+      "pages": "239\u2013252",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Sch90"
+    },
+    {
+      "key": "Set20",
+      "raw_text": "",
+      "authors": [
+        "Setty, S."
+      ],
+      "title": "Spartan: Efficient and general-purpose zkSNARKs without trusted setup",
+      "year": "2020",
+      "venue": "CRYPTO 2020, Part III",
+      "volume": "12172",
+      "pages": "704\u2013737",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "Set20"
+    },
+    {
+      "key": "WTs+18",
+      "raw_text": "",
+      "authors": [
+        "Wahby, R. S.",
+        "Tzialla, I.",
+        "Shelat, a.",
+        "Thaler, J.",
+        "Walfish, M."
+      ],
+      "title": "Doubly-efficient zkSNARKs without trusted setup",
+      "year": "2018",
+      "venue": "IEEE Symposium on Security and Privacy",
+      "volume": "",
+      "pages": "926\u2013943",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "WTS+18"
+    },
+    {
+      "key": "WZC+18",
+      "raw_text": "",
+      "authors": [
+        "Wu, H.",
+        "Zheng, W.",
+        "Chiesa, A.",
+        "Popa, R. A.",
+        "Stoica, I."
+      ],
+      "title": "DIZK: A distributed zero knowledge proof system",
+      "year": "2018",
+      "venue": "USENIX Security 2018",
+      "volume": "",
+      "pages": "675\u2013692",
+      "doi": "",
+      "urls": [],
+      "eprint_id": "",
+      "arxiv_id": "",
+      "isbn": "",
+      "note": "",
+      "entry_type": "inproceedings",
+      "alpha_key": "WZC+18"
+    }
+  ]
 }

--- a/data/markdown/eprint/2021_934/bibliography_info.json
+++ b/data/markdown/eprint/2021_934/bibliography_info.json
@@ -1,13 +1,13 @@
 {
-  "provider": "claude-code",
-  "model": "sonnet",
-  "extracted_at": "2026-03-29T18:07:15.042930+00:00",
-  "elapsed_seconds": 1200.33,
+  "provider": "ollama",
+  "model": "qwen2.5-coder:7b",
+  "extracted_at": "2026-04-03T07:25:45.174243+00:00",
+  "elapsed_seconds": 289.06,
   "source_markdown": "2021_934.md",
   "markdown_sha256": "5996ac6e23c8ad7e5d1d378600e562af300fcfbc89ff26b336a1d7dbcbbd9cf0",
   "prompt_version": "v2",
-  "reference_count": 0,
-  "input_tokens": 0,
-  "output_tokens": 0,
+  "reference_count": 55,
+  "input_tokens": 6235,
+  "output_tokens": 8897,
   "estimated_cost_usd": 0.0
 }


### PR DESCRIPTION
Extracted structured bibliography for `2021/934`.

55 references parsed into `bibliography.json` (authors, title, year, venue, DOI, URLs, eprint/arXiv IDs).

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit a39080a)
Website: https://papyrus.badaas.eu