### PR TITLE
Add markdown for 2020/1428

### DIFF
--- a/data/markdown/eprint/2020_1428/2020_1428.md
+++ b/data/markdown/eprint/2020_1428/2020_1428.md
@@ -1,0 +1,929 @@
+
+
+{0}------------------------------------------------
+
+# <span id="page-0-0"></span>On Statistical Security in Two-Party Computation
+
+Dakshita Khurana<sup>∗</sup> Muhammad Haris Mughees†
+
+November 14, 2020
+
+#### **Abstract**
+
+There has been a large body of work characterizing the round complexity of general-purpose maliciously secure two-party computation (2PC) against probabilistic polynomial time adversaries. This is particularly true for zero-knowledge, which is a special case of 2PC. In fact, in the special case of zero knowledge, optimal protocols with unconditional security against one of the two players have also been meticulously studied and constructed.
+
+On the other hand, general-purpose maliciously secure 2PC with *statistical* or unconditional security against one of the two participants has remained largely unexplored so far. In this work, we initiate the study of such protocols, which we refer to as 2PC with one-sided statistical security. We settle the round complexity of 2PC with one-sided statistical security with respect to black-box simulation by obtaining the following tight results:
+
+- In a setting where only one party obtains an output, we design 2PC in 4 rounds with statistical security against receivers and computational security against senders.
+- In a setting where both parties obtain outputs, we design 2PC in 5 rounds with computational security against the party that obtains output first and statistical security against the party that obtains output last.
+
+Katz and Ostrovsky (CRYPTO 2004) showed that 2PC with black-box simulation requires at least 4 rounds when one party obtains an output and 5 rounds when both parties obtain outputs, even when only computational security is desired against both parties. Thus in these settings, not only are our results tight, but they also show that statistical security is achievable at no extra cost to round complexity. This still leaves open the question of whether 2PC can be achieved with black-box simulation in 4 rounds with statistical security against senders and computational security against receivers. Based on a lower bound on computational zero-knowledge proofs due to Katz (TCC 2008), we observe that the answer is negative unless the polynomial hierarchy collapses.
+
+# **1 Introduction**
+
+Secure two-party computation allows two mutually distrustful participants to compute jointly on their private data without revealing anything beyond the output of their computation. Protocols that securely compute general functionalities have been constructed under a variety of assumptions, and with a variety of efficiency guarantees.
+
+A fundamental question in the study of secure computation is *round complexity*. This question has been researched extensively, and even more so for the special case of zero-knowledge.
+
+**Zero-Knowledge.** Computational zero-knowledge arguments with negligible soundness error can be achieved in 4 messages [\[FS90\]](#page-25-0), under the minimal assumption that one-way functions exist [\[BJY97\]](#page-24-0). This is tight: for languages outside BPP, with black-box simulation and without any trusted setup, zero-knowledge arguments require at least four messages [\[GK96\]](#page-25-1).
+
+<sup>∗</sup>University of Illinois Urbana-Champaign, USA. Email: dakshita@illinois.edu
+
+<sup>†</sup>University of Illinois Urbana-Champaign, USA. Email: mughees2@illinois.edu
+
+{1}------------------------------------------------
+
+<span id="page-1-1"></span>For zero-knowledge with black-box simulation, different flavors have been studied depending on the level of soundness and zero knowledge achieved. Either property can be statistical or computational, meaning that it holds against unbounded or computationally bounded adversaries, respectively. Protocols that satisfy both properties statistically, known as statistical zero knowledge proofs, are only known for languages in AM ∩ coAM [\[For87,](#page-25-2) [AH91\]](#page-24-1); however, once either property is relaxed to be computational, protocols for all of NP can be constructed assuming the existence of one way functions [\[GMW91,](#page-25-3) [Nao91,](#page-26-0) [BCC88,](#page-24-2) [NOVY98,](#page-26-1) [HNO](#page-25-4)<sup>+</sup>09]. Specifically,
+
+- *Statistical Zero-knowledge Arguments for* NP, where soundness is computational and zero-knowledge is statistical, are known to be achievable in 4 rounds with black-box simulation, assuming the existence of collision resistant hash functions [\[BJY97\]](#page-24-0).
+- *Computational Zero-knowledge Proofs for* NP, that satisfy statistical soundness and computational zeroknowledge, are known to be achievable in 5 rounds with black-box simulation, assuming the existence of collision resistant hash functions [\[GK96\]](#page-25-1).
+
+Protocols that satisfy *statistical security*, either against a malicious prover or a malicious verifier, are more secure and therefore can be more desirable than protocols that are only computationally secure on both sides. For instance, statistical zero-knowledge arguments provide an unconditional privacy guarantee – even a verifier that runs an arbitrary amount of post-processing on the proof transcript, does not obtain any information that cannot be simulated efficiently.
+
+**Secure Computation of General Functionalities.** While tight results for zero-knowledge with black-box simulation with statistical security against one party are known, the state of affairs is significantly lacking in the case of two-party secure computation of general functionalities. Specifically, in the two-party setting, it is natural to ask whether statistical or unconditional security can be achieved, against at least one of the parties.
+
+In a setting where both parties are computationally bounded, Katz and Ostrovsky [\[KO04\]](#page-26-2) showed how to securely compute general functionalities with black-box simulation, with only 4 messages of interaction, when one party receives the output, and 5 messages when both parties receive the output. They also demonstrate that this result is tight with respect to black-box simulation. There has been significant progress in the last few years, extending the results of Katz and Ostrovsky to obtain better round optimal secure protocols both in [\[ORS15,](#page-27-0) [COSV17b\]](#page-25-5) and beyond the two-party setting [\[GMPP16,](#page-25-6) [ACJ17,](#page-24-3) [BHP17,](#page-24-4) [COSV17a,](#page-25-7) [BGJ](#page-24-5)+18, [CCG](#page-25-8)+19].
+
+Despite all this progress, there are significant gaps in our understanding of the round complexity of 2PC with one-sided statistical security, i.e. statistical security against one of the participants. While there are known techniques to achieve weaker notions such as super-polynomial simulation with statistical security [\[OPP14,](#page-27-1) [CO17,](#page-25-9) [KKS18\]](#page-26-3), the (standard) setting of polynomial simulation is not well understood at all.
+
+## **1.1 Our Results**
+
+In this paper, we settle the round complexity of two-party secure computation with black-box simulation and one-sided statistical security. This is the best possible security that can be achieved by any non-trivial two-party protocol in the plain model.
+
+We now describe our results in some detail. First, we consider a setting where only one party receives the output of the computation. Without loss of generality, we call the party that receives the output, the receiver R, and the other party the sender S. We obtain a tight characterization with respect to black-box simulation, as follows.
+
+<span id="page-1-0"></span>**Informal Theorem 1.** *Assuming polynomial hardness of either DDH or QR or LWE, there exists a* 4 *round twoparty secure computation protocol for general functionalities with black-box simulation, with statistical security against an adversarial receiver and computational security against an adversarial sender.*
+
+Next, we recall a result due to Katz [\[Kat08a\]](#page-26-4) who proved that 4 round computational zero-knowledge proofs for NP with black-box simulation cannot exist unless the polynomial hierarchy collapses. This helps 
+
+{2}------------------------------------------------
+
+rule out the existence of a 4 round two-party protocol for secure computation of general functionalities with black-box simulation, with statistical security against an adversarial sender and computational security against an adversarial receiver, unless the polynomial hierarchy collapses. A formal proof of this statement appears in Appendix [A.](#page-27-2) We also match this lower bound with the following result.
+
+<span id="page-2-0"></span>**Informal Theorem 2.** *Assuming polynomial hardness of either DDH or QR or LWE, there exists a* 5 *round twoparty secure computation protocol for general functionalities with black-box simulation, with statistical security against an adversarial sender and computational security against an adversarial receiver.*
+
+We formalize and prove Informal Theorem [1](#page-1-0) and Informal Theorem [2](#page-2-0) by demonstrating a *single* 5 round protocol for symmetric functionalities (i.e. functionalities that generate identical output for both parties), where the receiver R obtains the output at the end of the 4 th round, and the sender S obtains the output at the end of the 5 th round. This protocol is unconditionally secure against malicious receivers, and computationally secure against malicious senders. Such a protocol can be unconditionally compiled, in a round-preserving way, to work for asymmetric functionalities using the following folklore technique: each participant additionally inputs a uniformly random key to the functionality, and the symmetric functionality masks each participant's output with their respective key.
+
+We prove that our protocol provides statistical security against a malicious receiver R and computational security against a malicious sender S. We observe that Informal Theorem [1](#page-1-0) follows from this protocol by simply eliminating the last message from the receiver R to the sender S. Informal Theorem [2](#page-2-0) also follows from this protocol *by simply renaming the players: that is, we will now call the party* S *in our original protocol,* R*; and we will call* R*,* S. The resulting protocol, after renaming parties, is statistically secure against a malicious sender S and computationally secure against a malicious receiver R. Because both parties obtain the output by the end of the 5 th round, the (re-named) receiver R is guaranteed to obtain the output at the end of round 5.
+
+Together, these results characterize the round complexity of secure two-party computation with blackbox simulation and statistical security against one participant. Along the way, we develop a toolkit for establishing statistical security that may be useful in other settings.
+
+In the rest of this paper, in protocols where a single party gets the output – we will call the party that obtains an output the receiver, and the other party the sender. In protocols both parties get the output, we call the party that obtains its output first, the receiver and the party that obtains output second, the sender.
+
+# **2 Our Techniques**
+
+We now provide an informal overview of our techniques. Our starting point is the simple case of security against semi-honest adversaries, with statistical security against one party and computational security against the other. A simple way to obtain round-optimal secure computation for general functionalities, in the semi-honest setting, is to rely on Yao's garbling technique. Here one party, referred to as the garbler, computes a garbled circuit and labels for the evaluation of a circuit. The garbler sends the resulting circuit to the other party, the evaluator, and both parties rely on 2-choose-1 oblivious transfer (OT) to transfer the "right" labels corresponding to the input of the evaluator. The evaluator then executes a public algorithm on the garbled circuit and labels to recover the output of the circuit.
+
+**Limitations in the Semi-Honest Setting.** Even in the semi-honest setting, garbled circuits that provide security against unbounded evaluators are only known for circuits in NC1. In fact, whether constant round two-party *semi-honest* protocols secure against unbounded senders and unbounded receivers exist, even in the OT hybrid model, is an important unresolved open problem in information-theoretic cryptography. In the absence of such protocols, the best security we can hope to achieve even in the semi-honest setting, is when at least one party is computationally bounded. As a result, in the malicious setting also, the best we can hope for is security against unbounded senders and bounded receivers, or unbounded receivers and bounded senders.
+
+As discussed in the previous section, we construct a *single* 5 round protocol for symmetric functionalities (i.e. functionalities that generate identical output for both parties), where the receiver R obtains the output 
+
+{3}------------------------------------------------
+
+<span id="page-3-1"></span>at the end of the  $4^{th}$  round, and the sender S obtains the output at the end of the  $5^{th}$  round<sup>1</sup>. We prove that this protocol provides statistical security against an unbounded malicious receiver R\* and security against a computationally bounded malicious sender S\*. For simplicity, we discuss the first 4 rounds of this protocol in more detail: specifically, we discuss a 4 round protocol where R obtains the output (and S does not), that we prove is secure against an unbounded malicious R\* and computationally bounded malicious S\*.
+
+R must generate the garbled circuit, and S must evaluate it. Garbled circuits form an important component of our protocol. Because garbled circuits for functions outside of NC1 are insecure against unbounded evaluators, when looking at all efficiently computable functions (which is the focus of this work), our defacto strategy will be to have a malicious evaluator that is computationally bounded (i.e. PPT) whereas a malicious garbler may be computationally unbounded.
+
+Because we desire statistical security against R\*, the receiver R must be the entity that generates the garbled circuit, and S will evaluate this circuit on labels obtained via a 2-choose-1 oblivious transfer (OT) protocol. Recall that we also require the receiver R to obtain the output by the end of round 4. Since S is the one evaluating the garbled circuit, this enforces that the garbled circuit must be evaluated by the sender by the end of round 3. In other words, R must output the garbled circuit and transfer labels to the sender by round 3.
+
+This requires that labels for the garbled circuit be transferred from R to S via a 3 round OT protocol, in which R is the OT sender and S is the OT receiver. Naturally, this oblivious transfer protocol is also required to be statistically secure against malicious R\* (who is the OT sender) and computationally secure against malicious S\* (who is the OT receiver). Unfortunately, no OT protocols achieving malicious security are known in 3 rounds (in fact, the existence of such protocols with black-box simulation would contradict the lower bound of [KO04]). The fact that the OT must also be statistically secure against malicious senders complicates matters further. This brings us to our first technical barrier: *identifying and using weaker forms of OT to obtain full-fledged malicious security*.
+
+Three Round Oblivious Transfer. Here, it is appropriate to discuss known notions of oblivious transfer that are achievable in three rounds and provide some semblance of malicious security. A popular notion has been game-based security: roughly, this requires that the receiver choice bit be hidden from a malicious sender, and one of the sender messages remain hidden from the receiver. A further strengthening of this notion is security with superpolynomial simulation, commonly called SPS-security. Very roughly, this requires the existence of a *superpolynomial* simulator that simulates the view of a malicious sender/receiver only given access to the ideal functionality. There are known constructions of SPS-secure OT: in 2 rounds, SPS-secure OT was first constructed by  $[BGI^+17]$  based on two-round game-based OT, which can itself be realized based on a variety of assumptions, including DDH, LWE, QR, and  $N^{th}$ -residuosity [NP01, AIR01, Kal05, HK12, BD18].
+
+Recall that we also desire *statistical security* against an adversarial sender. Achieving this property requires at least three rounds [KKS18], and [KKS18] obtained 3 round OT with SPS security based on superpolynomial hardness of DDH, LWE, QR, and *N*<sup>th</sup>-residuosity. Even more recently, [JJGM20] improved this result to rely only on polynomial hardness of any of the same assumptions. In fact, [JJGM20] achieve a notion in between SPS-security and standard security against malicious receivers: their protocol obtains distinguisher-dependent security [DNRS99, JKKR17] against malicious receivers. This relaxes the standard notion of malicious security by reversing the order of quantifiers, namely, by allowing the simulator to depend upon the distinguisher that is attempting to distinguish the real and ideal experiments. Importantly, unlike standard security, a distinguisher-dependent OT simulator is *not* guaranteed to efficiently extract the adversary's actual input, unless it has access to the distinguisher. On the other hand, we would like to achieve *full-fledged* malicious security in our 2PC protocol. This means that our 2PC simulator must nevertheless find a way to extract the adversary's input and cannot rely on the OT simulator for this purpose. Looking ahead, we will only rely on the OT protocol to obtain an indistinguishability-based guarantee, and our 2PC simulator will not use the OT simulator at all. Next, we describe additional components that we add to this protocol to enable full-fledged malicious security.
+
+<span id="page-3-0"></span><sup>&</sup>lt;sup>1</sup>We note that this is without loss of generality, since any asymmetric functionality can be unconditionally computed from a symmetric one by having each party input a random value, and using it to mask the output.
+
+{4}------------------------------------------------
+
+<span id="page-4-1"></span>**Immediate Pitfalls of the Current Template.** Now as discussed previously, garbled circuits and an appropriate OT protocol do *not* by themselves guarantee meaningful security against malicious adversaries. A malicious garbler could generate the garbled circuit or labels so as to completely alter the output of an honest evaluator. As such, the sender must be convinced that the garbled circuit and labels that she obtained from the receiver were generated "correctly", before she evaluates the garbled circuit. In other words, R should convince S, *within three rounds*, that the garbled circuit and oblivious transfer messages were correctly generated, so that it is "safe" for the sender to evaluate the garbled circuit.
+
+A na¨ıve approach would entail the use of a *computational* zero-knowledge *proof*, where R proves to S that the garbled circuit, labels and OT messages sent by R were correctly generated. Unfortunately, *computational* zero-knowledge *proofs* are not known to exist in less than 4 rounds of interaction from standard assumptions, even assuming non-black-box simulation. This brings us to our second technical barrier.
+
+We overcome this barrier with the help of a special conditional disclosure of secrets (CDS) protocol, that we will detail towards the end of this overview. This CDS protocol will help us compile protocols that are secure against adversaries that "promise to behave well" (that we will denote as *explainable adversaries* in line with [\[BKP19\]](#page-24-9)) into protocols secure against arbitrarily malicious adversaries, while retaining one-sided statistical security. An "explainable" adversary generates messages in the support of the distribution of all honestly generated messages.[2](#page-4-0)
+
+In fact, we take a modular approach to building 2PC with one-sided statistical security against fully malicious adversaries: first, we obtain a protocol secure against explainable adversaries alone, and next, we compile this protocol to one that is secure against arbitrary malicious adversaries. For now, we focus our attention towards achieving simulation-based security against explainable adversaries alone, instead of arbitrary malicious ones. Later, we discuss our CDS-based approach to achieve security against arbitrary malicious adversaries.
+
+**Extracting inputs of Explainable Adversaries.** Recall that by definition of explainability, for every garbled circuit GC and OT message that an explainable R ∗ sends, there exists randomness r and input inp such that GC is generated as an output of the garbling algorithm for the circuit corresponding to the two-party function f, on input inp and with randomness r.
+
+As already discussed, proving security requires establishing the existence of a *simulator* that interacts with an ideal functionality and with the adversary to output a view that is indistinguishable from the adversary's view in its interaction with the honest party. Importantly, this simulator must *extract* the input of a malicious R <sup>∗</sup> or S ∗ , and cannot use the 3-round OT for this purpose.
+
+Therefore, to enable extraction from R ∗ , we modify the protocol to require the receiver to send a statistically binding extractable commitment (constructed, eg, in [\[PRS02\]](#page-27-3)) to its input, in parallel with the rest of the protocol. By definition, an *explainable* R ∗ is guaranteed to send an extractable commitment to the "right" input that is consistent with the garbled circuit, and a simulator Sim<sup>R</sup> ∗ will be able to extract R ∗ 's input from the extractable commitment. Such extractable commitments are known to exist in 3 rounds by the work of Prabhakaran et al [\[PRS02\]](#page-27-3).
+
+Similarly, in order to enable the extraction of S ∗ 's input, we will modify the protocol to require the sender to send an extractable commitment to its input, in parallel with the rest of the protocol. The simulator Sim<sup>S</sup> ∗ will be able to extract the sender's input from this extractable commitment. Since we require statistical security against R, the extractable commitment used by S should be statistically hiding. A simple modification to the extractable commitments of Prabhakaran et. al. [\[PRS02\]](#page-27-3), replacing statistically binding computationally hiding commitments with statistically hiding computationally binding commitments yields the required extractable commitment in 4 rounds. Unfortunately, this also means that Sim<sup>S</sup> ∗ can *only* send the input of S <sup>∗</sup> and obtain an output from the ideal functionality at the end of the 4 th round. However, S ∗ evaluates the garbled circuit and may obtain an output before round 4 even begins, which would allow S ∗ to distinguish the real and ideal executions. Said differently, this would leave Sim<sup>S</sup> ∗ with no opportunity to program the output of the ideal functionality in the view of S ∗ .
+
+<span id="page-4-0"></span><sup>2</sup> Importantly, this is *different* from semi-malicious security [\[LTV13,](#page-26-8) [MW16\]](#page-26-9) where the adversary in addition to generating messages in the support of the distribution of all honestly generated messages, outputs the input and randomness that it used, on a special tape. On the other hand, simulating an explainable adversary is much more challenging: since in this case the adversary does not output any such special tape, and therefore the input and randomness must still be extracted from an explainable adversary by the simulator.
+
+{5}------------------------------------------------
+
+To provide  $\mathsf{Sim}^{\mathsf{S}^*}$  with such an opportunity and overcome this technical barrier, we modify the protocol as follows: instead of garbling the circuit corresponding to the function f,  $\mathsf{R}$  samples the keys  $(\mathsf{pk},\mathsf{sk})$  for a public key encryption scheme, and garbles a circuit that computes  $(\mathsf{Enc}_{\mathsf{pk}} \circ f)$ . Here  $\mathsf{Enc}_{\mathsf{pk}}$  denotes the encryption algorithm of an IND-CPA secure encryption scheme, and the randomness used for encryption is hardwired by  $\mathsf{R}$  into the circuit. As a result,  $\mathsf{S}$  on evaluating the garbled circuit, obtains a ciphertext that *encrypts* the output of the function under  $\mathsf{R}'\mathsf{s}$  public jey. It must then forward this ciphertext to  $\mathsf{R}$ , who uses the corresponding secret key to decrypt the ciphertext and recover the output of the function<sup>3</sup>. This concludes the bare-bones description of our 5-round protocol with security against explainable adversaries.
+
+In addition to proving that this protocol is secure against explainable PPT adversaries, we also establish an additional property, that will come in handy later. We prove that the protocol is *robust* in the first two rounds: meaning that even an adversary that behaves arbitrarily maliciously (and not necessarily explainably) in the first two rounds can only influence the function output, but not obtain any information about the private input of the other participant.
+
+**Simulating Explainable Adversaries.** This completes a simplified overview of our protocol with security against explainable adversaries. But there are several subtleties that arise when formalizing the proof of security. We describe our simulators and discuss a few of these subtleties below.
+
+First, we discuss how to build a simulator Sim<sup>S\*</sup> that simulates the view of a malicious sender S\*. Recall that Sim<sup>S\*</sup> must extract the input of a malicious S\*, query the ideal functionality, and program the resulting output in the view of S\*. The use of statistically hiding extractable commitments allows Sim<sup>S\*</sup> to extract S\*'s input by the end of the fourth round. Therefore, Sim<sup>S\*</sup> only obtains an output from the ideal functionality by the end of the fourth round. But Sim<sup>S\*</sup> must send to S\* a garbled circuit in the third round, on behalf of R, *even before* learning the output. How should Sim<sup>S\*</sup> construct this circuit? Sim<sup>S\*</sup> cannot even invoke the simulator of the garbled circuit because it has not extracted S\*'s input at this time. Instead, we have the simulator simply garble a circuit that outputs an encryption of the all zeroes string. Finally, the simulator extracts the input of S\* from the fourth round message, and queries the ideal functionality to obtain an output. In the fifth round, it sends this output S\* in the clear.
+
+Recall that S\* can behave arbitrarily maliciously while generating its OT message, and only provides a proof of correct behaviour in round 4. Therefore, we must use a careful argument to ensure that the result appears indistinguishable to S\*. The indistinguishability argument heavily relies on *the distinguisher-dependent simulation* property of the OT protocol. In particular, we build a careful sequence of hybrids where we extract S\*'s (who is the OT receiver) input to the OT protocol in a distinguisher-dependent manner, and use the extracted input to replace the actual garbled circuit with a simulated one. Next, we change the output of the garbled circuit from an encryption of the right output to an encryption of the all zeroes string, and finally we replace the simulated garbled circuit with a real circuit that always outputs an encryption of the all zeroes string. All intermediate hybrids in this sequence are distinguisher-dependent. A similar argument also helps prove *robustness* of our protocol against S\* that behaves maliciously in the second round.
+
+Next, we discuss how we simulate the view of an unbounded malicious R\*. The simulator Sim<sup>R\*</sup> uses the third round extractable commitment to obtain the input of R\*, queries the ideal functionality to obtain an output, and in the fourth round message, sends an encryption under the receiver's public key pk of this output. Here, we carefully prove that for any explainable receiver R\*, the simulated message (encrypting the output generated by the ideal functionality) is indistinguishable from the message generated by an honest sender.
+
+This concludes an overview of how we achieve a protocol with security against explainable adversaries. Next, we discuss techniques to compile any explainable protocol with robustness in the first two rounds, into one that is secure against malicious adversaries. We also discuss a few additional subtleties that come up in this setting.
+
+**Security against Malicious Senders via Statistical ZK Arguments.** In order to achieve security against arbitrary malicious S\*, the protocol is further modified to require R and S to execute a *statistical zero-knowledge* 
+
+<span id="page-5-0"></span> $<sup>^3</sup>$ Alternatively, R could withhold the garbled circuit decoding information, i.e. the correspondence between the output wire labels and the output of the circuit, from S until the  $5^{th}$  round. This would achieve the same effect, but leads to a more complex analysis. For simplicity of analysis, we choose to garble an encrypted circuit in our formal presentation.
+
+{6}------------------------------------------------
+
+<span id="page-6-1"></span>argument, where S proves to R that S generated its OT messages correctly, and perform the garbled circuit evaluation correctly to obtain the result that it output to R. Because of a technical condition in the proof, we actually require the SZK argument to be an argument of knowledge. Such arguments of knowledge with delayed-input completeness and soundness, and requiring exactly 4 rounds can be obtained by instantiating the FLS paradigm with statistically hiding extractable commitments. These are executed in parallel with our 4 round explainable protocol described above. With these arguments in place, at the end of the fourth round R will decrypt the ciphertext to recover the output only if the verification algorithm applied to the zero-knowledge argument accepts. Otherwise R rejects. This helps argue security against malicious S\*, but we point out one subtlety: the SZK argument can only be verified at the end of round 4, an unwitting receiver could send its round 3 message in response to an arbitrarily maliciously generated round 2 sender message. This is where we invoke the additional robustness property discussed earlier. Next, we discuss the somewhat more complex case of malicious receivers.
+
+Security against Malicious Receivers via Statistical Conditional Disclosure of Secrets. So far, an arbitrary malicious R\* could recover additional information about the sender's input based on the output of evaluation of incorrectly garbled circuits. Ideally, we would like to ensure that R\* can obtain the sender's fourth round message if and only if R\* generated its first and third round messages in an "explainable" manner.
+
+As discussed at the beginning of this overview, using zero-knowledge proofs to enable this requires too many rounds: therefore, our next idea is to rely on a two-round conditional disclosure of secrets (CDS) protocol. This will allow R\* to recover the message sent by S if and only if R\* inputs a witness attesting to the fact that its first and third messages were explainable. Notably, the witness input by R\* is hidden from S. Furthermore, when no such witness exists (i.e. when R\* does not generate explainable messages), the CDS protocol computationally hides the message of S <sup>4</sup>. Clearly, such a protocol can be used to ensure that R\* recovers the output of evaluation of the garbled circuit iff it behaved in an explainable fashion, and otherwise obtains no information.
+
+However, because we desire statistical security against R\*, we need the CDS protocol to provide *statistical* security against R\*. Fortunately, a CDS protocol with statistical security can be obtained for the class of relations that are verifiable by NC1 circuits, by combining two round game-based OT (eg, Naor-Pinkas [NP01]) with information-theoretic garbled circuits for NC1. Specifically, the receiver generates OT receiver messages corresponding to each of the bits in his witness, and the sender garbles a circuit that outputs the original sender message if and only if the receiver's input is a valid witness. We also note that there exists a generic transform that allows verifying (given the randomness and inputs of R\*) that R\* behaved in an explainable way – in logarithmic depth, or by an NC1 circuit.
+
+Next, we rely on robustness of the underlying protocol to argue security against a receiver that may have behave arbitrarily maliciously in the first round of the protocol. Finally, to ensure that the receiver sends the correct output to the sender in the fifth round, we require the receiver to send a zero-knowledge proof asserting that it computed this final message explainably. This proof can be obtained in 5 rounds [GK96], and is executed in parallel with the rest of the protocol.
+
+Another hurdle, and its Resolution. While CDS helps keep round complexity low, it leads to another technical barrier when simulating the view of a malicious sender. Specifically, the malicious simulator obtains messages from the underlying simulator of the robust explainable protocol. Because it obtains these messages externally, there is no way for the malicious simulator to recover the sender's next message encoded within the CDS protocol. At the same time, simulator needs to necessarily recover this next message in order to generate the final message of the protocol. To get around this issue, we require the statistical ZK argument provided by the simulator to be an *argument of knowledge* (AoK). As a result, the malicious simulator is able to use the AoK property of the sender's SZK argument to extract a witness, and we carefully ensure that this witness helps the simulator reconstruct the next message of the sender, and proceed as before.
+
+**Concluding Remarks.** This completes an overview of our techniques. In summary, we obtain round optimal two-party computation with one-sided statistical security assuming the existence of public key encryption, collision resistant hash functions, and two round statistically sender-private OT. We also end
+
+<span id="page-6-0"></span><sup>&</sup>lt;sup>4</sup>Such protocols have been used previously in the literature, most recently in [BKP19].
+
+{7}------------------------------------------------
+
+<span id="page-7-0"></span>up requiring some of these primitives to allow for verification in NC1 because of the reasons discussed above, however, we note that natural instantiations of these primitives based on the hardness of DDH or QR or LWE already satisfy this additional constraint. This allows us to base our protocol on a range of assumptions including DDH, QR or LWE.
+
+We also note that we depart from existing work by using OT protocols with distinguisher-dependent simulation to achieve an end goal of standard simulation security in a general-purpose two-party computation protocol. We believe that this application to statistically secure 2PC represents a meaningful new application domain for distinguisher-dependent simulation. In addition, we rely on several other technical tools such as deferred evaluation of garbled circuits, and combining robust protocols with delayed-input proofs - that may be of independent interest.
+
+**Open Problems and Future Directions.** Our work obtains feasibility results for round optimal *two-party* secure computation with one-sided statistical security, which is the best possible security that one can hope to achieve in two-party protocols in the plain model. A natural question is whether statistical security can be obtained against at least one of the participants in more general multi-party settings. It is also interesting to understand the minimal assumptions required to obtain 2PC with one-sided statistical security, in a round optimal manner, following similar investigations on assumptions versus round complexity in ZK with onesided statistical security, perhaps via highly optimized cut-and-choose techniques. Another interesting question is whether it is possible to achieve one-sided statistically secure protocols that make black-box use of cryptography. Finally, it is also interesting to understand whether 4 rounds are *necessary* to obtain specialized statistically secure protocols, such as statistical ZAPs, from polynomial hardness assumptions (in light of the fact that recent constructions of statistical ZAPs in less that 4 rounds [\[BFJ](#page-24-10)+20, [JJGM20,](#page-25-11) [LVW20\]](#page-26-10) rely on superpolynomial hardness assumptions).
+
+**Roadmap.** We refer the reader to Section [4](#page-12-0) for a detailed description of our protocol against explainable adversaries, and a proof of its security; and to Section [5](#page-18-0) for a description of our protocol against malicious adversaries, and a proof of its security. In Appendix [A,](#page-27-2) for completeness, we discuss the impossibility of two-party computation with statistical security against senders and computational security against receivers in four rounds, and with black-box simulation.
+
+# **3 Preliminaries**
+
+In the rest of this paper, we will denote the security parameter by k, and we will use negl(·) to denote any function that is aymtpotically smaller than the inverse of every polynomial.
+
+## **3.1 Secure Two-Party Computation**
+
+**Two Party Computation.** A two-party protocol Π is cast by specifying a process that maps pairs of inputs to pairs of outputs (one for each party). We refer to such a process as a *functionality* and denote it by F = f<sup>n</sup> : {0, 1} <sup>n</sup> × {0, 1} <sup>n</sup> → {0, 1} poly(n) × {0, 1} poly(n) . We restrict ourselves to symmetric functionalities, where for every pair of inputs (x, y), the output is a random variable f(x, y) ranging over pair of strings.
+
+**Secure Two Party Computation.** In this definition we assume an adversary that corrupts one of the parties. The parties are *sender* S and *receiver* R. Let A ∈ {S, R} denote a corrupted party and H ∈ {S, R}, H 6= A denote the honest party.
+
+- **Ideal Execution.** An ideal execution for the computation of functionality F proceeds as:
+  - **– Inputs:** S and R obtain inputs x ∈ X<sup>n</sup> and y ∈ Yn, respectively.
+  - **– Send inputs to trusted party:** H sends its input to F. Moreover, there exists a simulator Sim<sup>A</sup> that has black box access to A, that sends input on behalf of A to F.
+  - **– Trusted party output to simulator:** If x /∈ Xn, F sets x to some default input in Xn; likewise if y /∈ Yn, F sets y equal to some default input in Yn. Then the trusted party sends f(x, y) to Sim<sup>A</sup>.
+
+{8}------------------------------------------------
+
+<span id="page-8-4"></span>It waits for a special symbol from  $\mathsf{Sim}^{\mathcal{A}}$ , upon receiving which, it sends the output to  $\mathcal{H}$ . If it receives  $\bot$  from  $\mathsf{Sim}^{\mathcal{A}}$ , it outputs  $\bot$  to  $\mathcal{H}$ .
+
+**– Outputs:**  $\mathcal{H}$  outputs the value it obtained from  $\mathcal{F}$  and  $\mathcal{A}$  outputs its view. We denote the joint distribution of the output of  $\mathcal{H}$  and the view of  $\mathcal{A}$  by  $\mathsf{IDEAL}_{\mathcal{F},\mathsf{Sim},A}(x,y,n)$ .
+
+We let  $\mathsf{IDEAL}_{\mathcal{F},\mathsf{Sim},\mathcal{A}}(x,y,n)$  be the joint distribution of the view of the corrupted party and the output of the honest party following an execution in the ideal model as described above.
+
+• **Real Execution** In the real world, the two party protocol  $\Pi$  is executed between S and R. In this case,  $\mathcal{A}$  gets the inputs of the party it has corrupted and sends all the messages on behalf of this party, using an arbitrary polynomial-time strategy.  $\mathcal{H}$  follows the instructions in  $\Pi$ .
+
+Let  $\mathcal{F}$  be as above and let  $\pi$  be two-party protocol computing  $\mathcal{F}$ . Let  $\mathcal{A}$  be a non-uniform probabilistic poly-time machine with auxiliary input z. We let  $\mathsf{REAL}_{\Pi,\mathcal{A}}(x,y,n)$  denote the joint distribution the view of corrupted party and the output of the honest party, in the real execution of the protocol.
+
+<span id="page-8-0"></span>**Definition 1.** A protocol  $\Pi$  securely computes  $\mathcal{F}$  with computational security against a party if there exists a PPT simulator Sim such that for every non-uniform probabilistic polynomial time adversary  $\mathcal{A}$  corrupting the party,
+
+$$\mathsf{IDEAL}_{\mathcal{F},\mathsf{Sim},\mathcal{A}}(x,y,n) \approx_c \mathsf{REAL}_{\Pi,\mathcal{A}}(x,y,n)$$
+
+It securely computes  $\mathcal{F}$  with statistical security against a party if there exists a PPT simulator  $\mathsf{Sim}$  such that for every non-uniform probabilistic polynomial time adversary  $\mathcal{A}$  corrupting the party,
+
+$$\mathsf{IDEAL}_{\mathcal{F},\mathsf{Sim},\mathcal{A}}(x,y,n) \approx_s \mathsf{REAL}_{\Pi,\mathcal{A}}(x,y,n)$$
+
+**Definition 2** (Explainable transcript). Let  $\Pi_{S^*,R^*}$  be a protocol between an arbitrary sender  $S^*$  and arbitrary receiver  $R^*$ . We say that a transcript T of an execution  $\Pi$  between  $S^*$  and  $R^*$  is explainable for  $S^*$  if there exists an input i and coins r such that T is consistent with the transcript of an execution between  $S_{i,r}$  and  $R^*$ , until the point in T where  $S_{i,r}$  aborts. (Here  $S_{i,r}$  is the honest sender on input i using coins r). Similarly, we say that a transcript T of an execution  $\Pi$  between  $S^*$  and  $R^*$  is explainable for  $R^*$  if there exists an input i coins r such that T is consistent with the transcript of an execution between  $R_{i,r}$  and  $S^*$ , until the point in T that  $R_{i,r}$  aborts. (Here  $R_{i,r}$  is the honest receiver strategy using input i and coins r).
+
+<span id="page-8-1"></span>**Definition 3** (Explainable sender). Let  $\Pi_{S^*,R^*}$  be a protocol between an arbitrary sender  $S^*$  and arbitrary receiver  $R^*$ . A (possibly probabilistic) sender  $S^* = \{S_k^*\}_{k \in \mathbb{N}}$  is explainable if there exists a negligible  $\mu(\cdot)$  such that for any receiver  $R^* = \{R_k^*\}_{k \in \mathbb{N}}$ , and large enough  $k \in \mathbb{N}$ ,
+
+$$\Pr_{\mathsf{S}_k^*}[T \text{ is explainable } | T \leftarrow \Pi_{\mathsf{S}_k^*,\mathsf{R}_k^*}] \geq 1 - \mu(k).$$
+
+<span id="page-8-2"></span>**Definition 4** (Explainable receiver). Let  $\Pi_{S^*,R^*}$  be a protocol between an arbitrary sender  $S^*$  and arbitrary receiver  $R^*$ . A (possibly probabilistic) receiver  $R^* = \{R_k^*\}_{k \in \mathbb{N}}$  is explainable if there exists a negligible  $\mu(\cdot)$  such that for any sender  $S^* = \{S_k^*\}_{k \in \mathbb{N}}$ , and large enough  $k \in \mathbb{N}$ ,
+
+$$\Pr_{\mathsf{R}_k^*}[T \text{ is explainable } | T \leftarrow \Pi_{\mathsf{S}_k^*,\mathsf{R}_k^*}] \geq 1 - \mu(k).$$
+
+<span id="page-8-3"></span>**Definition 5** (Robust Explainable Secure Protocol). We will say that a protocol is secure against explainable adversaries, if Definition 1 holds against explainable adversaries. Furthermore, such a protocol is robust if for every (arbitrarily) malicious R\*, the real view of the adversary until round 2 is indistinguishable from the adversary until round 3 is indistinguishable from the adversary's simulated view until round 3.
+
+## 3.2 Yao's Garbled Circuits
+
+We will also rely on Yao's technique for garbling circuits [Yao86]. In the following, we define the notation that we will use, and the security properties of Yao's garbling scheme.
+
+{9}------------------------------------------------
+
+<span id="page-9-2"></span><span id="page-9-1"></span>**Definition 6.** Let  $p(\cdot)$  denote any fixed polynomial. We will consider a circuit family  $\mathbb{C}: \{0,1\}^k \to \{0,1\}^{p(k)}$ , that takes an input of size k bits and outputs p(k) bits. Yao's garbled circuits consist of the following algorithms:
+
+• GARBLE $(1^k, C; r)$  obtains as input a circuit  $C \in \mathbb{C}$  and randomness r, and outputs the garbled circuit  $G_C$  as well as a set of 2k keys corresponding to setting each of the k input bits to 0 and 1. We will denote this by:
+
+$$(G_{C}, \{ \mathsf{label}_{i,b} \}_{i \in [k], b \in \{0,1\}}) \leftarrow \mathsf{GARBLE}(1^{k}, C; r).$$
+
+•  $\mathsf{EVAL}(\mathsf{G}_\mathsf{C}, \{\mathsf{label}_{i,x_i}\}_{i\in[k]})$  obtains as input garbled circuit  $\mathsf{G}_\mathsf{C}$ , and a set of k keys. It generates an output z. We will denote this by
+
+$$z \leftarrow \mathsf{EVAL}(\mathsf{G}_\mathsf{C}, \{\mathsf{label}_{i,x_i}\}_{i \in [k]}).$$
+
+We require these algorithms to satisfy the following properties:
+
+• Correctness: For all  $C \in \mathbb{C}, x \in \{0, 1\}^k$ ,
+
+$$\Pr\left[C(x) = z \middle| ^{(\mathsf{G}_{\mathsf{C}}, \{\mathsf{label}_{i,b}\}_{i \in [k], b \in \{0,1\}}) \leftarrow \mathsf{GARBLE}(1^k, C; r)}_{z \leftarrow \mathsf{EVAL}(G_C, \{\mathsf{label}_{i,x_i}\}_{i \in [k]})}\right] = 1 - \mathsf{negl}(k)$$
+
+• **Security:** There exists a PPT simulator Sim such that for all non-uniform PPT  $\mathcal{D}$ , and all  $C \in \mathbb{C}, x \in \{0,1\}^k$ ,
+
+$$\Big|\Pr[\mathcal{D}(\mathsf{G}_\mathsf{C}, \{\mathsf{label}_{i,x_i}\}_{i \in [k]}) = 1] - \Pr[\mathcal{D}(\mathsf{Sim}(1^k, C(x))) = 1]\Big| = \mathsf{negl}(k)$$
+
+where
+
+$$(\mathsf{G}_\mathsf{C}, \{\mathsf{label}_{i,b}\}_{i \in [k], b \in \{0,1\}}) \leftarrow \mathsf{GARBLE}(1^k, C; r).$$
+
+#### 3.3 Extractable Commitments
+
+<span id="page-9-0"></span>**Definition 7** (Extractable Commitment). A statistically binding and computationally hiding three round commitment scheme is said to be extractable if there exists a PPT extractor Ext such that for any PPT committer C and every polynomial  $p(\cdot)$ , If
+
+$$\Pr_{\substack{\mathsf{c}_1 \leftarrow \mathsf{C}, \\ \mathsf{c}_2 \leftarrow \mathsf{R}(\mathsf{c}_1, 1^k), \\ \mathsf{c}_3 \leftarrow \mathsf{C}(\mathsf{c}_1, \mathsf{c}_2)}} \left[ \mathsf{R}(\mathsf{c}_1, \mathsf{c}_2, \mathsf{c}_3) \neq \bot \right] \geq \frac{1}{p(k)}$$
+
+then
+
+$$\Pr_{\substack{\mathsf{c}_1 \leftarrow \mathsf{C} \\ \mathsf{c}_2 \leftarrow \mathsf{R}(\mathsf{c}_1, \mathsf{c}_2) \\ \mathsf{c}_3 \leftarrow \mathsf{C}(\mathsf{c}_1, \mathsf{c}_2)}} \left[ \begin{array}{l} \mathsf{R}(\mathsf{c}_1, \mathsf{c}_2, \mathsf{c}_3) = 1 \land \\ d \leftarrow \mathsf{C}(\mathsf{c}_1, \mathsf{c}_2, \mathsf{c}_3) \land \\ s \leftarrow \mathsf{R}(\mathsf{c}_1, \mathsf{c}_2, \mathsf{c}_3, d) \land \\ s' \leftarrow \mathsf{Ext}^\mathsf{C}(1^k, 1^{p(k)}) \land \\ s' \neq s \land s \neq \bot \end{array} \right] \leq \mathsf{negl}(k)$$
+
+where R denotes the honest receiver algorithm, d denotes a decommitment string (obtained from  $C(c_1, c_2, c_3)$  at the start of the decommit phase), and R outputs s to be equal to the decommitted value if it accepts the decommitment, and  $\bot$  otherwise.
+
+Three-message computationally hiding extractable commitments can be constructed from non-interactive commitments [PRS02]. We will also consider statistically hiding extractable commitments, that satisfy the same extraction guarantee, except against computationally unbounded committers. These can be obtained in four rounds by substituting non-interactive commitments in the construction of [PRS02] with two round statistically hiding commitments.
+
+{10}------------------------------------------------
+
+## <span id="page-10-2"></span>3.4 Zero-Knowledge Proofs and Arguments for NP
+
+An n-round delayed-input interactive protocol  $\langle P, V \rangle$  for deciding a language L with associated relation  $R_L$  proceeds in the following manner:
+
+- At the beginning of the protocol, P and V receive the size of the instance and execute the first n-1 rounds.
+- At the start of the last round, P receives input  $(x, w) \in R_L$  and V receives x. Upon receiving the last round message from P, V outputs 0 or 1.
+
+We will rely on proofs and arguments for NP that satisfy delayed-input completeness, adaptive soundness and adaptive ZK.
+
+<span id="page-10-1"></span>**Definition 8** (Statistical Zero Knowledge Argument). Fix any language L. Let  $\langle P, V \rangle$  denote the execution of a protocol between a PPT prover P and a (possibly unbounded) verifier V, let  $V_{out}$  denote the output of the verifier and let  $V_{iew}(P, V)$  denote the transcript together with the state and randomness of a party  $A \in \{P, V\}$  at the end of an execution of a protocol. Then we say  $\langle P, V \rangle$  is zero knowledge proof system for L if the following properties hold:
+
+• Completeness: For all  $x \in L$ ,
+
+$$\Pr[\mathsf{V}_{\mathsf{out}}\langle\mathsf{P},\mathsf{V}\rangle=1]=1-\mathsf{negl}(k),$$
+
+where the probability is over the random coins of P and V.
+
+• Adaptive Soundness: For all polynomial size  $P^*$  and all  $x \notin L$  sampled by  $P^*$  adaptively depending upon the first n-1 rounds,
+
+$$\Pr[\mathsf{V}_\mathsf{out} \langle \mathsf{P}^*, \mathsf{V} \rangle = 1] = \mathsf{negl}(k)$$
+
+• **Statistical Zero Knowledge:** There exists a PPT simulator Sim such that for all  $V^*$  and all  $x \in L$ ,
+
+$$\Big|\Pr[\mathsf{V}^*(\mathsf{View}_{\mathsf{V}^*}\langle\mathsf{P}(x,w),\mathsf{V}^*\rangle)=1] - \Pr[\mathsf{V}^*(\mathsf{Sim}^{\mathsf{V}^*}(x))=1]\Big| = \mathsf{negl}(k)$$
+
+These can be obtained by a simple modification to delayed-input ZK arguments based on the Lapidot-Shamir [LS90] technique, by relying on a two round statistically hiding committent (that can itself be based on any collision-resistant hash functions), instead of a one-round statistically binding one.
+
+<span id="page-10-0"></span>**Definition 9** (Zero Knowledge Proof). Fix any language L. Let  $\langle P, V \rangle$  denote the execution of a protocol between a (possibly unbounded) prover P and a PPT verifier V, let  $V_{out}$  denote the output of the verifier and let  $V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out} \neq V_{out}$ 
+
+• Completeness: For all  $x \in L$ ,
+
+$$\Pr[\mathsf{V}_{\mathsf{out}}\langle\mathsf{P},\mathsf{V}\rangle=1]=1-\mathsf{negl}(k),$$
+
+where the probability is over the random coins of P and V.
+
+• Adaptive Soundness: For all P\* and all  $x \notin L$  sampled by P\* adaptively depending upon the first n-1 rounds,
+
+$$\Pr[\mathsf{V}_{\mathsf{out}}\langle\mathsf{P}^*,\mathsf{V}\rangle=1]=\mathsf{negl}(k)$$
+
+• Computational Zero Knowledge: There exists a PPT simulator Sim such that for all polynomial size  $V^*$  and all  $x \in L$ ,
+
+$$\Big|\Pr[\mathsf{V}^*(\mathsf{View}_{\mathsf{V}^*}\langle\mathsf{P}(x,w),\mathsf{V}^*\rangle)=1] - \Pr[\mathsf{V}^*(\mathsf{Sim}^{\mathsf{V}^*}(x))=1]\Big| = \mathsf{negl}(k)$$
+
+Such proofs were first constructed by [GK96], and can be made complete and sound when the instance is chosen by the prover in the last round of the interaction, by relying on the work of [LS90].
+
+**Imported Theorem 1.** [GK96, LS90] Assuming the existence of collision-resistant hash functions, there exist 5 round zero-knowledge proofs for all languages in NP, satisfying Definition 9.
+
+{11}------------------------------------------------
+
+#### <span id="page-11-2"></span>3.5 Oblivious Transfer (OT)
+
+Oblivious Transfer (OT) is a protocol between two parties, an (unbounded) sender S with messages  $(m_0, m_1)$  and a (PPT) receiver R with choice bit b, where R receives output  $m_b$  at the end of protocol. We let  $\langle S(m_0, m_1), R(b) \rangle$  denote execution of the OT protocol with sender input  $(m_0, m_1)$  and receiver input b. We will rely on a three round oblivious transfer protocol that satisfies perfect correctness and the following security guarantee:
+
+<span id="page-11-0"></span>**Definition 10** (Statistically Receiver-Private OT). We will say that an oblivious transfer protocol is statistically receiver private if it satisfies the following properties.
+
+• Statistical Receiver Security. For every unbounded  $S^*$  and all  $(b,b') \in \{0,1\}$ , the following distributions are statistically indistinguishable:
+
+$$\mathsf{View}_{S^*}\langle S^*, R(b) \rangle$$
+ and  $\mathsf{View}_{S^*}\langle S^*, R(b') \rangle$ 
+
+• Sender Security (Distinguisher-dependent Simulation Under Parallel Composition). For every polynomial n = n(k), for every efficiently sampleable distribution over messages  $\{\mathcal{M}_{0,i}, \mathcal{M}_{1,i}\}_{i \in [n]}$ , there exists a PPT simulator Sim such that for every non-uniform PPT receiver  $R^*$  and non-uniform PPT distinguisher  $\mathcal{D}$ ,
+
+$$|\Pr[\mathcal{D}(\mathsf{View}_{R^*}\langle S(\{m_{0,i},m_{1,i}\}_{i\in[n]}),R^*\rangle)=1]-$$
+
+$$\Pr[\mathcal{D}(\mathsf{Sim}^{R^*,\mathcal{D},\{\mathcal{F}_{\mathsf{OT},i}(m_{0,i},m_{1,i},\cdot)\}_{i\in[n]}})=1]|=\mathsf{negl}(k)$$
+
+where the probability is over the randomness of sampling  $\{(m_{0,i},m_{1,i})\}_{i\in[n]} \stackrel{\$}{\leftarrow} \{(\mathcal{M}_{0,i},\mathcal{M}_{1,i})\}_{i\in[n]}$ , the randomness of the sender and the simulator, and where  $\mathcal{F}_{\mathsf{OT}}$  is a single-query ideal OT functionality with  $\{(m_{0,i},m_{1,i})\}_{i\in[n]}$  hardwired, that on input  $\{b_i\}_{i\in[n]}$  outputs  $\{m_{b_i,i}\}_{i\in[n]}$  and then self-destructs.
+
+**Imported Theorem 2.** [JJGM20] Assuming the existence of any two-round statistical sender-private OT (resp., polynomial hardness of CDH), there exists a three-round statistically receiver-private OT protocol in the plain model satisfying Definition 10.
+
+Here, we note that two-round statistical sender-private OT can in turn be based on the polynomial hardness of DDH [NP01], QR and  $N^{th}$  residuosity [Kal05, HK12] and LWE [BD18]. We will represent the three messages of an OT protocol satisfying Definition 10 by  $\mathsf{OT}_{\mathsf{S},1}, \mathsf{OT}_{\mathsf{R}}(\cdot), \mathsf{OT}_{\mathsf{S},3}(\cdot)$ .
+
+#### 3.6 Conditional Disclosure of Secrets
+
+Conditional disclosure of secrets for an NP language  $\mathcal{L}$  [AIR01] can be viewed as a two-message analog of witness encryption [GGSW13]. That is, the sender holds an instance x and message m and the receiver holds x and a corresponding witness w. If the witness is valid, then the receiver obtains m, whereas if  $x \notin \mathcal{L}$ , m remains hidden. We further require that the protocol hides the witness w from the sender.
+
+<span id="page-11-1"></span>**Definition 11.** A conditional disclosure of secrets scheme (CDS.R, CDS.S, CDS.D) for a language  $\mathcal{L} \in \mathsf{NP}$  satisfies:
+
+1. Correctness: For any  $(x, w) \in R_{\mathcal{L}}$ , and message  $m \in \{0, 1\}^*$ ,
+
+$$\Pr\left[\mathsf{CDS.D}_K(c') = m \middle| \substack{(c,K) \leftarrow \mathsf{CDS.R}(x,w) \\ c' \leftarrow \mathsf{CDS.S}(x,m,c)} \right] = 1$$
+
+2. **Message indistinguishability:** For any  $x \in \{0,1\}^k \setminus \mathcal{L}$ ,  $c^*$ , and two equal-length messages  $m_0, m_1$ , the following distributions are statistically indistinguishable:
+
+CDS.S
+$$(x, m_0, c^*)$$
+ and CDS.S $(x, m_1, c^*)$ 
+
+3. **Receiver simulation:** There exists a simulator CDS.Sim such that for any polynomial-size distinguisher  $\mathcal{D}$ , there exists a negligible  $\mu$  such that for any  $x \in \mathcal{L}$ ,  $w \in R_{\mathcal{L}}(x)$  and large enough security parameter  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathcal{D}(\mathsf{CDS.R}(x,w)) = 1] - \Pr[\mathcal{D}(\mathsf{CDS.Sim}(x)) = 1]| = \mu(k)$$
+
+{12}------------------------------------------------
+
+<span id="page-12-1"></span>**Instantiations.** CDS schemes satisfying definition [11](#page-11-1) for relations that are verifiable in NC1 can be instantiated by combining information-theoretic Yao's garbled circuits for NC1 with any two-message oblivious transfer protocol where the receiver message is computationally hidden from any semi-honest sender, and with (unbounded) simulation security against malicious receivers. Such oblivious transfer schemes are known based on DDH [\[NP01\]](#page-26-5), Quadratic (or Nth) Residuosity [\[HK12\]](#page-25-10), and LWE [\[BD18\]](#page-24-8).
+
+# **3.7 Low-Depth Proofs**
+
+We will describe how any computation that is verifiable by a family of polynomial sized ciruits can be transformed into a proof that is verifiable by a family of circuits in NC1. Let R be an efficiently computable binary relation. For pairs (x, w) ∈ R we call x the statement and w the witness. Let L be the language consisting of statements in R.
+
+**Definition 12** (Low-Depth Non-Interactive Proofs)**.** *A low-depth non-interactive proof with perfect completeness and soundness for a relation* R *consists of an (efficient) prover* P *and a verifier V that satisfy:*
+
+• **Perfect completeness.** *A proof system is perfectly complete if an honest prover with a valid witness can always convince an honest verifier. For all* (x, w) ∈ R *we have*
+
+$$\Pr[V(\pi) = 1 | \pi \leftarrow P(x, w)] = 1$$
+
+• **Perfect soundness.** *A proof system is perfectly sound if it is infeasible to convince an honest verifier when the statement is false. For all* x 6∈ L *and all (even unbounded) adversaries* A *we have*
+
+$$Pr[V(x,\pi) = 1 | \pi \leftarrow \mathcal{A}(x)] = 0.$$
+
+• **Low Depth.** *The verifier* V *can be implemented in* NC1*.*
+
+We discuss a very simple construction of a low-depth non-interactive proof, that was outlined in [\[GGH](#page-25-14)+16]. The prover P executes the NP-verification circuit on the witness and generates the proof as the sequential concatenation (in some specified order) of the bit values assigned to the individual wires of the circuit. The verifier V proceeds by checking consistency of the values assigned to the internal wires of the circuit for each gate. In particular for each gate in the NP-verification circuit the verifier checks if the wire vales provided in the proof represent a correct evaluation of the gate. Since the verification corresponding to each gate can be done independent of every other gate and in constant depth, we have that V itself is constant depth.
+
+# <span id="page-12-0"></span>**4** 2PC **with One-sided Statistical Security against Explainable Parties**
+
+## **4.1 Construction**
+
+As a first step, in Figure [1,](#page-13-0) we describe a 5 round protocol with security against explainable adversaries (Definitions [3](#page-8-1) and [4\)](#page-8-2). In a nutshell, these adversaries are like malicious adversaries, but with an additional promise: explainable adversaries generate messages that are in the suport of honestly generated messages, except with negligible probability.
+
+Our protocol uses the following building blocks:
+
+- A 3 round statistically binding and computationally hiding commitment scheme satisfying extractability according to Definition [7,](#page-9-0) denoted by Ecom.
+- A 4 round statistically hiding and computationally binding commitment scheme satisfying extractability according to Definition [7,](#page-9-0) denoted by SHEcom.
+- A 3 round statistically receiver private oblivious transfer protocol satisfying Definition [10,](#page-11-0) denoted by OT.
+- Garbled circuits satisfying Definition [6,](#page-9-1) with algorithms denoted by Garble, Eval.
+
+{13}------------------------------------------------
+
+**Public Input:** Function f that players wish to compute on their private inputs. **Private Inputs:** The receiver R has private input A and sender S has private input B.
+
+#### Round 1: R does the following.
+
+- 1. Sample randomness  $r_c$ ,  $r_d$ ,  $r_{enc}$ ,  $\{r_{OT,i}\}_{i \in [k]} \stackrel{\$}{\leftarrow} \{0,1\}^*$ . Set  $(pk, sk) = \text{KeyGen}(1^k)$ .
+- 2. Set  $f' = \operatorname{Enc}_{pk}(f_A(\cdot); r_{enc})$  where  $f_A(\cdot)$  denotes f with input A hardwired.
+- 3. Garble f' to obtain a garbled circuit and labels  $(G, \{label_{i,b}\}_{i \in [k], b \in \{0,1\}} = Garble(1^k, f')$ . Compute OT sender messages for  $i \in [k]$  as  $o_{1,i} = \mathsf{OT}_{\mathsf{S},1}(label_{i,0}, label_{i,1}; \mathsf{r}_{\mathsf{OT},i})$ .
+- 4. Set  $c_1 = \mathsf{Ecom}_{\mathsf{S}}((\mathsf{A}||\mathsf{r}_{\mathsf{enc}});\mathsf{r}_{\mathsf{c}})$  to be the first (committer) message of a statistically binding extractable commitment to  $(A||\mathsf{r}_{\mathsf{enc}})$ . Additionally, set  $d_1 = \mathsf{SHEcom}_{\mathsf{R}}(\mathsf{r}_{\mathsf{d}})$  to be the first (receiver) message of a statistically hiding extractable commitment.
+- 5. Send  $(pk, \{o_{1,i}\}_{i \in k}, c_1, d_1)$  to S. Note that R does not send G yet.
+
+## Round 2: S does the following.
+
+- 1. Sample randomness  $\{\mathsf{r}'_{\mathsf{OT},i}\}_{i\in[k]},\mathsf{r}'_{\mathsf{c}},\mathsf{r}'_{\mathsf{d}} \stackrel{\$}{\leftarrow} \{0,1\}^*$ .
+- 2. Set  $c_2 = \mathsf{Ecom}_{\mathsf{R},c_1}(\mathsf{r}'_\mathsf{c})$  to be the second (receiver) message of the statistically binding extractable commitment, and  $d_2 = \mathsf{SHEcom}_{\mathsf{S},d_1}(\mathsf{B};\mathsf{r}'_\mathsf{d})$  to be the second (committer) message of the statistically hiding extractable commitment, committing to input B.
+- 3. Compute OT receiver messages for every  $i \in [k]$  as  $o_{2,i} = \mathsf{OT}_{\mathsf{R}}(o_{1,i},\mathsf{B}_i;\mathsf{r}'_{\mathsf{OT},i})$ .
+- 4. Send  $(c_2, d_2, \{o_{2,i}\}_{i \in [k]})$  to R.
+
+## Round 3: R does the following.
+
+- 1. Compute OT sender messages for  $i \in [k]$  as  $\{o_{3,i} = \mathsf{OT}_{\mathsf{S},3}(o_{2,i}, (\mathsf{label}_{i,0}, \mathsf{label}_{i,1}); \mathsf{r}_{\mathsf{OT},i})\}_{i \in [k]}$ .
+- 2. Set  $c_3 = \mathsf{Ecom}_{\mathsf{S},c_1,c_2}(\mathsf{A}||\mathsf{r}_{\mathsf{enc}};\mathsf{r}_{\mathsf{c}})$  to be the final (committer) message of the statistically binding extractable commitment and  $d_3 = \mathsf{SHEcom}_{\mathsf{R},d_1,d_2}(\mathsf{r}_{\mathsf{d}})$  to be the third (receiver) messages of the statistically hiding extractable commitment.
+- 3. Send  $(G, c_3, d_3, \{o_{3,i}\}_{i \in [k]})$  to S, where recall that G was computed in round 1.
+
+#### Round 4: S does the following.
+
+- 1. For  $i \in [k]$ , get  $\mathsf{lab}_i$  from  $o_{3,i}$ . Evaluate the garbled circuit to obtain  $z = \mathsf{Eval}(G, \{\mathsf{lab}_i\}_{i \in [k]})$ .
+- 2. Set  $d_4 = SHEcom_{S,d_1,d_2,d_3}(B; r'_d)$  to be the final message of the statistically hiding extractable commitment.
+- 3. Send  $(z, d_4)$  to R.
+
+**Round 5**: R outputs out =  $DEC_{sk}(z)$  and sends out to S.
+
+Output: S outputs out.
+
+<span id="page-13-0"></span>Figure 1: The protocol  $\Pi_{exp}\langle S, R \rangle$  secure against explainable adversaries.
+
+## 4.2 Analysis
+
+We demonstrate security of our protocol against explainable adversaries by proving the following theorem.
+
+<span id="page-13-2"></span>**Theorem 1.** Assuming 3 round computationally hiding and 4 round statistically hiding extractable commitments according to Definition 7, garbled circuits satisfying Definition 6 and three round oblivious transfer satisfying Definition 10, there exists a robust 5-round secure two-party computation protocol with black-box simulation against unbounded explainable receivers and PPT explainable senders, where the receiver obtains its output at the end of round 4 and the sender obtains its output at the end of the fifth round<sup>5</sup>.
+
+<span id="page-13-1"></span><sup>&</sup>lt;sup>5</sup>We point out that Informal Theorem 2 follows from this theorem by exchanging the roles of S and R.
+
+{14}------------------------------------------------
+
+<span id="page-14-2"></span>We observe that 3 round computationally hiding commitments can be based on any non-interactive commitment scheme [PRS02], which can itself be based on any public-key encryption [LS19], and 4 round statistically hiding extractable commitments can be based on collision-resistant hash functions. Garbled circuits can be obtained only assuming the existence of one-way functions [Yao86], and three round oblivious transfer satisfying Definition 10 can be based on any statistically sender-private 2 round OT. All of these primitives can be based on the hardness of the Decisional Diffie-Hellman assumption (DDH), or Quadratic Residuosity (QR), or the Learning with Errors assumption (LWE), and we therefore have the following corollary.
+
+**Corollary 2.** Assuming polynomial hardness of the Decisional Diffie-Hellman assumption (DDH), or Quadratic Residuosity (QR), or the Learning with Errors assumption (LWE), there exists a robust 5-round secure two-party computation protocol with black-box simulation against unbounded explainable receivers and PPT explainable senders, where the receiver obtains its output at the end of round 4 and the sender obtains its output at the end of round 5.
+
+Theorem 1 follows immediately from Lemma 1 that proves security against bounded explainable senders and Lemma 2 that proves security against unbounded explainable receivers.
+
+<span id="page-14-0"></span>**Lemma 1.** Assuming computational hiding of Ecom, extractability of SHEcom according to Definition 7, security of garbled circuits according to Definition 6, and sender security of OT according to Definition 10, the construction in Figure 1 satisfies robust simulation-based security against explainable PPT senders according to Definition 3.
+
+*Proof.* We prove that there exists a simulator Sim<sup>S\*</sup> that with black-box access to a computationally bounded explainable sender S\*, outputs a simulated view that is indistinguishable from the real view of S\*. Our simulator is described in Figure 2, with differences from the real protocol underlined.
+
+The simulator  $Sim^{S^*}$  interacts with  $S^*$ , sending the following messages on behalf of R. It uses as subroutine  $SHEcom_{Ext}$ , which denotes the extractor for SHEcom.
+
+# **Round 1**: Sim<sup>S\*</sup> does the following.
+
+- 1. Sample  $r_k, r_c, r_{enc}, \{r_{OT,i}\}_{i \in [k]} \stackrel{\$}{\leftarrow} \{0,1\}^*$ , set  $\underline{A = 0^k}$ . Set  $(pk, sk) = \text{KeyGen}(1^k; r_k)$ .
+- 2. Set  $f' = \mathsf{Enc}_{pk}(f_A(\cdot), \mathsf{r_k}), (G, \{\mathsf{label}_{i,b}\}_{i \in [k], b \in \{0,1\}}) = \mathsf{Garble}(1^k, f').$
+- 3. Set  $\{o_{1,i} = \mathsf{OT}_{\mathsf{S},1}(\mathsf{label}_{i,0},\mathsf{label}_{i,1};\mathsf{r}_{\mathsf{OT},i})\}_{i\in[k]},$  and
+- 4. Set  $c_1 = \mathsf{Ecom}_{\mathsf{S}}((\underline{\mathsf{A}}, 0^k); \mathsf{r_c})$ , and obtain  $d_1$  from  $\mathsf{SHEcom}_{\mathsf{Ext}}$ .
+- 5. Send  $(pk, \{o_{1,i}\}_{i \in [k]}, c_1, d_1)$  to  $S^*$ .
+
+# **Round 3**: Sim<sup>S\*</sup> does the following.
+
+- 1. Obtain input  $(c_2, d_2, \{o_{2,i}\}_{i \in [k]})$  from  $S^*$ . Send  $d_2$  to  $SHEcom_{Ext}$  and obtain  $d_3$ .
+- 2. Set  $\{o_{3,i} = \mathsf{OT}_{\mathsf{S},\mathsf{3}}(o_{2,i},(\mathsf{label}_{i,0},\mathsf{label}_{i,1});\mathsf{r}_{\mathsf{OT},i})\}_{i\in[k]}$  and  $c_3 = \mathsf{Ecom}_{\mathsf{S},c_1,c_2}(\mathsf{A};\mathsf{r}_\mathsf{c}).$
+- 3. Send  $(G, c_3, d_3, \{o_{3,i}\}_{i \in [k]})$  to  $S^*$ .
+
+# **Round 5**: Sim<sup>S\*</sup> does the following.
+
+- 1. Obtain input  $(z, d_4)$  from S\* and send  $d_4$  to SHEcom<sub>Ext</sub>.
+- 2. If  $SHEcom_{Ext}$  rewinds, the execution automatically goes back to round 3. Otherwise, obtain B' from  $SHEcom_{Ext}$ .
+- 3. Send B' to the ideal functionality  ${\mathcal F}$  and obtain output out. Send out to  $S^*$ .
+
+<span id="page-14-1"></span>Figure 2: Simulation strategy for an explainable adversarial sender S\*
+
+We now prove that the real and ideal worlds are indistinguishable. Towards a contradiction, assume that there exists a polynomial  $p(\cdot)$  and a distinguisher D that distinguishes the joint distribution of the view of S\* and the output of R in the real and ideal worlds, with probability  $\frac{1}{p(k)}$  for infinitely many  $k \in \mathbb{N}$ . We consider the following sequence of hybrids:
+
+{15}------------------------------------------------
+
+Hyb<sub>0</sub>: This hybrid represents an execution where the explainable sender  $S^*$  interacts with an honest R, that follows the strategy in Figure 1. The output of this hybrid is the view of the adversary in its interaction with honest R, together with the output of R.
+
+Hyb<sub>1</sub>: In this hybrid, the adversary interacts with a challenger that behaves identically to  $\mathsf{Hyb}_0$ , except that it generates  $(c_1, c_3)$  as messages for an extractable commitment to  $(0^k, 0^k)$ , instead of to  $(\mathsf{A}, \mathsf{r}_{\mathsf{enc}})$ . The output of this hybrid corresponds to the view of the adversary  $\mathsf{S}^*$  in it's interaction with the challenger, together with the output of  $\mathsf{R}$ .
+
+**Claim 1.** Assuming that Ecom is computationally hiding, for every PPT distinguisher D, there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_0) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_1) = 1]| = \mu(k)$$
+
+*Proof.* The proof of this claim follows directly based on the hiding property of Ecom. Specifically, if this claim is not true, then a reduction that obtains the messages of Ecom externally, generates remaining protocol messages according to  $Hyb_1$ , can use D to directly contradict the hiding of Ecom.
+
+ $\mathsf{Hyb}_2$ : In this hybrid, the adversary interacts with the challenger that behaves exactly as in  $\mathsf{Hyb}_1$ . Except, the challenger extracts B by using  $\mathsf{SHEcom}_{\mathsf{Ext}}$  at the end of round 4, queries the ideal functionality  $\mathcal{F}_{\mathsf{2PC}}$  with input B, and obtains output out from the ideal functionality. It then outputs out to  $\mathsf{S}^*$ . The hybrid outputs  $\bot$  if extraction fails.
+
+The output of this hybrid corresponds to the view of the adversary S\* in it's interaction with with the challenger, together with the output of R.
+
+**Claim 2.** Assuming that SHEcom is extractable according to Definition 7, denoting statistical distance by  $\Delta$ , there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ ,
+
+$$\Delta(\mathsf{Hyb}_1,\mathsf{Hyb}_2) = \mu(k)$$
+
+*Proof.* The only difference between these hybrids is that the challenger extracts the adversary's input via the extractor of SHEcom, and relays the extracted value to the ideal functionality. Because the adversary is explainable, these hybrids are identical whenever extraction succeeds. Furthermore, by the extractability property of SHEcom, extraction succeeds except with negligible probability.
+
+Hyb<sub>3,D</sub>: This is a distinguisher-dependent hybrid: the challenger runs the PPT distinguisher-dependent simulator Sim<sub>OT</sub> for the 3 round OT protocol, with error  $\frac{1}{4p(\cdot)}$ .
+
+Recall that  $\mathsf{Sim}_{\mathsf{OT}}$  requires oracle access to a receiver  $R^*_{\mathsf{OT}}$ , a distinguisher  $\mathcal{D}_{\mathsf{OT}}$  and an ideal functionality  $\{\mathcal{F}^i_{\mathsf{OT}}(\mathsf{label}_{i,0},\mathsf{label}_{i,1})\}_{i\in[k]}$ . The challenger constructs  $R^*_{\mathsf{OT}}$  as follows:
+
+- $R_{\mathsf{OT}}^*$  obtains  $\{o_{1,i}\}_{i\in[k]}$  externally. Next, it samples remaining round 1 messages  $(pk,c_1,d_1)$  exactly according to the strategy in  $\mathsf{Hyb}_1$  and sends them to  $\mathsf{S}^*$  on behalf of  $\mathsf{R}$ .
+- On receiving  $(c_2,d_2,\{o_{2,i}\}_{i\in[k]})$  from  $S^*$ ,  $R^*_{\mathsf{OT}}$  forwards  $\{o_{2,i}\}_{i\in[k]}$  as its own OT receiver message, and obtains  $\{o_{3,i}\}_{i\in[k]}$  externally. It samples remaining round 3 messages  $(c_3,d_3,G)$  exactly according to the strategy in  $\mathsf{Hyb}_1$  and sends  $(\{o_{3,i}\}_{i\in[k]},G,c_3,d_3)$  to  $S^*$  on behalf of  $\mathsf{R}$ .
+- On input  $(z, d_4)$  from  $S^*$ , it runs  $SHEcom_{Ext}$  to find B, obtain out from the ideal functionality, and outputs the final view V of  $S^*$ .
+
+The challenger constructs  $\mathcal{D}_{\mathsf{OT}}$  that on input view V, executes the hybrid distinguisher D on V and forwards its output externally. The output of this hybrid is the view V generated by  $R^*_{\mathsf{OT}}$  described above.
+
+**Claim 3.** Assuming that OT satisfies distinguisher-dependent simulation security against malicious receivers according to Definition 10, for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_1) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_{3,\mathsf{D}}) = 1]| \leq \frac{1}{4p(k)}$$
+
+{16}------------------------------------------------
+
+*Proof.* We note that when  $\{o_{1,i}, o_{3,i}\}_{i \in [k]}$  are generated according to honest strategy, the output of  $\mathcal{D}_{\mathsf{OT}}$  is identical to that of D on input distribution  $\mathsf{Hyb}_1$ . When  $\{o_{1,i}, o_{3,i}\}_{i \in [k]}$  are generated according to OT simulation strategy, the output of  $\mathcal{D}_{\mathsf{OT}}$  is identical to that of D on input distribution  $\mathsf{Hyb}_{3,\mathsf{D}}$ . Therefore, the claim follows by the definition of distinguisher-dependent simulation, with error parameter  $\frac{1}{4p(\cdot)}$ .
+
+ $\mathsf{Hyb}_{4,\mathsf{D}}$ : This is a distinguisher-dependent hybrid like  $\mathsf{Hyb}_{3,\mathsf{D}}$ . Here, just like in  $\mathsf{Hyb}_{3,\mathsf{D}}$ , the challenger runs the PPT distinguisher-dependent simulator  $\mathsf{Sim}_{\mathsf{OT}}$  for the 3-round OT protocol, with error  $\frac{1}{4p(\cdot)}$  in order to generate messages  $\{o_{1,i},o_{3,i}\}_{i\in[k]}$ . Recall that  $\mathsf{Sim}_{\mathsf{OT}}$  requires oracle access to a receiver  $R^*_{\mathsf{OT}}$ , a distinguisher  $\mathcal{D}_{\mathsf{OT}}$  and an ideal functionality  $\{\mathcal{F}^i_{\mathsf{OT}}(\mathsf{label}_{i,0},\mathsf{label}_{i,1})\}_{i\in[k]}$ . These are all constructed the same way as  $\mathsf{Hyb}_{3,\mathsf{D}}$ .
+
+To generate the output of this hybrid, however, the challenger behaves differently from  $\operatorname{Hyb}_{3,D}$ . Specifically, it takes the partial transcript and partial view of  $R_{\mathsf{OT}}^*$  until round 2, obtains the simulated message  $o_{3,i}$  from  $\operatorname{Sim}_{\mathsf{OT}}$ , and generates  $(c_3,d_3)$  exactly according to the strategy in  $\operatorname{Hyb}_1$ . However, it generates G as the output of  $\operatorname{Sim}_{\mathsf{GC}}(1^k,f',f'_{\mathsf{A}}(\mathsf{B}'))$ , where  $\mathsf{B}'$  denotes the input query of  $\operatorname{Sim}_{\mathsf{OT}}$  to the OT ideal functionality  $\{\mathcal{F}_{\mathsf{OT}}^i(|\mathsf{abel}_{i,0},|\mathsf{abel}_{i,1})\}_{i\in[k]}$ . As before, it sends these values to  $\mathsf{S}^*$ . On input  $(z,d_4)$  from  $\mathsf{S}^*$ , it runs  $\mathsf{SHEcom}_{\mathsf{Ext}}$  to find the sender input  $\mathsf{B}$  committed to in the extractable commitment, obtains out from the ideal functionality, and outputs the final view V of  $\mathsf{S}^*$ .
+
+**Claim 4.** Assuming that garbled circuits satisfy Definition 6, for every distinguisher D, there exists a negligible function  $\mu(\cdot)$  such that for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_{3,\mathsf{D}}) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_{4,\mathsf{D}}) = 1]| \leq \mu(k)$$
+
+*Proof.* This claim follows directly by the security property of garbled circuits, as otherwise distinguisher D can be used to distinguish a real garbled circuit from a simulated one. Specifically, there exists a reduction that obtains a challenge garbled circuit externally, and generates the rest of the protocol execution according to  $Hyb_3$ . Since the only difference between these hybrids is whether the garbled circuit is real or simulated, the reduction can run D to distinguish real from simulated garbled circuits.
+
+ $\mathsf{Hyb}_{5,\mathsf{D}}$ : This is a distinguisher-dependent hybrid like  $\mathsf{Hyb}_{4,\mathsf{D}}$ . Here, just like in  $\mathsf{Hyb}_{3,\mathsf{D}}$ , the challenger runs the PPT distinguisher-dependent simulator  $\mathsf{Sim}_{\mathsf{OT}}$  for the 3-round OT protocol, with error  $\frac{1}{4p(\cdot)}$  in order to generate messages  $\{o_{1,i},o_{3,i}\}_{i\in[k]}$ . Recall that  $\mathsf{Sim}_{\mathsf{OT}}$  requires oracle access to a receiver  $R^*_{\mathsf{OT}}$ , a distinguisher  $\mathcal{D}_{\mathsf{OT}}$  and an ideal functionality  $\{\mathcal{F}^i_{\mathsf{OT}}(\mathsf{label}_{i,0},\mathsf{label}_{i,1})\}_{i\in[k]}$ . These are all constructed the same way as  $\mathsf{Hyb}_{3,\mathsf{D}}$ .
+
+To generate the output of this hybrid, however, the challenger behaves differently from  $\mathsf{Hyb}_{4,\mathsf{D}}$ . Specifically, as before it takes the partial transcript and partial view of  $R^*_{\mathsf{OT}}$  until round 2, obtains the simulated message  $o_{3,i}$  from  $\mathsf{Sim}_{\mathsf{OT}}$ , and generates  $(c_3,d_3)$  exactly according to the strategy in  $\mathsf{Hyb}_1$ . However, it generates G as the output of  $\mathsf{Sim}_{\mathsf{GC}}(1^k,f',f'_{0^k}(\mathsf{B}'))$ , where  $\mathsf{B}'$  denotes the input query of  $\mathsf{Sim}_{\mathsf{OT}}$  to  $\{\mathcal{F}^i_{\mathsf{OT}}(\mathsf{label}_{i,0},\mathsf{label}_{i,1})\}_{i\in[k]}$ . As before, it sends these values to  $\mathsf{S}^*$ . On input  $(z,d_4)$  from  $\mathsf{S}^*$ , it runs  $\mathsf{SHEcom}_{\mathsf{Ext}}$  to find the sender input  $\mathsf{B}$  committed in the extractable commitment, obtain out from the ideal functionality, and outputs the final view V of  $\mathsf{S}^*$ .
+
+**Claim 5.** Assuming that IND-CPA security of the public key encryption scheme, for every distinguisher D, there exists a negligible function  $\mu(\cdot)$  such that for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_{4,\mathsf{D}}) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_{5,\mathsf{D}}) = 1]| \leq \mu(k)$$
+
+*Proof.* This claim follows directly by IND-CPA security of the public key encryption scheme.  $\Box$ 
+
+ $\mathsf{Hyb}_{5,\mathsf{D}}$ : This is a distinguisher-dependent hybrid like  $\mathsf{Hyb}_{5,\mathsf{D}}$ . Here, just like in  $\mathsf{Hyb}_{5,\mathsf{D}}$ , the challenger runs the PPT distinguisher-dependent simulator  $\mathsf{Sim}_{\mathsf{OT}}$  for the 3-round OT protocol, with error  $\frac{1}{4p(\cdot)}$  in order to generate messages  $\{o_{1,i},o_{3,i}\}_{i\in[k]}$ . Recall that  $\mathsf{Sim}_{\mathsf{OT}}$  requires oracle access to a receiver  $R^*_{\mathsf{OT}}$ , a distinguisher  $\mathcal{D}_{\mathsf{OT}}$  and an ideal functionality  $\{\mathcal{F}^i_{\mathsf{OT}}(\mathsf{label}_{i,0},\mathsf{label}_{i,1})\}_{i\in[k]}$ . These are all constructed the same way as  $\mathsf{Hyb}_{5,\mathsf{D}}$ .
+
+To generate the output of this hybrid, however, the challenger behaves differently from  $\mathsf{Hyb}_{5,\mathsf{D}}$ . Specifically, it takes the partial transcript and partial view of  $R^*_{\mathsf{OT}}$  until round 2, obtains the simulated message  $o_{3,i}$  from  $\mathsf{Sim}_{\mathsf{OT}}$ , and generates  $(c_3,d_3)$  exactly according to the strategy in  $\mathsf{Hyb}_1$ .
+
+{17}------------------------------------------------
+
+However, it generates G,  $\{label_{i,b}\}_{i\in[k],b\in\{0,1\}}$  as the output of  $Garble(1^k,f'_{0^k}(B'))$ , where B' denotes the input query of  $Sim_{OT}$ . As before, it sends these values to  $S^*$ . On input  $(z,d_4)$  from  $S^*$ , it runs  $SHEcom_{Ext}$  to find the sender input B committed in the extractable commitment, obtains out from the ideal functionality, and outputs the final view V of  $S^*$ .
+
+**Claim 6.** Assuming that garbled circuits satisfy Definition 6, for every distinguisher D, there exists a negligible function  $\mu(\cdot)$  such that for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_{5,\mathsf{D}}) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_{6,\mathsf{D}}) = 1]| \le \mu(k)$$
+
+*Proof.* The proof of this claim follows identically to the proof of indistinguishability between  $\mathsf{Hyb}_{3,\mathsf{D}}$  and  $\mathsf{Hyb}_{4,\mathsf{D}}$ .
+
+Hyb<sub>7</sub>: In this hybrid, the adversary interacts with the simulator. We note that the simulator behaves exactly like the challenger of  $\mathsf{Hyb}_2$ , except that the simulator sets A to  $0^k$ . That is, the simulator garbles the circuit corresponding to function  $f'(\cdot) = \mathsf{Enc}_{\mathsf{pk}}(f_{0^k}(\cdot);\mathsf{r_{enc}})$ , and extracts B from SHEcom to query the ideal functionality. The output of this hybrid corresponds to the view of the explainable sender S\* interacting with the simulator together with the output of honest party R.
+
+**Claim 7.** Assuming that 3 round OT satisfies Definition 10, for every distinguisher D, for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_{6,\mathsf{D}}) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_7) = 1]| \leq \frac{1}{4p(k)}$$
+
+*Proof.* The proof of this claim follows in a similar way as the proof of indistinguishability between  $\mathsf{Hyb}_2$  and  $\mathsf{Hyb}_{3,\mathsf{D}}$ .
+
+Together, these claims contradict our assumption that D distinguishes real and ideal worlds with probability  $\frac{1}{p(k)}$ , completing our proof of security against an explainable S\*. Robustness follows by noting that throughout these claims, we only rely on explainability to argue that messages generated in round 5 are indistinguishable. This completes the proof of Lemma 1.
+
+<span id="page-17-0"></span>**Lemma 2.** Assuming statistical hiding of SHEcom and extractability of Ecom according to Definition 7 and receiver security of OT according to Definition 10, the construction in Figure 1 satisfies robust statistical simulation security (Definition 1) against explainable unbounded receivers as per Definition 3.
+
+*Proof.* We prove that there exists a PPT simulator  $Sim^{R^*}$  that with black-box access to an unbounded explainable sender R\*, outputs a simulated view that is statistically indistinguishable from the real view of R\*. Our simulator is described in Figure 3, with changes from the real protocol underlined.
+
+Suppose there exists a polynomial  $p(\cdot)$  and an unbounded distinguisher D that distinguishes the joint distribution of the view of R\* and the output of S in the real and ideal worlds with probability  $\frac{1}{p(k)}$  for large enough  $k \in \mathbb{N}$ . We consider the following sequence of hybrids:
+
+ $\mathsf{Hyb}_0$ : This hybrid represents an execution where the explainable receiver  $\mathsf{R}^*$  interacts with an honest  $\mathsf{S}$  that follows the strategy in Figure 1. The output of this hybrid is the view of the adversary in its interaction with honest  $\mathsf{S}$ , together with the output of  $\mathsf{S}$ .
+
+ $\mathsf{Hyb}_1$ : This hybrid is similar to  $\mathsf{Hyb}_0$ , except that the challenger runs the extractor Ecom.Ext to obtain  $(\mathsf{A},\mathsf{r}_{\mathsf{enc}})$ , and aborts if extraction fails.
+
+**Claim 8.** Assuming that Ecom is extractable according to Definition 7,  $Hyb_0$  and  $Hyb_1$  are statistically indistinguishable.
+
+*Proof.* From extractability of the statistically binding extractable commitment scheme according to Definition 7, it follows that the probability of abort in  $\mathsf{Hyb}_1$  is  $\mathsf{negl}(k)$ . Therefore, the two hybrids are statistically indistinguishable.
+
+{18}------------------------------------------------
+
+The simulator Sim<sup>R</sup> ∗ interacts with R ∗ , sending the following messages on behalf of S. It uses as subroutine Ecom, the extractor of Ecom.
+
+#### **Round 2:** Sim<sup>R</sup> ∗ does the following.
+
+- 1. Obtain input (pk, {o1,i}i∈[k] , c1, d1) from R ∗ . Send c<sup>1</sup> to EcomExt and obtain c2.
+- 2. Sample {r 0 OT,i}i∈[k] ,r 0 c ,r 0 d \$ ← {0, 1} ∗ . Set B = 0<sup>k</sup> .
+- 3. Set d<sup>2</sup> = SHEcomS,d<sup>1</sup> (B;r 0 d ) and {o2,i = OTR(B<sup>i</sup> ;r 0 OT,i)}i∈[k] .
+- 4. Send (c2, d2, {o2,i}i∈[k]) to R ∗ .
+
+#### **Round 4:** Sim<sup>R</sup> ∗ does the following.
+
+- 1. Obtain input (G, c3, d3, {o3,i}i∈[k]) from R ∗ . Send c<sup>3</sup> to EcomExt.
+- 2. If EcomExt rewinds, the execution automatically goes back to the beginning of round 2. Otherwise, obtain (A,renc) from EcomExt.
+- 3. Send A to the ideal functionality. Obtain out and compute z = Encpk(out;renc).
+- 4. Set d<sup>4</sup> = SHEcomS,d1,d<sup>3</sup> (B;r 0 d ) where recall that B was set to 0 k .
+- 5. Send (z, d4) to R ∗ .
+
+<span id="page-18-1"></span>Figure 3: Simulation strategy against an explainable unbounded adversarial receiver R ∗
+
+Hyb<sup>2</sup> : This hybrid is similar to Hyb<sup>1</sup> , except that the challenger generates the messages d2, d<sup>4</sup> as statistically hiding commitments SHEcom to 0 k instead of to B.
+
+**Claim 9.** *Assuming that* SHEcom *is statistically hiding against malicious receivers,* Hyb<sup>1</sup> *and* Hyb<sup>2</sup> *are statistically indistinguishable.*
+
+*Proof.* This claim follows directly from the statistical hiding property of the commitment scheme SHEcom.
+
+Hyb<sup>3</sup> : This hybrid represents the joint distribution of the view of R <sup>∗</sup> and the output of S, when interacting with the simulator Sim<sup>R</sup> ∗ .
+
+**Claim 10.** *Assuming that the OT protocol satisfies statistical security against malicious senders according to Definition [1,](#page-8-0)* Hyb<sup>2</sup> *and* Hyb<sup>3</sup> *are statistically indistinguishable.*
+
+*Proof.* This claim follows because of the fact that the receiver's choice is statistically hidden (due to statistically receiver private security of the OT protocol), and due to the correctness of extraction of (A, renc) from Ecom against explainable receivers.
+
+Together, these claims contradict our assumption that for an explainable R ∗ , Hyb<sup>0</sup> and Hyb<sup>3</sup> are statistically distinguishable, completing our proof of security against an explainable R ∗ . Robustness follows by observing that throughout these claims, we only rely on explainability to argue that (A, renc) are correctly extracted in order to prove indistinguishability of the messages generated in round 4. This completes the proof of Lemma [2.](#page-17-0)
+
+# <span id="page-18-0"></span>**5 From Explainable to Malicious One-sided Statistical Security**
+
+In this section, we describe a compiler that compiles any robust two-party secure computation protocol against explainable adversaries, into one that is secure against arbitrary malicious adversaries. Assuming the hardness of DDH/LWE/QR, the resulting protocol is computationally secure against PPT malicious senders. In addition, we demonstrate that the resulting protocol is secure against unbounded malicious receivers if the underlying robust explainable protocol is secure against unbounded malicious receivers.
+
+{19}------------------------------------------------
+
+# **5.1 Construction**
+
+In Figure [4,](#page-20-0) we describe a protocol compiler that compiles any 5 round robust explainable protocol into a fully malicious protocol while preserving round complexity. In the next section, we prove that when instantiated with special types of robust explainable protocols, including the protocol in Section [4,](#page-12-0) the resulting protocol is secure against unbounded malicious receivers and PPT malicious senders. Our protocol uses the following building blocks:
+
+• Any robust two-party protocol secure against explainable adversaries from Figure [1](#page-13-0) by ΠexphS, Ri. We denote the messages of this protocol where S uses input B and randomness rS, and R uses input A and randomness rR, by:
+
+$$\begin{split} \left(\tau_{\mathsf{R},1} &= \Pi_{\mathsf{exp},\mathsf{R},1}(\mathsf{A};\mathsf{r}_{\mathsf{R}}), \tau_{\mathsf{S},2} = \Pi_{\mathsf{exp},\mathsf{S},2}(\tau_{\mathsf{R},1},\mathsf{B};\mathsf{r}_{\mathsf{S}}), \tau_{\mathsf{R},3} = \Pi_{\mathsf{exp},\mathsf{R},3}(\tau_{\mathsf{S},2},\mathsf{A};\mathsf{r}_{\mathsf{R}}), \right. \\ & \left. \tau_{\mathsf{S},4} = \Pi_{\mathsf{exp},\mathsf{S},4}(\tau_{\mathsf{R},1},\tau_{\mathsf{R},3},\mathsf{B};\mathsf{r}_{\mathsf{S}}), \tau_{\mathsf{R},5} = \Pi_{\mathsf{exp},\mathsf{R},5}(\tau_{\mathsf{S},2},\tau_{\mathsf{S},4},\mathsf{A};\mathsf{r}_{\mathsf{R}}) \right) \end{split}$$
+
+• A 4 round delayed-input adaptively sound and adaptively statistical ZK argument of knowledge according to Definition [8,](#page-10-1) with messages denoted by
+
+$$SZKA.V, SZKA.P(\cdot), SZKA.V(\cdot), SZKA.P(\cdot, x, w),$$
+
+and the output of the verifier denoted by SZKA.out(·, x).
+
+• A 5 round delayed-input adaptively sound and adaptively computational ZK proof according to Definition [9,](#page-10-0) with messages denoted by
+
+$$\mathsf{ZKP.P}, \mathsf{ZKP.V}(\cdot), \mathsf{ZKP.P}(\cdot), \mathsf{ZKP.V}(\cdot), \mathsf{ZKP.P}(\cdot, x, w),$$
+
+and the output of the verifier denoted by ZKP.out(·, x).
+
+# **5.2 Analysis**
+
+We demonstrate one-sided statistical security of our protocol against arbitrary malicious adversaries by formally proving the following theorem.
+
+<span id="page-19-0"></span>**Theorem 3.** *Assume the existence of four round delayed-input adaptive statistical zero-knowledge arguments of knowledge with adaptive soundness according to Definition [8,](#page-10-1) five round delayed-input adaptive computational zeroknowledge proofs with adaptive soundness according to Definition [9,](#page-10-0) and two round statistical* CDS *for* NP *relations verifiable by* NC<sup>1</sup> *circuits according to Definition [11.](#page-11-1) Assume also that there exists a robust two-party secure computation protocol against explainable adversaries according to Definition [5.](#page-8-3) Then there exists a* 5*-round secure two-party computation protocol with black-box simulation against unbounded malicious receivers and PPT malicious senders, where the receiver obtains its output at the end of round* 4 *and the sender obtains its output at the end of round* 5*.*
+
+Here, we note that the required proof systems can be based on two round statistically hiding commitments, which can themselves be based on the hardness of Decisional Diffie-Hellman (DDH), Quadratic Residuosity (QR) or the Learning with Errors (LWE) assumption. Furthermore, the requisite statistical CDS for NP relations verifiable by NC<sup>1</sup> circuits can be based on any two round statistically sender private OT, which can itself be based on DDH/QR/LWE. In addition, we observe that the robust two-party secure computation protocol against explainable adversaries constructed in Section [4](#page-12-0) satisfies Definition [5,](#page-8-3) and can be instantiated based on DDH/QR/LWE. This results in the following Corollary of Theorem [3.](#page-19-0)
+
+**Corollary 4.** *Assuming polynomial hardness of the Decisional Diffie-Hellman (DDH) assumption, or Quadratic Residuosity (QR) or Learning with Errors (LWE), there exists a* 5*-round secure two-party computation protocol with black-box simulation against unbounded malicious receivers and PPT malicious senders, where the receiver obtains its output at the end of round* 4 *and the sender obtains its output at the end of round* 5*.*
+
+The proof of Theorem [3](#page-19-0) follows from Lemma [3](#page-21-0) and Lemma [4,](#page-22-0) that prove security against malicious senders and unbounded malicious receivers respectively. These are formally stated and proved below.
+
+{20}------------------------------------------------
+
+**Public Input:** Function f that players wish to compute on their private inputs.
+
+**Private Inputs:** The receiver R has private input A and sender S has private input B.
+
+## **Round 1**: R does the following.
+
+- 1. Sample r<sup>R</sup> ← {0, 1} ∗ , compute τR,<sup>1</sup> = Πexp,R,1(A;rR) according to the explainable protocol.
+- 2. Set z<sup>1</sup> ← ZKP.P and z 0 <sup>1</sup> ← SZKA.V as the first messages of the ZK proof with R as prover, and SZK argument with R as verifier, respectively.
+- 3. Send (τR,1, z1, z<sup>0</sup> 1 ) to S.
+
+## **Round 2**: S does the following.
+
+- 1. Sample r<sup>S</sup> ← {0, 1} <sup>∗</sup> and set τS,<sup>2</sup> = Πexp,S,2(τR,1, B;rS) according to the explainable protocol.
+- 2. Set z<sup>2</sup> ← ZKP.V(z1), z<sup>0</sup> <sup>2</sup> ← SZKA.P(z 0 1 ) as the second message of the ZK proof with S as verifier, and SZK argument with S as prover, respecitvely.
+- 3. Send (τS,2, z2, z<sup>0</sup> 2 ) to R.
+
+## **Round 3**: R does the following.
+
+- 1. Set τR,<sup>3</sup> = Πexp,R,3(τS,2, A;rR). Set x = (τR,1, τR,3), w = (A,rR, ldp) where ldp is a low-depth proof of (τR,1, τR,3) = R(A, rR, τS,2).
+- 2. Compute CDS message (ct, k) ← CDS.R(x, w) and z<sup>3</sup> ← ZKP.P(z2), z<sup>0</sup> <sup>3</sup> ← SZKA.V(z 0 2 ).
+- 3. Send (τR,3, ct, z3, z<sup>0</sup> 3 ) to S.
+
+## **Round 4**: S does the following.
+
+- 1. Set τS,<sup>4</sup> = Πexp,S,4(τR,1, τR,3, B;rS), and CDS response c ← CDS.S(x, τS,4, ct).
+- 2. Set x<sup>1</sup> = (τS,2, c), w<sup>1</sup> = (B,rS), z<sup>4</sup> ← ZKP.V(z1, z3), z<sup>0</sup> <sup>4</sup> ← SZKA.P(z 0 1 , z<sup>0</sup> 3 , x1, w1).
+- 3. Send (c, z4, z<sup>0</sup> 4 ) to R.
+
+### **Round 5**: R does the following.
+
+- 1. If SZKA.out(z 0 1 , z<sup>0</sup> 2 , z<sup>0</sup> 3 , z<sup>0</sup> 4 ) = 0, abort. Otherwise, recover τS,<sup>4</sup> = CDS.Dk(c) and set τR,<sup>5</sup> = Πexp,R,5(τS,2, τS,4, A;rR).
+- 2. Set x = (τR,1, τR,3, τR,5), w = (A,rR), z<sup>5</sup> = ZKP.P(z2, z4, x2, w2).
+- 3. Send (τR,5, z5) to S, and output Πexp,R,out(τS,2, τS,4, A;rR).
+
+**Sender Output**: If ZKP.out(z1, z2, z3, z4, z5) = 0, abort. Else output Πexp,S,out(τR,1, τR,3, τR,5, B;rS).
+
+<span id="page-20-0"></span>Figure 4: Our two-party secure computation protocol ΠmalhS, Ri for general functionalities, with computational security against malicious S and statistical security against malicious R. Here languages for the CDS protocol, SZK argument and ZK proof are defined as follows:
+
+$$\begin{split} \mathsf{L}_{\mathsf{CDS}} &= \{ (\tau_{\mathsf{R},1}, \tau_{\mathsf{R},3}) : \exists (\mathsf{A}, r_{\mathsf{R}}, \mathsf{Idp}) \text{ s.t. Idp is a low-depth proof of } (\tau_{\mathsf{R},1}, \tau_{\mathsf{R},3}) = \mathsf{R}(\mathsf{A}, r_{\mathsf{R}}, \tau_{\mathsf{S},2}) \} \\ & \mathsf{L}_{\mathsf{ZKP}} = \{ (\tau_{\mathsf{R},1}, \tau_{\mathsf{R},3}, \tau_{\mathsf{R},5}) : \exists (\mathsf{A}, r_{\mathsf{R}}) \text{ s.t. } (\tau_{\mathsf{R},1}, \tau_{\mathsf{R},3}, \tau_{\mathsf{R},5}) = \mathsf{R}(\mathsf{A}, r_{\mathsf{R}}, \tau_{\mathsf{S},2}, \tau_{\mathsf{S},4}) \} \\ & \mathsf{L}_{\mathsf{SZKA}} = \{ (\tau_{\mathsf{S},2}, c) : \exists (\mathsf{B}, r_{\mathsf{S}}) \text{ s.t. } (\tau_{\mathsf{S},2}, c) = \mathsf{S}(\mathsf{B}, r_{\mathsf{S}}, \tau_{\mathsf{R},1}, \tau_{\mathsf{R},3}) \} \end{split}$$
+
+where R(A, rR, τS,2)) denotes that the transcript (τR,1, τR,3) is generated using honest receiver strategy with input A and randomness rR; R(A, rR, τS,2, τS,4)) denotes that the transcript (τR,1, τR,3, τR,5) is generated using honest receiver strategy with input A and randomness rR; and S(B, rS, τR,1, τR,3)) denotes that the transcript (τS,2, c) is generated using honest sender strategy with input B and randomness rS.
+
+{21}------------------------------------------------
+
+<span id="page-21-0"></span>**Lemma 3.** Assuming CDS satisfies receiver simulation according to Definition 11, SZKA is adaptively sound according to Definition 8 and ZKP satisfies adaptive computational zero-knowledge according to Definition 9, and assuming  $\Pi_{\text{exp}}$  is a robust explainable protocol satisfying the additional property described in Theorem 3, the protocol  $\Pi_{\text{mal}}\langle S,R\rangle$  in Figure 4 is secure against PPT malicious senders according to Definition 1.
+
+*Proof.* We prove that there exists a simulator Sim<sup>S\*</sup> that with black-box access to a computationally bounded malicious sender S\*, outputs a simulated view that is indistinguishable from the real view of S\*. Our simulator is in Figure 5.
+
+The simulator  $\mathsf{Sim}^{\mathsf{S}^*}$  interacts with  $\mathsf{S}^*$ , sending the following messages on behalf of R. It uses as subroutine the simulator  $\mathsf{Sim}_{\mathsf{S},\mathsf{exp}}$  against an explainable sender S, the simulator CDS. Sim of the CDS protocol, the simulator ZKP. Sim of the 5 round zero-knowledge proof and the extractor SZKA. Ext of the 4 round statistical zero-knowledge argument of knowledge.
+
+# **Round 1**: Sim<sup>S\*</sup> does the following.
+
+- 1. Obtain  $\tau_{R,1}$  from  $Sim_{S,exp}$ .
+- 2. Sample  $z_1 \leftarrow \mathsf{ZKP}.\mathsf{Sim}, z_1' \leftarrow \mathsf{SZKA}.\mathsf{Ext}.$
+- 3. Send  $(\tau_{R,1}, z_1, z'_1)$  to S\*.
+
+#### Round 3:
+
+- 1. Obtain  $(\tau_{S,2}, z_2, z_2')$  from S\*.
+- 2. Send  $\tau_{S,2}$  to  $Sim_{S,exp}$  and obtain  $\tau_{R,3}$ .
+- 3. Set  $x = (\tau_{R,1}, \tau_{R,3})$ , ct  $\leftarrow \mathsf{CDS}.\mathsf{Sim}(x)$ .
+- 4. Sample  $z_3 \leftarrow \mathsf{ZKP}.\mathsf{Sim}(z_2), z_3' \leftarrow \mathsf{SZKA}.\mathsf{Ext}(z_2').$
+- 5. Send  $(\tau_{S,2}, \text{ct}, z_3, z_3')$  to  $S^*$ .
+
+#### Round 5:
+
+- 1. Obtain  $(ct, z_4, z'_4)$  from  $S^*$ .
+- 2. Obtain  $\tau_{S,4}$  from SZKA.Ext. Send  $\tau_{S,4}$  to  $\mathsf{Sim}_{S,\mathsf{exp}}$  and obtain  $\tau_{R,5}$ .
+- 3. Set  $x_2 = (\tau_{R,1}, \tau_{R,3}, \tau_{R,5})$ , and  $z_5 \leftarrow \mathsf{ZKP}.\mathsf{Sim}(z_2, z_4, x_2)$ .
+- 4. Send  $(\tau_{R,5}, z_5)$  to S\*.
+
+<span id="page-21-1"></span>Figure 5: Simulation strategy against a PPT malicious sender S\*
+
+Suppose there exists a polynomial  $p(\cdot)$  and a distinguisher D that distinguishes the joint distribution of the view of S\* and the output of R in the real and ideal worlds, with probability  $\frac{1}{p(k)}$  for infinitely many  $k \in \mathbb{N}$ . We consider the following sequence of hybrids:
+
+Hyb<sub>0</sub>: This hybrid represents an execution where the malicious sender  $S^*$  interacts with an honest R, that follows the strategy in Figure 1. The output of this hybrid is the view of the adversary in its interaction with honest R, together with the output of R.
+
+Hyb<sub>1</sub>: In this hybrid, the adversary interacts with the challenger that behaves identically to  $\mathsf{Hyb}_0$ , except that it generates the messages  $(z_1, z_3, z_5)$  as the output of the simulator ZKP. Sim as opposed to executing honest prover strategy.
+
+**Claim 11.** Assuming that the zero-knowledge proof ZKP is computationally zero-knowledge according to Definition 9, for every PPT distinguisher D, there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_0) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_1) = 1]| = \mu(k)$$
+
+{22}------------------------------------------------
+
+*Proof.* This claim follows directly from the computational zero-knowledge property of the zero-knowledge proof according to Definition 9, because the only difference between  $\mathsf{Hyb}_0$  and  $\mathsf{Hyb}_1$  is whether the proof is real or simulated. Therefore, there is a straightforward reduction that with access to a distinguisher D that distinguishes these hybrids with non-negligible probability, contradicts the zero-knowledge property according to Definition 9.
+
+Hyb<sub>2</sub>: In this hybrid, the adversary interacts with the challenger that behaves identically to Hyb<sub>1</sub>, except that it generates the message ct as the output of the CDS simulator on input x, and extracts  $\tau_{S,4}$  from the extractor of the SZK argument.
+
+**Claim 12.** Assuming that the CDS satisfies receiver simulation according to Definition 11 and the SZK argument of knowledge satisfies Definition 8, for every PPT distinguisher D, there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_1) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_2) = 1]| = \mu(k)$$
+
+*Proof.* This claim follows by correctness of extraction of the SZK argument, by Definition 8, and the receiver simulation property of the CDS protocol according to Definition 11.
+
+ $Hyb_3$ : This hybrid denotes the view of the simulator interacting with malicious  $S^*$ , together with the output of R.
+
+**Claim 13.** Assuming that the conditions in Lemma 1 hold for  $\Pi_{\text{exp}}$ , for every PPT distinguisher D, there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ ,
+
+$$|\Pr[\mathsf{D}(\mathsf{Hyb}_2) = 1] - \Pr[\mathsf{D}(\mathsf{Hyb}_3) = 1]| = \mu(k)$$
+
+*Proof.* The only difference between  $\mathsf{Hyb}_2$  and  $\mathsf{Hyb}_3$  is that  $\mathsf{Hyb}_2$  uses honest receiver strategy to generate the messages of  $\Pi_\mathsf{exp}$ , whereas  $\mathsf{Hyb}_3$  uses the simulator  $\mathsf{Sim}_\mathsf{exp}$  of the explainable protocol.
+
+Note that these hybrids are indistinguishable whenever  $S^*$  is explainable, by simulation-based security of  $\Pi_{\text{exp}}$  against explainable senders. For any  $S^*$  that is not explainable, the argument of knowledge property of the statistical ZK argument of knowledge provided by  $S^*$  in the  $4^{th}$  round ensures that both hybrids abort at the end of the  $4^{th}$  round, except with negligible probability. Furthermore, because  $\Pi_{\text{exp}}$  is robust, in that the first three messages of the sender (and receiver respectively) are indistinguishable in real and ideal experiments even against malicious adversaries, these hybrids are indistinguishable upto round 4, in the case where the experiment aborts at the end of the  $4^{th}$  round.
+
+This completes the proof of Lemma 3.
+
+<span id="page-22-0"></span>**Lemma 4.** Assuming CDS satisfies statistical message indistinguishability for NP relations verifiable by NC<sub>1</sub> circuits according to Definition 11, assuming L<sub>CDS</sub> is verifiable in NC<sub>1</sub>, assuming ZKP is adaptively sound against unbounded provers according to Definition 9 and SZKA satisfies adaptive statistical zero-knowledge according to Definition 8, and assuming  $\Pi_{\text{exp}}$  is robust and statistically secure against unbounded explainable receivers, the protocol  $\Pi_{\text{mal}}\langle S,R\rangle$  in Figure 4 is statistically secure against unbounded malicious receivers according to Definition 1.
+
+*Proof.* We prove that there exists a simulator Sim<sup>R\*</sup> that with black-box access to a malicious receiver R\*, outputs a simulated view that is indistinguishable from the real view of R\*. Our simulator is described in Figure 6.
+
+Suppose there exists a polynomial  $p(\cdot)$  and a distinguisher D that distinguishes the joint distribution of the view of R\* and the output of S in the real and ideal worlds, with probability  $\frac{1}{p(k)}$  for infinitely many  $k \in \mathbb{N}$ . We consider the following sequence of hybrids:
+
+ $Hyb_0$ : This hybrid represents an execution where the malicious receiver R\* interacts with an honest S, that follows the strategy in Figure 1. The output of this hybrid is the view of the adversary in its interaction with honest S, together with the output of S.
+
+{23}------------------------------------------------
+
+The simulator  $Sim^{R^*}$  interacts with  $R^*$ , sending the following messages on behalf of S. It uses as subroutine the simulator  $Sim_{R^*,exp}$  against an explainable receiver  $R^*$  and the simulator SZKA. Sim of the 4 round zero-knowledge argument of knowledge.
+
+**Round 2:** Sim<sup>R\*</sup> does the following.
+
+- 1. Obtain  $(\tau_{R,1}, z_1, z_1')$  from R\*.
+- 2. Send  $\tau_{R,1}$  to  $Sim_{R^*,exp}$  and obtain  $\tau_{S,2}$ .
+- 3. Sample  $z_2 \leftarrow \mathsf{ZKP.V}(z_1), z_2' \leftarrow \mathsf{SZKA.Sim}(z_1')$ .
+- 4. Send  $(\tau_{S,2}, z_2, z_2')$  to R\*.
+
+# **Round 4:** Sim<sup>R\*</sup> does the following.
+
+- 1. Obtain input  $(\tau_{R,3}, \operatorname{ct}, z_3, z_3')$  from  $R^*$ .
+- 2. Send  $\tau_{R,3}$  to  $Sim_{R^*,exp}$  and obtain  $\tau_{S,4}$ .
+- 3. Set  $x_1 = (\tau_{S,2}, c)$ , where  $c \leftarrow \mathsf{CDS.S}(x, \tau_{S,4}, \mathsf{ct})$  and  $x = (\tau_{R,1}, \tau_{R,3})$ .
+- 4. Sample  $z_4 \leftarrow \mathsf{ZKP.V}(z_3)$ ,  $z_4' \leftarrow \mathsf{SZKA.Sim}(z_3', x_1)$ .
+- 5. Send  $(c, z_4, z'_4)$  to R\*.
+
+**Output:** Obtain  $\tau_{R,5}, z_5$  from R\*. Allow the ideal functionality to release the output to honest party iff  $\mathsf{ZKP.out}(z_1, z_2, z_3, z_4, z_5) = 1$ .
+
+<span id="page-23-0"></span>Figure 6: Simulation strategy against a malicious receiver R\*
+
+Hyb<sub>1</sub>: In this hybrid, the adversary interacts with a challenger that behaves identically to Hyb<sub>0</sub>, except that it generates the messages  $(z_2, z_4)$  as the output of the simulator SZKA. Sim as opposed to executing honest prover strategy.
+
+**Claim 14.** Assuming that the zero-knowledge argument SZKA is statistically zero-knowledge according to Definition 9, there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ , the statistical distance between  $\mathsf{Hyb}_0$  and  $\mathsf{Hyb}_1$  is  $\mu(k)$ .
+
+*Proof.* This claim follows directly from the statistical zero-knowledge property of the zero-knowledge argument according to Definition 9, because the only difference between  $\mathsf{Hyb}_1$  and  $\mathsf{Hyb}_2$  is whether the proof is real or simulated. Therefore, there exists a reduction that with access to any unbounded distinguisher D that distinguishes these hybrids with non-negligible probability, contradicts the statistical zero-knowledge property according to Definition 8.
+
+Hyb<sub>2</sub>: This hybrid denotes the view of the simulator interacting with malicious  $R^*$ , together with the output of S.
+
+**Claim 15.** Assuming that  $\Pi_{\text{exp}}$  is robust and unconditionally secure against explainable receivers, that CDS satisfies statistical message indistinguishability according to Definition 11 for relations verifiable by  $NC_1$  circuits, that instances in  $L_{\text{CDS}}$  are verifiable by  $NC_1$  circuits given the witness, there exists a negligible function  $\mu(\cdot)$  s.t. for large enough  $k \in \mathbb{N}$ , the statistical distance between  $Hyb_1$  and  $Hyb_2$  is  $\mu(k)$ .
+
+*Proof.* The only difference between  $\mathsf{Hyb}_1$  and  $\mathsf{Hyb}_2$  is that  $\mathsf{Hyb}_1$  uses honest sender strategy to generate the messages of  $\Pi_{\mathsf{exp}}$ , whereas  $\mathsf{Hyb}_2$  uses the simulator  $\mathsf{Sim}_{\mathsf{R},\mathsf{exp}}$  of the explainable protocol.
+
+These hybrids are statistically indistinguishable whenever R\* is explainable, by simulation-based statistical security of  $\Pi_{\text{exp}}$  against explainable receivers. For any R\* that is not explainable, the soundness of the zero-knowledge proof provided by R\* at the end of the  $5^{th}$  round ensures that both hybrids abort at the end of the  $5^{th}$  round. For any R\* that behaves arbitrarily maliciously in the first three rounds, the fact that  $\Pi_{\text{exp}}$ 
+
+{24}------------------------------------------------
+
+is robust in the first two rounds together with the statistical message indistinguishability property of CDS ensures that Hyb<sup>1</sup> and Hyb<sup>2</sup> are statistically indistinguishable. This completes the proof of Lemma [4,](#page-22-0) and the proof of our main theorem.
+
+**Acknowledgments.** We thank Giulio Malavolta, Akshayaram Srinivasan and the anonymous TCC reviewers for useful suggestions.
+
+# **References**
+
+- <span id="page-24-3"></span>[ACJ17] Prabhanjan Ananth, Arka Rai Choudhuri, and Abhishek Jain. A new approach to roundoptimal secure multiparty computation. In *Advances in Cryptology - CRYPTO 2017 - 37th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 20-24, 2017, Proceedings, Part I*, pages 468–499, 2017. [2](#page-1-1)
+- <span id="page-24-1"></span>[AH91] William Aiello and Johan Hastad. Statistical zero-knowledge languages can be recognized in ˚ two rounds. *J. Comput. Syst. Sci.*, 42(3):327–345, 1991. [2](#page-1-1)
+- <span id="page-24-7"></span>[AIR01] William Aiello, Yuval Ishai, and Omer Reingold. Priced oblivious transfer: How to sell digital goods. In *Advances in Cryptology - EUROCRYPT 2001, International Conference on the Theory and Application of Cryptographic Techniques, Innsbruck, Austria, May 6-10, 2001, Proceeding*, pages 119–135, 2001. [4,](#page-3-1) [12](#page-11-2)
+- <span id="page-24-2"></span>[BCC88] Gilles Brassard, David Chaum, and Claude Crepeau. Minimum disclosure proofs of knowl- ´ edge. *J. Comput. Syst. Sci.*, 37(2):156–189, 1988. [2](#page-1-1)
+- <span id="page-24-8"></span>[BD18] Zvika Brakerski and Nico Dottling. Two-message statistically sender-private OT from LWE. In ¨ *TCC*, 2018. [4,](#page-3-1) [12,](#page-11-2) [13](#page-12-1)
+- <span id="page-24-10"></span>[BFJ+20] Saikrishna Badrinarayanan, Rex Fernando, Aayush Jain, Dakshita Khurana, and Amit Sahai. Statistical ZAP arguments. In Anne Canteaut and Yuval Ishai, editors, *Advances in Cryptology - EUROCRYPT 2020 - 39th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Zagreb, Croatia, May 10-14, 2020, Proceedings, Part III*, volume 12107 of *Lecture Notes in Computer Science*, pages 642–667, 2020. [8](#page-7-0)
+- <span id="page-24-6"></span>[BGI+17] Saikrishna Badrinarayanan, Sanjam Garg, Yuval Ishai, Amit Sahai, and Akshay Wadia. Twomessage witness indistinguishability and secure computation in the plain model from new assumptions. In Tsuyoshi Takagi and Thomas Peyrin, editors, *Advances in Cryptology - ASI-ACRYPT 2017 - 23rd International Conference on the Theory and Applications of Cryptology and Information Security, Hong Kong, China, December 3-7, 2017, Proceedings, Part III*, pages 275–303, 2017. [4](#page-3-1)
+- <span id="page-24-5"></span>[BGJ<sup>+</sup>18] Saikrishna Badrinarayanan, Vipul Goyal, Abhishek Jain, Yael Tauman Kalai, Dakshita Khurana, and Amit Sahai. Promise zero knowledge and its applications to round optimal MPC. In *Advances in Cryptology - CRYPTO 2018 Proceedings, Part II*, pages 459–487, 2018. [2](#page-1-1)
+- <span id="page-24-4"></span>[BHP17] Zvika Brakerski, Shai Halevi, and Antigoni Polychroniadou. Four round secure computation without setup. In *Theory of Cryptography - 15th International Conference, TCC 2017, Baltimore, MD, USA, November 12-15, 2017, Proceedings, Part I*, pages 645–677, 2017. [2](#page-1-1)
+- <span id="page-24-0"></span>[BJY97] Mihir Bellare, Markus Jakobsson, and Moti Yung. Round-optimal zero-knowledge arguments based on any one-way function. In *Advances in Cryptology - EUROCRYPT '97, Proceeding*, pages 280–305, 1997. [1,](#page-0-0) [2](#page-1-1)
+- <span id="page-24-9"></span>[BKP19] Nir Bitansky, Dakshita Khurana, and Omer Paneth. Weak zero-knowledge beyond the blackbox barrier. In *Proceedings of the 51st Annual ACM SIGACT Symposium on Theory of Computing, STOC 2019, Phoenix, AZ, USA, June 23-26, 2019*, pages 1091–1102, 2019. [5,](#page-4-1) [7](#page-6-1)
+
+{25}------------------------------------------------
+
+- <span id="page-25-8"></span>[CCG<sup>+</sup>19] Arka Rai Choudhuri, Michele Ciampi, Vipul Goyal, Abhishek Jain, and Rafail Ostrovsky. On round optimal secure multiparty computation from minimal assumptions. *IACR Cryptology ePrint Archive*, 2019:216, 2019. [2](#page-1-1)
+- <span id="page-25-9"></span>[CO17] Wutichai Chongchitmate and Rafail Ostrovsky. Circuit-private multi-key FHE. In Serge Fehr, editor, *Public-Key Cryptography - PKC 2017 - 20th IACR International Conference on Practice and Theory in Public-Key Cryptography, Amsterdam, The Netherlands, March 28-31, 2017, Proceedings, Part II*, volume 10175 of *Lecture Notes in Computer Science*, pages 241–270. Springer, 2017. [2](#page-1-1)
+- <span id="page-25-7"></span>[COSV17a] Michele Ciampi, Rafail Ostrovsky, Luisa Siniscalchi, and Ivan Visconti. Delayed-input nonmalleable zero knowledge and multi-party coin tossing in four rounds. In *Theory of Cryptography - 15th International Conference, TCC 2017, Baltimore, MD, USA, November 12-15, 2017, Proceedings, Part I*, pages 711–742, 2017. [2](#page-1-1)
+- <span id="page-25-5"></span>[COSV17b] Michele Ciampi, Rafail Ostrovsky, Luisa Siniscalchi, and Ivan Visconti. Round-optimal secure two-party computation from trapdoor permutations. In *Theory of Cryptography - 15th International Conference, TCC 2017, Baltimore, MD, USA, November 12-15, 2017, Proceedings, Part I*, pages 678–710, 2017. [2](#page-1-1)
+- <span id="page-25-12"></span>[DNRS99] Cynthia Dwork, Moni Naor, Omer Reingold, and Larry J. Stockmeyer. Magic functions. In *40th Annual Symposium on Foundations of Computer Science, FOCS '99, 17-18 October, 1999, New York, NY, USA*, pages 523–534, 1999. [4](#page-3-1)
+- <span id="page-25-2"></span>[For87] Lance Fortnow. The complexity of perfect zero-knowledge (extended abstract). In *Proceedings of the 19th Annual ACM Symposium on Theory of Computing, 1987, New York, New York, USA*, pages 204–209, 1987. [2](#page-1-1)
+- <span id="page-25-0"></span>[FS90] Uriel Feige and Adi Shamir. Witness indistinguishable and witness hiding protocols. In *Proceedings of the 22nd Annual ACM Symposium on Theory of Computing, May 13-17, 1990, Baltimore, Maryland, USA*, pages 416–426, 1990. [1](#page-0-0)
+- <span id="page-25-14"></span>[GGH+16] Sanjam Garg, Craig Gentry, Shai Halevi, Mariana Raykova, Amit Sahai, and Brent Waters. Candidate indistinguishability obfuscation and functional encryption for all circuits. *SIAM J. Comput.*, 45(3):882–929, 2016. [13](#page-12-1)
+- <span id="page-25-13"></span>[GGSW13] Sanjam Garg, Craig Gentry, Amit Sahai, and Brent Waters. Witness encryption and its applications. In *Symposium on Theory of Computing Conference, STOC'13, Palo Alto, CA, USA, June 1-4, 2013*, pages 467–476, 2013. [12](#page-11-2)
+- <span id="page-25-1"></span>[GK96] Oded Goldreich and Ariel Kahan. How to construct constant-round zero-knowledge proof systems for NP. *J. Cryptology*, 9(3):167–190, 1996. [1,](#page-0-0) [2,](#page-1-1) [7,](#page-6-1) [11](#page-10-2)
+- <span id="page-25-6"></span>[GMPP16] Sanjam Garg, Pratyay Mukherjee, Omkant Pandey, and Antigoni Polychroniadou. The exact round complexity of secure computation. In *EUROCRYPT*, 2016. [2](#page-1-1)
+- <span id="page-25-3"></span>[GMW91] Oded Goldreich, Silvio Micali, and Avi Wigderson. Proofs that yield nothing but their validity for all languages in NP have zero-knowledge proof systems. volume 38, pages 691–729, 1991. [2](#page-1-1)
+- <span id="page-25-10"></span>[HK12] Shai Halevi and Yael Tauman Kalai. Smooth projective hashing and two-message oblivious transfer. *J. Cryptology*, 25(1):158–193, 2012. [4,](#page-3-1) [12,](#page-11-2) [13](#page-12-1)
+- <span id="page-25-4"></span>[HNO<sup>+</sup>09] Iftach Haitner, Minh-Huyen Nguyen, Shien Jin Ong, Omer Reingold, and Salil P. Vadhan. Statistically hiding commitments and statistical zero-knowledge arguments from any one-way function. *SIAM J. Comput.*, 39(3):1153–1218, 2009. [2](#page-1-1)
+- <span id="page-25-11"></span>[JJGM20] Abhishek Jain, Zhengzhong Jin, Vipul Goyal, and Giulio Malavolta. Statistical zaps and new oblivious transfer protocols, to appear. In *Eurocrypt*, 2020. [4,](#page-3-1) [8,](#page-7-0) [12](#page-11-2)
+
+{26}------------------------------------------------
+
+- <span id="page-26-7"></span>[JKKR17] Abhishek Jain, Yael Tauman Kalai, Dakshita Khurana, and Ron Rothblum. Distinguisherdependent simulation in two rounds and its applications. In *Advances in Cryptology - CRYPTO 2017 - 37th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 20-24, 2017, Proceedings, Part II*, pages 158–189, 2017. [4](#page-3-1)
+- <span id="page-26-6"></span>[Kal05] Yael Tauman Kalai. Smooth projective hashing and two-message oblivious transfer. In Ronald Cramer, editor, *Advances in Cryptology - EUROCRYPT 2005, 24th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Aarhus, Denmark, May 22-26, 2005, Proceedings*, volume 3494 of *Lecture Notes in Computer Science*, pages 78–95, 2005. [4,](#page-3-1) [12](#page-11-2)
+- <span id="page-26-4"></span>[Kat08a] Jonathan Katz. Which languages have 4-round zero-knowledge proofs? In *Theory of Cryptography, Fifth Theory of Cryptography Conference, TCC 2008, New York, USA, March 19-21, 2008*, pages 73–88, 2008. [2](#page-1-1)
+- <span id="page-26-13"></span>[Kat08b] Jonathan Katz. Which languages have 4-round zero-knowledge proofs? In *Theory of Cryptography Conference*, pages 73–88. Springer, 2008. [28](#page-27-5)
+- <span id="page-26-3"></span>[KKS18] Yael Tauman Kalai, Dakshita Khurana, and Amit Sahai. Statistical witness indistinguishability (and more) in two messages. In *Advances in Cryptology - EUROCRYPT 2018 - 37th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Tel Aviv, Israel, April 29 - May 3, 2018 Proceedings, Part III*, pages 34–65, 2018. [2,](#page-1-1) [4](#page-3-1)
+- <span id="page-26-2"></span>[KO04] Jonathan Katz and Rafail Ostrovsky. Round-optimal secure two-party computation. In *Advances in Cryptology - CRYPTO 2004, 24th Annual International CryptologyConference, Santa Barbara, California, USA, August 15-19, 2004, Proceedings*, pages 335–354, 2004. [2,](#page-1-1) [4](#page-3-1)
+- <span id="page-26-11"></span>[LS90] Dror Lapidot and Adi Shamir. Publicly verifiable non-interactive zero-knowledge proofs. In *Advances in Cryptology - CRYPTO '90, 10th Annual International Cryptology Conference, Santa Barbara, California, USA, August 11-15, 1990, Proceedings*, pages 353–365, 1990. [11](#page-10-2)
+- <span id="page-26-12"></span>[LS19] Alex Lombardi and Luke Schaeffer. A note on key agreement and non-interactive commitments. *IACR Cryptol. ePrint Arch.*, 2019:279, 2019. [15](#page-14-2)
+- <span id="page-26-8"></span>[LTV13] Adriana Lopez-Alt, Eran Tromer, and Vinod Vaikuntanathan. On-the-fly multiparty compu- ´ tation on the cloud via multikey fully homomorphic encryption. *IACR Cryptol. ePrint Arch.*, 2013:94, 2013. [5](#page-4-1)
+- <span id="page-26-10"></span>[LVW20] Alex Lombardi, Vinod Vaikuntanathan, and Daniel Wichs. Statistical ZAPR arguments from bilinear maps. In Anne Canteaut and Yuval Ishai, editors, *Advances in Cryptology - EURO-CRYPT 2020 - 39th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Zagreb, Croatia, May 10-14, 2020, Proceedings, Part III*, volume 12107 of *Lecture Notes in Computer Science*, pages 620–641, 2020. [8](#page-7-0)
+- <span id="page-26-9"></span>[MW16] Pratyay Mukherjee and Daniel Wichs. Two round multiparty computation via multi-key FHE. In Marc Fischlin and Jean-Sebastien Coron, editors, ´ *Advances in Cryptology - EUROCRYPT 2016 - 35th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Vienna, Austria, May 8-12, 2016, Proceedings, Part II*, volume 9666 of *Lecture Notes in Computer Science*, pages 735–763, 2016. [5](#page-4-1)
+- <span id="page-26-0"></span>[Nao91] Moni Naor. Bit commitment using pseudorandomness. *Journal of cryptology*, 4(2):151–158, 1991. [2](#page-1-1)
+- <span id="page-26-1"></span>[NOVY98] Moni Naor, Rafail Ostrovsky, Ramarathnam Venkatesan, and Moti Yung. Perfect zeroknowledge arguments for *NP* using any one-way permutation. *J. Cryptology*, 11(2), 1998. [2](#page-1-1)
+- <span id="page-26-5"></span>[NP01] Moni Naor and Benny Pinkas. Efficient oblivious transfer protocols. In *SODA*, 2001. [4,](#page-3-1) [7,](#page-6-1) [12,](#page-11-2) [13](#page-12-1)
+
+{27}------------------------------------------------
+
+- <span id="page-27-5"></span><span id="page-27-1"></span>[OPP14] Rafail Ostrovsky, Anat Paskin-Cherniavsky, and Beni Paskin-Cherniavsky. Maliciously circuitprivate FHE. In Juan A. Garay and Rosario Gennaro, editors, *Advances in Cryptology - CRYPTO 2014 - 34th Annual Cryptology Conference, Santa Barbara, CA, USA, August 17-21, 2014, Proceedings, Part I*, volume 8616 of *Lecture Notes in Computer Science*, pages 536–553. Springer, 2014. [2](#page-1-1)
+- <span id="page-27-0"></span>[ORS15] Rafail Ostrovsky, Silas Richelson, and Alessandra Scafuro. Round-optimal black-box two-party computation. In *Advances in Cryptology - CRYPTO 2015 - 35th Annual Cryptology Conference, Santa Barbara, CA, USA, August 16-20, 2015, Proceedings, Part II*, pages 339–358, 2015. [2](#page-1-1)
+- <span id="page-27-3"></span>[PRS02] Manoj Prabhakaran, Alon Rosen, and Amit Sahai. Concurrent zero knowledge with logarithmic round-complexity. In *43rd Symposium on Foundations of Computer Science (FOCS 2002), 16-19 November 2002, Vancouver, BC, Canada, Proceedings*, pages 366–375, 2002. [5,](#page-4-1) [10,](#page-9-2) [15](#page-14-2)
+- <span id="page-27-4"></span>[Yao86] Andrew Chi-Chih Yao. How to generate and exchange secrets (extended abstract). In *27th Annual Symposium on Foundations of Computer Science, Toronto, Canada, 27-29 October 1986*, pages 162–167, 1986. [9,](#page-8-4) [15](#page-14-2)
+
+# <span id="page-27-2"></span>**A Lower Bound on 4 Round Secure Computation with an Unbounded Sender**
+
+<span id="page-27-6"></span>**Theorem 5.** *A 4-round two-party secure computation protocol with black-box simulation, where the sender is unbounded and only the (bounded) receiver gets the output, is impossible unless the polynomial hierarchy collapses.*
+
+Our proof makes use of the following theorem from [\[Kat08b\]](#page-26-13).
+
+<span id="page-27-7"></span>**Imported Theorem 3.** *[\[Kat08b\]](#page-26-13)* NP*-complete languages do not have 4-round zero-knowledge proofs, unless the polynomial hierarchy collapses.*
+
+*Proof.* (of Theorem [5\)](#page-27-6) We prove Theorem [5](#page-27-6) by contradiction. Suppose there exists a 4-round two-party secure computation protocol Π, with black-box simulation, where S is unbounded and R is bounded. We show that this protocol can be used to construct a 4-round ZK proof for any language in NP, contradicting the result of Imported Theorem [3.](#page-27-7)
+
+**From 4-round 2PC to 4-round** ZK **proof for NP-complete languages.** By definition, given a functionality F, Π realizes F such that
+
+$$\mathsf{IDEAL}_{\mathcal{F},\mathsf{Sim},\mathsf{A}\in\{\mathsf{S},\mathsf{R}\}}(\mathsf{x},\mathsf{y},\mathsf{n}) \approx \mathsf{REAL}_{\pi,\mathsf{A}\in\{\mathsf{S},\mathsf{R}\}}(\mathsf{x},\mathsf{y},\mathsf{n}).$$
+
+**Ideal Functionality for** ZK **proofs.** Given any NP language L and an instance X, we define F as follows: F *takes* (x, w) *as input from unbounded* S *(prover) and* x 0 *as input from bounded* R *(verifier). It then outputs 1 to* R *(verifier) if and only if:*
+
+- x = x 0 , and
+- RL(x, w) = 1
+
+*Otherwise,* F *outputs* 0*.*
+
+Here RL(x, w) is the relation for language L. It remains to show that 2PC protocol based on the functionality F satisfies the completeness, soundness and zero-knowledge properties in [Definition 9.](#page-10-0)
+
+Following the security definition of 2PC, for each malicious party (either S or R) interacting with the 2PC protocol π in the real world, there exists a simulator Sim in ideal world, such that the view of the malicious party in the real world together with the output of the honest party, is indistinguishable from its view in the ideal world and the output of the honest party. Without loss of generality, we denote the simulators simulating the view of S and R respectively SimSen and SimRec.
+
+{28}------------------------------------------------
+
+**Completeness.** Completeness follows from the definition of the functionality. If  $x \in L$ , the functionality will always return 1 to the R.
+
+**Soundness.** Fix  $x \notin L$ , any polynomial  $poly(\cdot)$ , and any malicious S (prover) P\* that tries to force an honest R to accept with probability  $\frac{1}{poly(k)}$ . By the security definition of 2PC, there exists a simulator  $Sim_{Sen}$  that simulates the a view of a malicious S in the ideal world.  $Sim_{Sen}$  will extract the input of S and forward it to the ideal functionality. The ideal functionality will output 1 to the honest R if and only if  $x \in L$ . By Definition,
+
+$$\{\mathsf{IDEAL}_{\mathcal{F},A\in\{\mathsf{S},\mathsf{R}\}}(x,y,n)\} \approx \{\mathsf{REAL}_{\pi,A\in\{\mathsf{S},\mathsf{R}\}}(x,y,n)\} \tag{1}$$
+
+which in particular implies that
+
+<span id="page-28-0"></span>output-ideal<sub>Rec</sub> 
+$$\approx_c$$
+ output-real<sub>Rec</sub> (2)
+
+where output-ideal<sub>Rec</sub> and output-real<sub>Rec</sub> represent the output of honest R in ideal and real world respectively. Because  $x \notin L$ ,
+
+<span id="page-28-1"></span>
+$$output - ideal_{Rec} = 0 (3)$$
+
+Equations (2) and (3) imply that
+
+$$\Pr[\mathsf{output} - \mathsf{real}_{\mathsf{Rec}} = 0] = 1 - \mathsf{negl} \tag{4}$$
+
+which concludes the proof of soundness.
+
+**Zero Knowledge.** We prove that the protocol is zero-knowledge by showing that for every malicious verifier  $V^*$ , there exists a simulator  $\mathsf{Sim}^{V^*}$ , which only takes as input x and simulates a view for  $V^*$ , which is indistinguishable from its view in the real world.  $\mathsf{Sim}^{V^*}$  runs the code of  $\mathsf{Sim}_R$  internally, forwards to  $\mathsf{Sim}_R$  the messages it received from  $V^*$ .  $\mathsf{Sim}_R$  extracts  $V^*$ 's input x' from the messages and forwards it to ideal functionality as a R. On receiving an output z from the ideal functionality,  $\mathsf{Sim}_{rec}$  outputs simulated view for the malicious R, the  $\mathsf{Sim}^{V^*}$  outputs this view as the simulated view of  $V^*$ . By Definition,
+
+<span id="page-28-2"></span>
+$$\{\mathsf{IDEAL}_{\mathcal{F},\mathsf{R}}(x,y,n) \approx \mathsf{REAL}_{\pi,\mathsf{R}}(x,y,n)\} \tag{5}$$
+
+Also by construction
+
+<span id="page-28-3"></span>
+$$\{\mathsf{IDEAL}_{\mathcal{F},\mathsf{V}^*}(x,y,n)\} = \{\mathsf{IDEAL}_{\mathcal{F},\mathsf{R}}(x,y,n)\} \tag{6}$$
+
+Moreover,  $V^*$  and R are identical in the real world, which implies that
+
+<span id="page-28-4"></span>
+$$\{\mathsf{REAL}_{\pi,\mathsf{R}}(x,y,n)\} = \{\mathsf{REAL}_{\pi,\mathsf{V}^*}(x,y,n)\}\tag{7}$$
+
+Then, equations (5), (6) and (7) imply:
+
+$$\{\mathsf{IDEAL}_{\mathcal{F},\mathsf{V}^*}(x,y,n)\} = \{\mathsf{IDEAL}_{\mathcal{F},\mathsf{R}}(x,y,n)\} \approx \{\mathsf{REAL}_{\pi,\mathsf{R}}(x,y,n)\} = \{\mathsf{REAL}_{\pi,\mathsf{V}^*}(x,y,n)\}$$
+(8)
+
+which further implies that
+
+$$\{\mathsf{IDEAL}_{\mathcal{F},\mathsf{V}^*}(x,y,n)\} \approx \{\mathsf{REAL}_{\pi,\mathsf{V}^*}(x,y,n)\} \tag{9}$$
+
+as desired. This completes the proof of zero-knowledge.

--- a/data/markdown/eprint/2020_1428/2020_1428_meta.json
+++ b/data/markdown/eprint/2020_1428/2020_1428_meta.json
@@ -1,0 +1,2199 @@
+{
+  "table_of_contents": [
+    {
+      "title": "On Statistical Security in Two-Party Computation",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          117.63099670410156,
+          111.375
+        ],
+        [
+          494.372802734375,
+          109.828125
+        ],
+        [
+          494.372802734375,
+          128.67529296875
+        ],
+        [
+          116.841796875,
+          128.67529296875
+        ]
+      ]
+    },
+    {
+      "title": "Abstract",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          287.771484375,
+          221.203125
+        ],
+        [
+          323.18023681640625,
+          221.203125
+        ],
+        [
+          323.18023681640625,
+          231.58465576171875
+        ],
+        [
+          287.771484375,
+          231.58465576171875
+        ]
+      ]
+    },
+    {
+      "title": "1 Introduction",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          71.71875,
+          522.4825134277344
+        ],
+        [
+          176.3973388671875,
+          521.296875
+        ],
+        [
+          176.3973388671875,
+          536.8287200927734
+        ],
+        [
+          71.71875,
+          536.8287200927734
+        ]
+      ]
+    },
+    {
+      "title": "1.1 Our Results",
+      "heading_level": null,
+      "page_id": 1,
+      "polygon": [
+        [
+          71.71875,
+          538.69921875
+        ],
+        [
+          164.29409790039062,
+          538.69921875
+        ],
+        [
+          164.29409790039062,
+          551.4278411865234
+        ],
+        [
+          71.71875,
+          551.4278411865234
+        ]
+      ]
+    },
+    {
+      "title": "2 Our Techniques",
+      "heading_level": null,
+      "page_id": 2,
+      "polygon": [
+        [
+          71.12109375,
+          455.5546875
+        ],
+        [
+          198.303955078125,
+          454.0078125
+        ],
+        [
+          198.303955078125,
+          470.8519287109375
+        ],
+        [
+          71.12109375,
+          471.0234375
+        ]
+      ]
+    },
+    {
+      "title": "3 Preliminaries",
+      "heading_level": null,
+      "page_id": 7,
+      "polygon": [
+        [
+          71.419921875,
+          430.017822265625
+        ],
+        [
+          181.963623046875,
+          429.2578125
+        ],
+        [
+          181.963623046875,
+          444.3640441894531
+        ],
+        [
+          71.419921875,
+          444.3640441894531
+        ]
+      ]
+    },
+    {
+      "title": "3.1 Secure Two-Party Computation",
+      "heading_level": null,
+      "page_id": 7,
+      "polygon": [
+        [
+          71.419921875,
+          495.54583740234375
+        ],
+        [
+          269.8346862792969,
+          494.2265625
+        ],
+        [
+          269.8346862792969,
+          507.50103759765625
+        ],
+        [
+          71.419921875,
+          507.50103759765625
+        ]
+      ]
+    },
+    {
+      "title": "3.2 Yao's Garbled Circuits",
+      "heading_level": null,
+      "page_id": 8,
+      "polygon": [
+        [
+          70.5,
+          677.5
+        ],
+        [
+          221.0,
+          676.37109375
+        ],
+        [
+          221.0,
+          688.5
+        ],
+        [
+          70.5,
+          688.5
+        ]
+      ]
+    },
+    {
+      "title": "3.3 Extractable Commitments",
+      "heading_level": null,
+      "page_id": 9,
+      "polygon": [
+        [
+          70.5,
+          388.265625
+        ],
+        [
+          241.0,
+          386.71875
+        ],
+        [
+          241.0,
+          397.5
+        ],
+        [
+          70.5,
+          397.546875
+        ]
+      ]
+    },
+    {
+      "title": "3.4 Zero-Knowledge Proofs and Arguments for NP",
+      "heading_level": null,
+      "page_id": 10,
+      "polygon": [
+        [
+          70.5,
+          72.31640625
+        ],
+        [
+          357.0,
+          72.31640625
+        ],
+        [
+          357.0,
+          84.5
+        ],
+        [
+          70.5,
+          84.5
+        ]
+      ]
+    },
+    {
+      "title": "3.5 Oblivious Transfer (OT)",
+      "heading_level": null,
+      "page_id": 11,
+      "polygon": [
+        [
+          70.5,
+          73.0
+        ],
+        [
+          231.0,
+          71.54296875
+        ],
+        [
+          231.0,
+          83.0
+        ],
+        [
+          70.5,
+          83.14453125
+        ]
+      ]
+    },
+    {
+      "title": "3.6 Conditional Disclosure of Secrets",
+      "heading_level": null,
+      "page_id": 11,
+      "polygon": [
+        [
+          70.5,
+          474.0
+        ],
+        [
+          282.0,
+          472.95703125
+        ],
+        [
+          282.0,
+          484.0
+        ],
+        [
+          70.5,
+          484.0
+        ]
+      ]
+    },
+    {
+      "title": "3.7 Low-Depth Proofs",
+      "heading_level": null,
+      "page_id": 12,
+      "polygon": [
+        [
+          71.71875,
+          149.66015625
+        ],
+        [
+          199.51422119140625,
+          148.11328125
+        ],
+        [
+          199.51422119140625,
+          161.78997802734375
+        ],
+        [
+          70.5234375,
+          161.78997802734375
+        ]
+      ]
+    },
+    {
+      "title": "4 2PC with One-sided Statistical Security against Explainable Parties",
+      "heading_level": null,
+      "page_id": 12,
+      "polygon": [
+        [
+          71.71875,
+          496.8089599609375
+        ],
+        [
+          530.7601318359375,
+          495.38671875
+        ],
+        [
+          530.7601318359375,
+          511.9389343261719
+        ],
+        [
+          70.5234375,
+          511.9389343261719
+        ]
+      ]
+    },
+    {
+      "title": "4.1 Construction",
+      "heading_level": null,
+      "page_id": 12,
+      "polygon": [
+        [
+          70.5234375,
+          522.45703125
+        ],
+        [
+          169.94888305664062,
+          522.45703125
+        ],
+        [
+          169.94888305664062,
+          535.9799499511719
+        ],
+        [
+          70.5234375,
+          535.9799499511719
+        ]
+      ]
+    },
+    {
+      "title": "Round 1: R does the following.",
+      "heading_level": null,
+      "page_id": 13,
+      "polygon": [
+        [
+          74.5,
+          110.21484375
+        ],
+        [
+          211.869140625,
+          110.21484375
+        ],
+        [
+          211.5,
+          120.5
+        ],
+        [
+          73.810546875,
+          120.26953125
+        ]
+      ]
+    },
+    {
+      "title": "Round 2: S does the following.",
+      "heading_level": null,
+      "page_id": 13,
+      "polygon": [
+        [
+          74.0,
+          244.40625
+        ],
+        [
+          211.5,
+          242.859375
+        ],
+        [
+          211.5,
+          254.0
+        ],
+        [
+          74.0,
+          255.234375
+        ]
+      ]
+    },
+    {
+      "title": "Round 3: R does the following.",
+      "heading_level": null,
+      "page_id": 13,
+      "polygon": [
+        [
+          74.0,
+          351.140625
+        ],
+        [
+          212.0,
+          349.59375
+        ],
+        [
+          212.0,
+          360.421875
+        ],
+        [
+          74.0,
+          361.96875
+        ]
+      ]
+    },
+    {
+      "title": "Round 4: S does the following.",
+      "heading_level": null,
+      "page_id": 13,
+      "polygon": [
+        [
+          74.0,
+          440.0859375
+        ],
+        [
+          211.5,
+          438.5390625
+        ],
+        [
+          211.5,
+          450.0
+        ],
+        [
+          74.0,
+          450.0
+        ]
+      ]
+    },
+    {
+      "title": "4.2 Analysis",
+      "heading_level": null,
+      "page_id": 13,
+      "polygon": [
+        [
+          70.0,
+          600.9609375
+        ],
+        [
+          147.0,
+          599.4140625
+        ],
+        [
+          147.0,
+          612.5
+        ],
+        [
+          70.0,
+          612.5
+        ]
+      ]
+    },
+    {
+      "title": "Round 1: Sim<sup>S*</sup> does the following.",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          84.0,
+          385.0
+        ],
+        [
+          241.0,
+          384.3984375
+        ],
+        [
+          241.0,
+          397.5
+        ],
+        [
+          84.0,
+          398.3203125
+        ]
+      ]
+    },
+    {
+      "title": "Round 3: Sim<sup>S*</sup> does the following.",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          83.970703125,
+          489.19921875
+        ],
+        [
+          240.5,
+          487.65234375
+        ],
+        [
+          240.5,
+          502.34765625
+        ],
+        [
+          83.970703125,
+          503.89453125
+        ]
+      ]
+    },
+    {
+      "title": "Round 5: Sim<sup>S*</sup> does the following.",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          83.970703125,
+          556.48828125
+        ],
+        [
+          241.0,
+          554.94140625
+        ],
+        [
+          241.0,
+          569.63671875
+        ],
+        [
+          83.970703125,
+          571.18359375
+        ]
+      ]
+    },
+    {
+      "title": "Round 2: SimR\n∗\ndoes the following.",
+      "heading_level": null,
+      "page_id": 18,
+      "polygon": [
+        [
+          75.005859375,
+          103.32745361328125
+        ],
+        [
+          231.5633544921875,
+          103.32745361328125
+        ],
+        [
+          231.5633544921875,
+          117.56494140625
+        ],
+        [
+          73.810546875,
+          117.56494140625
+        ]
+      ]
+    },
+    {
+      "title": "Round 4: SimR\n∗\ndoes the following.",
+      "heading_level": null,
+      "page_id": 18,
+      "polygon": [
+        [
+          74.70703125,
+          191.9464111328125
+        ],
+        [
+          231.5633087158203,
+          191.42578125
+        ],
+        [
+          231.5633087158203,
+          206.18389892578125
+        ],
+        [
+          74.70703125,
+          206.18389892578125
+        ]
+      ]
+    },
+    {
+      "title": "5 From Explainable to Malicious One-sided Statistical Security",
+      "heading_level": null,
+      "page_id": 18,
+      "polygon": [
+        [
+          72.0,
+          638.47265625
+        ],
+        [
+          492.7166442871094,
+          636.92578125
+        ],
+        [
+          492.7166442871094,
+          653.3959503173828
+        ],
+        [
+          72.0,
+          653.3959503173828
+        ]
+      ]
+    },
+    {
+      "title": "5.1 Construction",
+      "heading_level": null,
+      "page_id": 19,
+      "polygon": [
+        [
+          71.71875,
+          72.703125
+        ],
+        [
+          169.94894409179688,
+          71.15625
+        ],
+        [
+          169.94894409179688,
+          85.2279052734375
+        ],
+        [
+          71.71875,
+          85.2279052734375
+        ]
+      ]
+    },
+    {
+      "title": "5.2 Analysis",
+      "heading_level": null,
+      "page_id": 19,
+      "polygon": [
+        [
+          71.419921875,
+          411.46875
+        ],
+        [
+          146.70806884765625,
+          409.921875
+        ],
+        [
+          146.70806884765625,
+          423.9469299316406
+        ],
+        [
+          71.419921875,
+          423.9469299316406
+        ]
+      ]
+    },
+    {
+      "title": "Round 1: R does the following.",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          75.005859375,
+          144.94390869140625
+        ],
+        [
+          212.71035766601562,
+          143.47265625
+        ],
+        [
+          212.71035766601562,
+          155.54791259765625
+        ],
+        [
+          73.810546875,
+          155.54791259765625
+        ]
+      ]
+    },
+    {
+      "title": "Round 2: S does the following.",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          75.38699340820312,
+          221.203125
+        ],
+        [
+          211.8113250732422,
+          219.65625
+        ],
+        [
+          211.8113250732422,
+          232.513916015625
+        ],
+        [
+          74.408203125,
+          232.513916015625
+        ]
+      ]
+    },
+    {
+      "title": "Round 3: R does the following.",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          75.38691711425781,
+          298.546875
+        ],
+        [
+          212.7102508544922,
+          297.0
+        ],
+        [
+          212.7102508544922,
+          309.4788818359375
+        ],
+        [
+          74.408203125,
+          309.4788818359375
+        ]
+      ]
+    },
+    {
+      "title": "Round 4: S does the following.",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          75.005859375,
+          375.50390625
+        ],
+        [
+          211.81114196777344,
+          373.95703125
+        ],
+        [
+          211.81114196777344,
+          386.4438781738281
+        ],
+        [
+          75.005859375,
+          386.4438781738281
+        ]
+      ]
+    },
+    {
+      "title": "Round 5: R does the following.",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          75.3046875,
+          440.85101318359375
+        ],
+        [
+          212.7101287841797,
+          439.69921875
+        ],
+        [
+          212.7101287841797,
+          451.4549865722656
+        ],
+        [
+          75.3046875,
+          451.4549865722656
+        ]
+      ]
+    },
+    {
+      "title": "Round 1: Sim<sup>S*</sup> does the following.",
+      "heading_level": null,
+      "page_id": 21,
+      "polygon": [
+        [
+          74.0,
+          240.15234375
+        ],
+        [
+          230.5,
+          238.60546875
+        ],
+        [
+          230.5,
+          253.0
+        ],
+        [
+          74.0,
+          253.30078125
+        ]
+      ]
+    },
+    {
+      "title": "Round 3:",
+      "heading_level": null,
+      "page_id": 21,
+      "polygon": [
+        [
+          74.5,
+          307.828125
+        ],
+        [
+          117.0,
+          306.28125
+        ],
+        [
+          117.0,
+          316.5
+        ],
+        [
+          74.109375,
+          317.109375
+        ]
+      ]
+    },
+    {
+      "title": "Round 5:",
+      "heading_level": null,
+      "page_id": 21,
+      "polygon": [
+        [
+          74.0,
+          407.6015625
+        ],
+        [
+          117.0,
+          406.0546875
+        ],
+        [
+          117.0,
+          416.5
+        ],
+        [
+          74.0,
+          416.8828125
+        ]
+      ]
+    },
+    {
+      "title": "Round 4: Sim<sup>R*</sup> does the following.",
+      "heading_level": null,
+      "page_id": 23,
+      "polygon": [
+        [
+          74.0,
+          207.0
+        ],
+        [
+          231.5,
+          205.734375
+        ],
+        [
+          231.5,
+          219.5
+        ],
+        [
+          74.0,
+          219.65625
+        ]
+      ]
+    },
+    {
+      "title": "References",
+      "heading_level": null,
+      "page_id": 24,
+      "polygon": [
+        [
+          71.71875,
+          169.3828125
+        ],
+        [
+          143.71664428710938,
+          167.8359375
+        ],
+        [
+          143.71664428710938,
+          183.92791748046875
+        ],
+        [
+          71.71875,
+          183.92791748046875
+        ]
+      ]
+    },
+    {
+      "title": "A Lower Bound on 4 Round Secure Computation with an Unbounded\nSender",
+      "heading_level": null,
+      "page_id": 27,
+      "polygon": [
+        [
+          69.92578125,
+          293.51953125
+        ],
+        [
+          540.0018310546875,
+          293.51953125
+        ],
+        [
+          540.0018310546875,
+          327.0241394042969
+        ],
+        [
+          69.92578125,
+          327.0241394042969
+        ]
+      ]
+    }
+  ],
+  "page_stats": [
+    {
+      "page_id": 0,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          162
+        ],
+        [
+          "Line",
+          41
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "ListItem",
+          2
+        ],
+        [
+          "Footnote",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 1,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          198
+        ],
+        [
+          "Line",
+          49
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "ListItem",
+          2
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 2,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          220
+        ],
+        [
+          "Line",
+          52
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 3,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Line",
+          59
+        ],
+        [
+          "Span",
+          32
+        ],
+        [
+          "Text",
+          6
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "Footnote",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 4,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          330
+        ],
+        [
+          "Line",
+          83
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "Footnote",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 5,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Line",
+          62
+        ],
+        [
+          "Span",
+          46
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Footnote",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 6,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Line",
+          61
+        ],
+        [
+          "Span",
+          14
+        ],
+        [
+          "Text",
+          7
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "Footnote",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 7,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          358
+        ],
+        [
+          "Line",
+          50
+        ],
+        [
+          "Text",
+          7
+        ],
+        [
+          "ListItem",
+          4
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 8,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          172
+        ],
+        [
+          "Line",
+          56
+        ],
+        [
+          "Text",
+          12
+        ],
+        [
+          "Reference",
+          5
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 9,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          61
+        ],
+        [
+          "Line",
+          44
+        ],
+        [
+          "Text",
+          11
+        ],
+        [
+          "Equation",
+          7
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 10,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          81
+        ],
+        [
+          "Line",
+          61
+        ],
+        [
+          "Text",
+          15
+        ],
+        [
+          "Equation",
+          6
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "ListItem",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 11,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          106
+        ],
+        [
+          "Line",
+          56
+        ],
+        [
+          "Text",
+          12
+        ],
+        [
+          "Equation",
+          6
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 12,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          298
+        ],
+        [
+          "Line",
+          42
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "ListItem",
+          4
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 13,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          111
+        ],
+        [
+          "Line",
+          68
+        ],
+        [
+          "ListItem",
+          15
+        ],
+        [
+          "Text",
+          5
+        ],
+        [
+          "SectionHeader",
+          5
+        ],
+        [
+          "ListGroup",
+          4
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "Caption",
+          1
+        ],
+        [
+          "Footnote",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 14,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          91
+        ],
+        [
+          "Line",
+          66
+        ],
+        [
+          "ListItem",
+          11
+        ],
+        [
+          "Text",
+          7
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "ListGroup",
+          3
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "Caption",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 15,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          124
+        ],
+        [
+          "Line",
+          60
+        ],
+        [
+          "Text",
+          12
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "ListItem",
+          3
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 16,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          189
+        ],
+        [
+          "Line",
+          63
+        ],
+        [
+          "Text",
+          11
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 17,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          95
+        ],
+        [
+          "Line",
+          60
+        ],
+        [
+          "Text",
+          14
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 18,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          555
+        ],
+        [
+          "Line",
+          99
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "ListItem",
+          9
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "ListGroup",
+          2
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "Caption",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 19,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          427
+        ],
+        [
+          "Line",
+          45
+        ],
+        [
+          "Text",
+          11
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 20,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          1113
+        ],
+        [
+          "Line",
+          74
+        ],
+        [
+          "ListItem",
+          15
+        ],
+        [
+          "Text",
+          5
+        ],
+        [
+          "SectionHeader",
+          5
+        ],
+        [
+          "ListGroup",
+          5
+        ],
+        [
+          "Equation",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 21,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          96
+        ],
+        [
+          "Line",
+          63
+        ],
+        [
+          "ListItem",
+          12
+        ],
+        [
+          "Text",
+          7
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "ListGroup",
+          3
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "Caption",
+          1
+        ],
+        [
+          "Equation",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 22,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          83
+        ],
+        [
+          "Line",
+          61
+        ],
+        [
+          "Text",
+          14
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 23,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          130
+        ],
+        [
+          "Line",
+          63
+        ],
+        [
+          "Text",
+          10
+        ],
+        [
+          "ListItem",
+          9
+        ],
+        [
+          "ListGroup",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "Caption",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 24,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          195
+        ],
+        [
+          "Line",
+          44
+        ],
+        [
+          "ListItem",
+          11
+        ],
+        [
+          "Reference",
+          11
+        ],
+        [
+          "Text",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 25,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          206
+        ],
+        [
+          "Line",
+          45
+        ],
+        [
+          "ListItem",
+          15
+        ],
+        [
+          "Reference",
+          15
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 26,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          201
+        ],
+        [
+          "Line",
+          45
+        ],
+        [
+          "ListItem",
+          14
+        ],
+        [
+          "Reference",
+          14
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 27,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          325
+        ],
+        [
+          "Line",
+          46
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "Reference",
+          8
+        ],
+        [
+          "ListItem",
+          6
+        ],
+        [
+          "ListGroup",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "Equation",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 28,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          68
+        ],
+        [
+          "Line",
+          56
+        ],
+        [
+          "Text",
+          13
+        ],
+        [
+          "Equation",
+          9
+        ],
+        [
+          "Reference",
+          5
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    }
+  ],
+  "debug_data_path": "debug_data/2020_1428",
+  "eprint": {
+    "title": "On Statistical Security in Two-Party Computation",
+    "authors": [
+      {
+        "name": "Dakshita Khurana",
+        "email": "dakshita@illinois",
+        "affiliation": ""
+      },
+      {
+        "name": "Muhammad Haris Mughees",
+        "email": "edumughees2@illinois",
+        "affiliation": ""
+      }
+    ],
+    "abstract": "There has been a large body of work characterizing the round complexity of general-purpose maliciously secure two-party computation (2PC) against probabilistic polynomial time adversaries. This is particularly true for zero-knowledge, which is a special case of 2PC. In fact, in the special case of zero knowledge, optimal protocols with unconditional security against one of the two players have also been meticulously studied and constructed.\n\nOn the other hand, general-purpose maliciously secure 2PC with statistical or unconditional security against one of the two participants has remained largely unexplored so far. In this work, we initiate the study of such protocols, which we refer to as 2PC with one-sided statistical security. We settle the round complexity of 2PC with one-sided statistical security with respect to black-box simulation by obtaining the following tight results: In a setting where only one party obtains an output, we design  2PC in $4$ rounds with statistical security against receivers and computational security against senders. In a setting where both parties obtain outputs, we design 2PC in $5$ rounds with computational security against the party that obtains output first and statistical security against the party that obtains output last.\n\nKatz and Ostrovsky (CRYPTO 2004) showed that 2PC with black-box simulation requires at least $4$ rounds when one party obtains an output and $5$ rounds when both parties obtain outputs, even when only computational security is desired against both parties. Thus in these settings, not only are our results tight, but they also show that statistical security is achievable at no extra cost to round complexity. This still leaves open the question of whether 2PC can be achieved with black-box simulation in $4$ rounds with statistical security against senders and computational security against receivers.  Based on a lower bound on computational zero-knowledge proofs due to Katz (TCC 2008), we observe that the answer is negative unless the polynomial hierarchy collapses.",
+    "keywords": [
+      "Statistical security",
+      "Two-party computation"
+    ],
+    "category": "Cryptographic protocols",
+    "publication_info": "A major revision of an IACR publication in TCC 2020",
+    "last_updated": "2020-11-15",
+    "license": "CC BY",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2020_1428/conversion_info.json
+++ b/data/markdown/eprint/2020_1428/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "marker",
+  "converted_at": "2026-04-16T04:24:46.484006+00:00",
+  "elapsed_seconds": 913.93,
+  "pdf_sha256": "415e0750362f2089aca44d885ce36f031e41ffcdd8ed2ba606428bc28ffb7d74",
+  "source_pdf": "2020_1428.pdf",
+  "output_path": "2020_1428/2020_1428.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "socs-MacBook-Pro.local",
+    "os": "Darwin",
+    "os_version": "25.4.0",
+    "arch": "arm64",
+    "python_version": "3.13.11",
+    "cpu_count": 14,
+    "provider": "",
+    "gpu_count": 0,
+    "gpu_name": "",
+    "gpu_vram_mb": 0,
+    "cuda_version": ""
+  },
+  "estimated_cost_usd": null
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2020/1428

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 7177717)
Website: https://papyrus.badaas.eu