### PR TITLE
Add markdown for 2020/1411

### DIFF
--- a/data/markdown/eprint/2020_1411/2020_1411.md
+++ b/data/markdown/eprint/2020_1411/2020_1411.md
@@ -1,0 +1,580 @@
+
+
+{0}------------------------------------------------
+
+# Transparent Error Correcting in a Computationally Bounded World
+
+Ofer Grossman<sup>∗</sup> Justin Holmgren† Eylon Yogev‡ November 16, 2020
+
+#### **Abstract**
+
+We construct uniquely decodable codes against channels which are computationally bounded. Our construction requires only a public-coin (transparent) setup. All prior work for such channels either required a setup with secret keys and states, could not achieve unique decoding, or got worse rates (for a given bound on codeword corruptions). On the other hand, our construction relies on a strong cryptographic hash function with security properties that we only instantiate in the random oracle model.
+
+<sup>∗</sup>MIT, email: ofer.grossman@gmail.edu.
+
+<sup>†</sup>NTT Research, email: justin.holmgren@ntt-research.com.
+
+<sup>‡</sup>Tel Aviv University, email: eylony@gmail.com.
+
+{1}------------------------------------------------
+
+# **Contents**
+
+| 1 | Introduction                                                             |        |  |  |  |  |
+|---|--------------------------------------------------------------------------|--------|--|--|--|--|
+|   | 1.1<br>Our Contributions<br>                                             | 1      |  |  |  |  |
+|   | 1.2<br>Main Definitions and Main Theorem Statement                       | 2      |  |  |  |  |
+|   | 1.3<br>Related Work                                                      | 3      |  |  |  |  |
+| 2 | Preliminaries                                                            | 4      |  |  |  |  |
+|   | 2.1<br>Combinatorics<br>                                                 | 4      |  |  |  |  |
+|   | 2.2<br>Codes<br>                                                         | 4      |  |  |  |  |
+|   | 2.3<br>Pseudorandomness<br>                                              | 6      |  |  |  |  |
+|   | 2.3.1<br>Permutations<br>                                                | 6      |  |  |  |  |
+| 3 | Multi-input Correlation Intractability                                   |        |  |  |  |  |
+|   | 3.1<br>Multi-Input Correlation Intractability of Random Oracles<br>      | 7<br>7 |  |  |  |  |
+| 4 | Our Construction                                                         | 9      |  |  |  |  |
+|   | 4.1<br>From 2-Input Correlation Intractability to Pseudodistance         | 10     |  |  |  |  |
+|   | 4.2<br>From Efficient List Decodability to Pseudounique Decodability<br> | 11     |  |  |  |  |
+|   | 4.3<br>Main Theorem<br>                                                  | 12     |  |  |  |  |
+|   | 4.4<br>Instantiations with Known Codes                                   | 13     |  |  |  |  |
+| A | Limited Independence Tail Bound                                          | 13     |  |  |  |  |
+| B | Covering Number Bounds                                                   | 14     |  |  |  |  |
+
+{2}------------------------------------------------
+
+# <span id="page-2-0"></span>**1 Introduction**
+
+Error correcting codes (ECCs) are a tool for handling errors when transmitting messages over an unreliable communication channel. They work by first encoding the message with additional redundant information, which is then sent over the channel. This allows the recipient to recover the original encoded message, even in the presence of a limited number of errors that might occur during transmission.
+
+Since their introduction in the 1950s, error correcting codes [\[Ham50\]](#page-16-0) have been a thriving research area due to their role both in practical applications and in theoretical computer science. One of the central open questions concerns the exact tradeoff between a code's *rate* (message length divided by codeword length) and the code's *error tolerance* (the number of errors that its decoding algorithm can tolerate). There are several known fundamental bounds (e.g. the Hamming, Singleton, and Plotkin bounds) on the maximum rate of a code in terms of its distance, and state of the art codes (especially over small alphabets) often only achieve significantly lower rates.
+
+To achieve better rates, two major relaxations of error correction have been proposed. In the first, called *list decoding* [\[Eli57,](#page-16-1) [Woz58\]](#page-17-0), a decoding algorithm is no longer required to output the originally encoded message, but may instead output a short *list* of messages which is required to *contain* the original message. In this work, we will focus on standard (unique) decoding, but we will use list-decodable codes as a central building block.
+
+In the second relaxation, the communication channel between the sender and receiver is assumed to be restricted in some way. In other words, the code is no longer required to handle fully worst-case errors. The most relevant model for us is the *computationally bounded channel* [\[Lip94\]](#page-16-2), which loosely speaking, models codeword errors as generated by a *polynomial-time* process.
+
+Lipton [\[Lip94\]](#page-16-2) and Micali et al. [\[MPSW10\]](#page-17-1) construct codes for the computationally bounded channel with better rates than are achievable by codes for worst-case errors, but their codes require a trusted setup. Specifically, the encoding algorithms for their codes (and in the case of [\[Lip94\]](#page-16-2), also the decoding algorithm) require a secret key that, if leaked, allows an efficient channel to thwart the decoding algorithm with a relatively small number of corruptions. Secret randomness is much more difficult to instantiate than public randomness (also known as transparent), which leads us to ask:
+
+*Are there "good" uniquely decodable codes for the computationally bounded channel with transparent setup?*
+
+An additional drawback of the constructions of [\[Lip94\]](#page-16-2) and [\[MPSW10\]](#page-17-1) is that they require a *stateful* encoder, which may render them unsuitable for use in data storage or in applications requiring concurrent transmission of multiple messages. In [\[Lip94\]](#page-16-2), it is essential for security that the encoder's state never repeats, and essential for correctness that the decoder's state is synchronized with the encoder's state. In [\[MPSW10\]](#page-17-1), the decoder is stateless, but it is essential for security that errors are chosen in an online fashion. In other words, there are no guarantees if a codeword is corrupted after seeing a codeword ′ that was encoded after . This exemplifies the undesirable dependence, induced by the encoder's statefulness, of the code's error tolerance on the precise environment in which it is used. Thus we ask:
+
+*Are there "good" uniquely decodable codes for the computationally bounded channel with a stateless encoder?*
+
+## <span id="page-2-1"></span>**1.1 Our Contributions**
+
+We answer both questions affirmatively, constructing a code for computationally bounded channels (with transparent setup *and* stateless encoding) that outperforms codes for worst-case errors. As a contribution that may be of independent interest, we also construct codes with high "pseudodistance", i.e., codes for which it is hard to find two codewords that are close in Hamming distance.
+
+**Pseudounique Decoding.** The main goal of an error correcting code is to facilitate the recovery of a transmitted message given a partially corrupted copy of (). To formalize this (in the informationtheoretic setting), a polynomial-time algorithm is said to be a *unique decoding algorithm for against* 
+
+{3}------------------------------------------------
+
+ $\rho$  errors if for all messages m and all strings c' that are  $\rho$ -close in Hamming distance to C(m), we have D(c') = m.
+
+In reality, messages and noise are created by nature, which can be conservatively modeled as a computationally bounded adversary. We thus relax the above for all quantification and only require efficient decoding when both m and c' are chosen by a computationally bounded process. Our codes will be described by a randomly generated seed that is used in the encoding and decoding procedures. In other words, we will work with a seeded family of codes  $\{C_{pp}\}$ , where pp is the seed, which we will also refer to as the public parameters for the code. In our constructions, the public parameters are merely unstructured uniformly random strings of a certain length.
+
+More formally, we say that a polynomial-time algorithm D is a pseudounique decoding algorithm for  $\{C_{pp}\}$  against  $\rho$  errors if no polynomial-time adversary A can win the following game with noticeable probability. The public parameters pp are first sampled uniformly at random and given to A. The adversary then produces a message m and a string c', and is said to win if c' is  $\rho$ -close to  $C_{pp}(m)$  and  $D(pp, c') \neq m$ .
+
+Under cryptographic assumptions (or in the random oracle model), we construct codes with pseudounique decoding algorithms for a larger fraction of errors than is possible in the standard setting. Our main theorem requires a "good" cryptographic hash function (which is used as a black box), where we defer the formalization of the necessary security requirements to Section 3. For now, we simply mention that it is a *multi-input* generalization of correlation intractability, and in Section 3 we show that it can be instantiated by a (non-programmable) random oracle. The precise statement and details about the construction appear in Section 4.
+
+**Informal Theorem 1.1.** For any  $r \in (0,1)$  and any  $\rho < \min(1-r,\frac{1}{2})$  there exist rate-r codes, over large (polynomial-sized) alphabets, that are efficiently pseudouniquely decodable against up to a  $\rho$  fraction of errors, assuming good hash functions exist (or in the random oracle model).
+
+This should be contrasted with the Singleton bound, which rules out (standard) unique decoding for more than  $\min(\frac{1-r}{2}, \frac{1}{2})$  errors. Our positive result is a corollary of a more general connection to efficient list-decodability, which we prove in Section 4. This connection also implies results over binary alphabets, albeit with bounds that are harder to state (see Corollary 4.11) because known binary codes do not achieve list-decoding capacity and instead have messy rate vs. error correction tradeoffs.
+
+**Pseudodistance.** Our second notion is an analogue of distance. Recall that a code C is said to have distance d if for all pairs of distinct messages  $m_0$ ,  $m_1$ , their encodings  $C(m_0)$  and  $C(m_1)$  have Hamming distance d. We can similarly replace this for all quantifier and only require  $C_{pp}(m_0)$  and  $C_{pp}(m_1)$  to be far for pairs  $m_0$ ,  $m_1$  that are computed from pp by a computationally bounded adversary.
+
+We note that a code's pseudodistance may be arbitrarily high without implying anything about its decodability, even by an inefficient algorithm. It is instructive to imagine a rate-1 code whose encoding algorithm is given by a (sufficiently obfuscated) random permutation mapping  $\{0,1\}^n \to \{0,1\}^n$ . The pseudodistance of this code will be roughly n/2, but it is information theoretically impossible to decode in the presence of even a single error.
+
+Still, pseudodistance is a useful intermediate notion for us in the construction of pseudouniquely decodable codes, and the notion may be of independent interest.
+
+#### <span id="page-3-0"></span>1.2 Main Definitions and Main Theorem Statement
+
+The preceding discussion is formalized in the following definitions.
+
+**Definition 1.2.** A seeded code with alphabet size  $q(\cdot)$  is a pair  $\mathcal{C} = (\mathsf{Setup}, \mathsf{Enc})$  of polynomial-time algorithms with the following syntax:
+
+- Setup is probabilistic, takes a domain length  $k \in \mathbb{Z}^+$  (in unary), and outputs public parameters pp.
+- Enc is deterministic, takes parameters pp and a message  $m \in \{0,1\}^k$ , and outputs a codeword  $c \in [q(k)]^{n(k)}$ , where  $n(\cdot)$  is called the length of C.
+
+{4}------------------------------------------------
+
+*When* lim→∞ () log<sup>2</sup> () ∈ [0*,* 1] *is well-defined it is called the* rate *of . If* Setup *simply outputs a uniformly random binary string of some length that depends on , then we say that is* public-coin*.*
+
+**Definition 1.3.** *A seeded code* = (Setup*,* Enc) *is said to have* (︀ (·)*,* (·) )︀ -pseudodistance (·) *if for all size-*(·) *circuit ensembles* {}∈Z<sup>+</sup> *, we have*
+
+$$\Pr_{\substack{\mathsf{pp} \leftarrow \mathsf{Setup}(1^k) \\ (m_0, m_1) \leftarrow \mathcal{A}_k(\mathsf{pp})}} \left[ \Delta \left( \mathsf{Enc}(\mathsf{pp}, m_0), \mathsf{Enc}(\mathsf{pp}, m_1) \right) < d \right] \leq \epsilon(k),$$
+
+*where* Δ(·*,* ·) *denotes the (absolute) Hamming distance.*
+
+*is said simply to have* pseudodistance (·) *if for all* () ≤ (1)*, there exists* () ≤ <sup>−</sup>(1) *such that has* (*,* )*-pseudodistance .*
+
+**Definition 1.4.** *An algorithm* Dec *is said to be an* (︀ (·)*,* (·) )︀ -pseudounique decoder for = (Setup*,* Enc) against (·) errors *if for all size-*(·) *circuit ensembles* {}∈Z<sup>+</sup>
+
+$$\Pr_{\substack{\mathsf{pp} \leftarrow \mathsf{Setup}(1^k) \\ (m,c) \leftarrow \mathcal{A}_k(\mathsf{pp})}} \left[ \Delta \left( c, \mathsf{Enc}(\mathsf{pp},m) \right) \leq d(k) \ \land \ \mathsf{Dec}(\mathsf{pp},c) \neq m \right] \leq \epsilon(k).$$
+
+*We say that is* efficiently (︀ (·)*,* (·) )︀ -pseudouniquely decodable against (·) errors *if there is a* polynomialtime *algorithm* Dec *that is an* (︀ (·)*,* (·) )︀ *-pseudounique decoder for . We omit and in usage of the above definitions when for all* () ≤ (1)*, there exists* () ≤ <sup>−</sup>(1) *such that the definition is satisfied.*
+
+*We sometimes say a "* fraction of errors*" to refer to some* () *such that* lim→∞ () () = *, where* (·) *is the length of .*
+
+As in the previous theorem, we assume the existence of random-like hash functions to obtain our result. These hash functions can be instantiated in the random oracle model.
+
+<span id="page-4-1"></span>**Informal Theorem 1.5.** *If* { : {0*,* 1} → [] } *is a rate- ensemble of codes that is efficiently listdecodable against a fraction of errors, and if good hash functions exist, then there exists a rate- seeded code that is efficiently pseudouniquely decodable against a* min (︂ *,* −<sup>1</sup> (︀ +() )︀ 2 )︂ *fraction of errors.*
+
+The above bound has a nice interpretation when approaches capacity, i.e. when + () ≈ 1. Then −<sup>1</sup> (+()) <sup>2</sup> ≈ 1 2 · (︀ 1 − 1 )︀ , which upper bounds the pseudo-unique decodability of any positive-rate code (implied by the proof of the Plotkin bound, and made explicit in [\[MPSW10\]](#page-17-1)). So if achieves capacity, Informal Theorem [1.5](#page-4-1) says that one can uniquely decode up to the (efficient) list-decoding radius of , as long as that doesn't exceed <sup>1</sup> 2 · (︀ 1 − 1 )︀ .
+
+# <span id="page-4-0"></span>**1.3 Related Work**
+
+The notion of a computationally bounded channel was first studied by Lipton [\[Lip94\]](#page-16-2), and has subsequently been studied in a variety of coding theory settings including local decodability, local correctability, and list decoding, with channels that are bounded either in time complexity or space complexity [\[DGL04,](#page-16-3) [GS16,](#page-16-4) [BGGZ19,](#page-15-1) [MPSW10,](#page-17-1) [SS16,](#page-17-2) [HOSW11,](#page-16-5) [HO08,](#page-16-6) [OPS07\]](#page-17-3). We compare some of these works in Table [1.](#page-6-0) Focusing on unique decoding against polynomial-time computationally bounded errors, the work most relevant to us is [\[MPSW10\]](#page-17-1), improving on [\[Lip94\]](#page-16-2).
+
+Lipton [\[Lip94\]](#page-16-2) showed that assuming one-way functions, any code that is (efficiently) uniquely decodable against *random* errors can be upgraded to a "secret-key, stateful code" that is (efficiently) uniquely decodable against any errors that are computed in polynomial time. Using known results on codes for random errors, this gives rate- (large alphabet) codes that are uniquely decodable against a 1 − fraction of errors. However, these codes require the sender and receiver to share a secret key, and to be stateful (incrementing a counter for each message sent / received).
+
+{5}------------------------------------------------
+
+Micali et al. [MPSW10] improve on this result, obtaining a coding scheme where only the sender needs a secret key (the receiver only needs a corresponding public key), and only the sender needs to maintain a counter. They show that these limitations are inherent in the high-error regime; namely, it is impossible to uniquely decode beyond error rates 1/4 (in the binary case) and more generally  $\frac{1}{2} \cdot (1 - \frac{1}{q})$  over q-ary alphabets, even if the errors are computationally bounded. Compared to [Lip94], [MPSW10] starts with codes that are efficiently list decodable, rather than codes that are uniquely decodable against random errors. The crux of their technique is using cryptographic signatures to "sieve" out all but one of the candidate messages returned by a list-decoding algorithm. Our construction also uses list decodability in a similar way. The key difference is that we use a different sieving mechanism that is stateless and transparent (i.e., the only setup is a public uniformly random string), but is only applicable for error rates below  $\frac{1}{2} \cdot (1 - \frac{1}{q})$ .
+
+Our work improves over [MPSW10] in the amount of setup required for the code. In [MPSW10], the sender must initially create a secret key and share the corresponding public key with the receiver (and the adversarial channel is also allowed to depend on the public key). In contrast, our code allows anyone to send messages—no secret key is needed. This property may be useful in applications such as Wi-Fi and cellular networks, where many parties need to communicate.
+
+Another important difference between [MPSW10] and our work is that in [MPSW10], the sender is stateful. That is, whenever the sender sends a message, he updates some internal state which affects the way the next message will be encoded. We do not make such an assumption. Note that in some situations, maintaining a state may not be possible. For example, if there are multiple senders (or a single sender who is operating several servers in different locations), it is unclear how to collectively maintain state. Whenever one of the senders sends a message, he must inform all the other senders so they can update their state accordingly, which may not be possible, or significantly slow down communication. Moreover, the guarantees of [MPSW10] only apply to adversaries that operate in a totally "online" fashion. The error tolerance guarantees break down if an adversary is able to corrupt a codeword after seeing a subsequently encoded message. In our construction, the sender and receiver are both stateless, so these issues do not arise.
+
+One drawback of our construction compared to [MPSW10] is that our construction is not applicable in the high-error regime (error rates above 1/4 for binary codes or 1/2 for large alphabet codes). However, over large alphabets we match the performance of [MPSW10] for all error rates below 1/2.
+
+## <span id="page-5-0"></span>2 Preliminaries
+
+## <span id="page-5-1"></span>2.1 Combinatorics
+
+**Definition 2.1.** The  $i^{th}$  falling factorial of  $n \in \mathbb{R}$  is  $(n)_i \stackrel{\mathsf{def}}{=} n \cdot (n-1) \cdots (n-i+1)$ .
+
+**Definition 2.2.** The q-ary entropy function  $H_q:[0,1] \to [0,1]$  is defined as
+
+$$H_q(x) \stackrel{\text{def}}{=} x \log_q(q-1) - x \log_q x - (1-x) \log_q(1-x).$$
+
+We write  $H_{\infty}(x)$  to denote  $\lim_{q\to\infty} H_q(x)$ , which is equal to x. If we write H(x), omitting the subscript, we mean  $H_2(x)$  by default.
+
+**Definition 2.3.** For any alphabet  $\Sigma$ , any n, and any  $u,v\in\Sigma^n$ , the Hamming distance between u and v, denoted  $\Delta(u,v)$ , is
+
+$$\Delta(u,v) \stackrel{\mathsf{def}}{=} \Big| \big\{ i \in [n] : u_i \neq v_i \big\} \Big|.$$
+
+When  $\Delta(u,v) \leq \delta n$ , we write  $u \approx_{\delta} v$ . If S is a set, we write  $\Delta(u,S)$  to denote  $\min_{v \in S} \Delta(u,v)$ .
+
+### <span id="page-5-2"></span>2.2 Codes
+
+**Definition 2.4.** A deterministic q-ary code is a function  $C:[K] \to [q]^n$ , where n is called the block length of C, [K] is called the message space, and [q] is called the alphabet. The distance of C is the minimum
+
+{6}------------------------------------------------
+
+<span id="page-6-0"></span>
+
+| work       | setup                           | noise             | decoding                | rate                                             | notes/assumptions                           |
+|------------|---------------------------------|-------------------|-------------------------|--------------------------------------------------|---------------------------------------------|
+| This paper | URS                             | P/poly            | unique                  | arbitrarily close to 1−<br>𝑝 for large alphabets | two-input<br>correlation<br>intractablility |
+| [GS16]     | URS                             | 𝑐<br>SIZE(𝑛<br>)  | list                    | arbitrarily close to 1−<br>𝐻(𝑝)                  | no assumptions                              |
+| [SS16]     | none                            | 𝑐<br>SIZE(𝑛<br>)  | list                    | arbitrarily close to 1−<br>𝐻(𝑝)                  | PRGs for small circuits                     |
+| [SS20]     | none                            | 𝛿<br>SPACE(𝑛<br>) | unique                  | arbitrarily close to 1−<br>𝐻(𝑝)                  | none                                        |
+| [MPSW10]   | public key                      | P/poly            | unique                  | matches list decoding<br>radius                  | stateful sender and one<br>way functions    |
+| [OPS07]    | private<br>shared<br>randomness | P/poly            | local                   | Ω(1)<br>(for<br>error<br>rate<br>Ω(1))           | one-way functions                           |
+| [HOSW11]   | public key                      | P/poly            | local                   | Ω(1)<br>(for<br>error<br>rate<br>Ω(1))           | public-key encryption                       |
+| [BGGZ19]   | URS                             | P/poly            | local<br>cor<br>rection | Ω(1)<br>(for<br>error<br>rate<br>Ω(1))           | collision-resistant<br>hash<br>function     |
+| [Lip94]    | private<br>shared<br>randomness | P/poly            | unique                  | matches BSC channel                              | stateful sender and one<br>way functions    |
+
+Table 1: Summary of related work. The column "message" refers to how the message are generated. The column "noise" describes the computational power of the adversary adding noise. URS stands for uniform random string (shared publicly between the sender, receiver, and adversary), BSC for binary symmetric channel, and PRG for pseudorandom generator.
+
+*Hamming distance between* () *and* (′ ) *for distinct ,* ′ ∈ []*. A* probabilistic -ary code *of block length and message space* [] *is a randomized function* : [] \$ → [] *.*
+
+When discussing the asymptotic performance of (deterministic or probabilistic) codes, it makes sense to consider ensembles of codes { : [ ] → [ ] } with varying message spaces, block lengths, and alphabet sizes. We will assume several restrictions on , , and that rule out various pathologies. Specifically, we will assume that:
+
+- , , and increase weakly monotonically with and are computable from in polynomial time (i.e. in time polylog()).
+- is at most polylog().
+- There is a polynomial-time algorithm that given (*,* ) for ∈ [ ] outputs ().
+- The limit = lim→∞ log ·log exists with ∈ (0*,* 1). We call the rate of the ensemble.
+- lim sup→∞ log +1 log = 1. This is important so that the cost of padding (to encode arbitrary-length messages) is insignificant.
+
+One implication of these restrictions is that without loss of generality we can assume that {}∈Z<sup>+</sup> = {︀ 2 }︀ ∈Z<sup>+</sup> and we can index our codes by rather than by .
+
+{7}------------------------------------------------
+
+**Definition 2.5.** We say that an ensemble of codes  $\{C_k : \{0,1\}^k \to [q_k]^{n_k}\}_{k \in \mathbb{Z}^+}$  is combinatorially  $\rho$ -list decodable if for any  $y \in [q_k]^{n_k}$ , there are at most  $\operatorname{poly}(k)$  values of  $m \in \{0,1\}^k$  for which  $C_k(m) \approx_{\rho} y$ . If there is a polynomial-time algorithm that outputs all such m given y (and  $1^k$ ), we say that  $\{C_k\}$  is efficiently  $\rho$ -list decodable.
+
+## <span id="page-7-0"></span>2.3 Pseudorandomness
+
+**Definition 2.6.** Random variables  $X_1, \ldots, X_n$  are said to be t-wise independent if for any set  $S \subseteq [n]$  with size |S| = t, the random variables  $\{X_i\}_{i \in S}$  are mutually independent.
+
+**Definition 2.7.** Discrete random variables  $X_1, \ldots, X_n$  are said to be t-wise  $\beta$ -dependent in Rényi  $\infty$ -divergence if for all sets  $S \subseteq [n]$  of size |S| = t, it holds for all  $(x_i)_{i \in S}$  that
+
+$$\Pr\left[\bigwedge_{i\in S} X_i = x_i\right] \le \beta \cdot \prod_{i\in S} \Pr[X_i = x_i].$$
+
+### <span id="page-7-1"></span>2.3.1 Permutations
+
+If X is a finite set, we write  $S_X$  to denote the set of all permutations of X.
+
+<span id="page-7-2"></span>**Definition 2.8.** A family of permutations  $\Pi \subseteq S_X$  is said to be t-wise  $\epsilon$ -dependent if for all distinct  $x_1, \ldots, x_t \in X$ , the distribution of  $(\pi(x_1), \ldots, \pi(x_t))$  for uniformly random  $\pi \leftarrow \Pi$  is  $\epsilon$ -close in statistical distance to uniform on  $\{(y_1, \ldots, y_t) : y_1, \ldots, y_t \text{ are distinct.}\}$ 
+
+To avoid pathological issues regarding the domains of permutation families (e.g. their sampleability, decidability, and compressability), we will restrict our attention to permutations on sets of the form  $\{0,1\}^k$  for  $k \in \mathbb{Z}^+$ .
+
+**Definition 2.9.** We say that an ensemble  $\{\Pi_k \subseteq S_{\{0,1\}^k}\}_{k \in \mathbb{Z}^+}$  of permutation families is fully explicit if there are  $\operatorname{poly}(k)$ -time algorithms for:
+
+- sampling a description of  $\pi \leftarrow \Pi_k$ ; and
+- computing  $\pi(x)$  and  $\pi^{-1}(x)$  given x and a description of  $\pi \in \Pi_k$ .
+
+<span id="page-7-3"></span>**Imported Theorem 2.10** ([KNR09]). For any  $t = t(k) \le k^{O(1)}$ , and any  $\epsilon = \epsilon(k) \ge 2^{-k^{O(1)}}$ , there is a fully explicit t-wise  $\epsilon$ -dependent ensemble  $\{\Pi_k \subseteq S_{\{0,1\}^k}\}_{k \in \mathbb{Z}^+}$  of permutation families.
+
+The following non-standard variation on the notion of t-wise almost-independence will prove to be more convenient for us.
+
+**Definition 2.11.** A probability distribution P is said to be  $\beta$ -close in Rényi  $\infty$ -divergence to a distribution Q if for all x,  $P(x) \leq \beta \cdot Q(x)$ .
+
+**Definition 2.12.** We say that a family  $\Pi \subseteq S_X$  is t-wise  $\beta$ -dependent in Rényi  $\infty$ -divergence if for all distinct  $x_1, \ldots, x_t \in X$ , the distribution of  $(\pi(x_1), \ldots, \pi(x_t))$  is  $\beta$ -close in Rényi  $\infty$ -divergence to the uniform distribution on  $X^t$ .
+
+It is easily verified that any family of permutations  $\Pi \subseteq S_{[K]}$  that is t-wise  $\epsilon$ -dependent as in Definition 2.8 is also t-wise  $\beta$ -dependent in Rényi  $\infty$ -divergence with  $\beta = \epsilon \cdot K^t + \frac{K^t}{(K)_t}$ . Thus Imported Theorem 2.10 gives us the following.
+
+Corollary 2.13. For any  $t = t(k) \le k^{O(1)}$ , there is a fully explicit t-wise O(1)-dependent (in Rényi  $\infty$ -divergence) ensemble  $\{\Pi_k \subseteq S_{\{0,1\}^k}\}_{k \in \mathbb{Z}^+}$  of permutation families.
+
+{8}------------------------------------------------
+
+## <span id="page-8-0"></span>3 Multi-input Correlation Intractability
+
+Correlation intractability was introduced by Canetti, Goldreich, and Halevi [CGH04] as a way to model a large class of random oracle-like security properties of hash functions. Roughly speaking, H is said to be correlation intractable if for any sparse relation R it is hard to find x such that  $(x, H(x)) \in R$ . In recent years, CI hash functions have been under the spotlight with surprising results on instantiating CI hash families from concrete computational assumptions (e.g., [CCR16, KRR17, HL18, CCRR18, CCH<sup>+</sup>19, PS19]).
+
+In this work, we need a stronger multi-input variant of correlation intractability. Several notions of multi-input correlation intractability were put forth by [CGH04] and shown to be impossible. Subsequently [HL18, LV20] gave constructions of hash functions that, under ostensibly unrelated cryptographic assumptions, achieve weak forms of multi-input correlation intractability that are insufficient for our applications. We give a notion of multi-input correlation intractability that is plausibly achievable, and we prove that a random oracle achieves this notion. We do not provide an instantiation from any simple, let alone standard, cryptographic assumption.
+
+**Definition 3.1** (Multi-Input Relations). For sets  $\mathcal{X}$  and  $\mathcal{Y}$ , an  $\ell$ -input relation on  $(\mathcal{X}, \mathcal{Y})$  is a subset  $R \subseteq \mathcal{X}^{\ell} \times \mathcal{Y}^{\ell}$ .
+
+We say that R is p-sparse if for all  $i \in [\ell]$ , all distinct  $x_1, \ldots, x_\ell \in \mathcal{X}$ , and all  $y_1, \ldots, y_{i-1}, y_{i+1}, \ldots, y_\ell \in \mathcal{Y}$ , we have
+
+$$\Pr_{y_i \leftarrow \mathcal{Y}} \left[ (x_1, \dots, x_\ell, y_1, \dots, y_\ell) \in R \right] \le p.$$
+
+An ensemble of  $\ell$ -input relations  $\{R_{\lambda}\}_{{\lambda}\in\mathbb{Z}^+}$  is said simply to be sparse if there is a negligible function  $p\colon\mathbb{Z}^+\to\mathbb{R}$  such that each  $R_{\lambda}$  is  $p(\lambda)$ -sparse.
+
+Remark 3.2. A natural but flawed generalization of single-input sparsity for an  $\ell$ -input relation R might instead require that for all  $x_1, \ldots, x_\ell$ , it holds with overwhelming probability over a uniform choice of  $y_1, \ldots, y_\ell$  that  $(x_1, \ldots, x_\ell, y_1, \ldots, y_\ell) \notin R$ . Unfortunately this definition does not account for an adversary's ability to choose some  $x_i$  adaptively. Indeed, even a random oracle would not be 2-input correlation intractable under this definition for the relation  $\{(x_1, x_2, y_1, y_2) : x_2 = y_1\}$ , which does satisfy the aforementioned "sparsity" property.
+
+<span id="page-8-2"></span>**Definition 3.3** (Multi-Input Correlation Intractability). An ensemble  $\mathcal{H} = \{\mathcal{H}_{\lambda}\}_{{\lambda} \in \mathbb{Z}^+}$  of function families  $\mathcal{H}_{\lambda} = \{H_k : \mathcal{X}_{\lambda} \to \mathcal{Y}_{\lambda}\}_{k \in \mathcal{K}_{\lambda}}$  is  $\ell$ -input  $(s(\cdot), \epsilon(\cdot))$ -correlation intractable for a relation ensemble  $\{R_{\lambda} \subseteq \mathcal{X}_{\lambda}^{\ell} \times \mathcal{Y}_{\lambda}^{\ell}\}$  if for every size- $s(\lambda)$  adversary  $\mathcal{A}$ :
+
+$$\Pr_{\substack{k \leftarrow \mathcal{K}_{\lambda} \\ (x_{1}, \dots, x_{\ell}) \leftarrow \mathcal{A}(k)}} \left[ \left( x_{1}, \dots, x_{\ell}, H_{k}(x_{1}), \dots, H_{k}(x_{\ell}) \right) \in R_{\lambda} \right] \leq \epsilon(\lambda).$$
+
+## <span id="page-8-1"></span>3.1 Multi-Input Correlation Intractability of Random Oracles
+
+We show that a random oracle is  $\ell$ -input correlation intractable as in Definition 3.3.
+
+**Theorem 3.4.** Let F be a uniformly random function mapping  $\mathcal{X} \to \mathcal{Y}$ , and let  $\ell \in \mathbb{Z}^+$  be a constant. Then, for any p-sparse  $\ell$ -distinct-input relation R on  $(\mathcal{X}, \mathcal{Y})$ , and any T-query oracle algorithm  $\mathcal{A}^{(\cdot)}$ , we have
+
+$$\Pr\left[\mathcal{A}^F \ outputs \ (x_1, \dots, x_\ell) \in \mathcal{X}^\ell \ s.t. \ \left(x_1, \dots, x_\ell, F(x_1), \dots, F(x_\ell)\right) \in R\right] \leq p \cdot (T)_\ell \leq p \cdot T^\ell.$$
+
+**Proof overview.** We give an overview of the proof which should give some intuition as to why get the expression  $p \cdot T^{\ell}$ . Fix a set of elements  $x_1, \ldots, x_{\ell}$  then the probability, over the random oracle, that these elements will be in the relation with respect with the random oracle is at most p, which follows from the definition of sparsity. However, for a longer list of elements of length, we would need to take into account all the possible tuples of size  $\ell$  in that list, and apply a union bound. Since the number of queries is bounded by T, we get that the probability is at most  $p \cdot T^{\ell}$ .
+
+{9}------------------------------------------------
+
+The above arguments work for a *fixed* list of elements, and gives intuition for the probability expression achieved in the theorem. However, an oracle algorithm is allowed to perform *adaptive* queries where the next query might depend on the result of the random oracle for previous queries. This makes the proof more challenging and, in particular, much more technical.
+
+*Proof.* We begin the proof by stating a few assumptions about the algorithm , and observe that these assumption hold without loss of generality:
+
+- is deterministic;
+- never makes repeated queries to nor does output non-distinct 1*, . . . , ℓ*; and
+- If at any point has made queries 1*, . . . ,*  and received answers 1*, . . . ,*  such that for some 1*, . . . ,*  ∈ [] *ℓ* the tuple (<sup>1</sup> *, . . . , <sup>ℓ</sup> ,* 1*, , . . . , <sup>ℓ</sup>* ) is in , then immediately outputs one such tuple (without making any further queries).
+
+We denote the random variables representing the various queries of the algorithm , and their responses from the oracle. Let be a random variable denoting the number of queries made by , let 1*, . . . ,*  denote the queries made by to , let 1*, . . . ,*  denote the corresponding evaluations of , let denote {1*, . . . ,* }, let 1*, . . . , <sup>ℓ</sup>* denote the output of , and let 1*, . . . , <sup>ℓ</sup>* denote the corresponding evaluations of .
+
+We split our analysis into two cases: either (1*, . . . , ℓ*) ∈ , or not, meaning that the algorithm did not query all of the *ℓ* elements it outputs. We argue about each case separately and at the end combine to the two to a single argument. We begin with the second case.
+
+**Claim 3.5.** *For any algorithm it holds that*
+
+$$\Pr\left[(X_1,\ldots,X_\ell,Y_1,\ldots,Y_\ell)\in R\mid (X_1,\ldots,X_\ell)\notin\mathcal{Q}^\ell\right]\leq p\cdot\ell.$$
+
+*where the probability is over the random oracle.*
+
+**Proof sketch.** There exists some component of 's output whose image under is independent of 's view, and thus is uniformly random. Since is -sparse, this ensures that (1*, . . . , ℓ,* 1*, . . . , ℓ*) is in with probability at most .
+
+*Proof.* Fix any ∈ [*ℓ*] and any (1*, . . . , ℓ,* 1*, . . . ,* −1*,* +1*, . . . , ℓ*). Since the relation is -sparse, we know that
+
+$$\Pr[(q_1, \dots, q_\ell, a_1, \dots, a_{i-1}, Y_i, a_{i+1}, \dots, a_\ell) \in R] \le p$$
+.
+
+Thus, we can write:
+
+$$\Pr\left[(X_{1},\ldots,X_{\ell},Y_{1},\ldots,Y_{\ell})\in R \mid (X_{1},\ldots,X_{\ell})\notin\mathcal{Q}^{\ell}\right]$$
+
+$$\leq \sum_{i\in[\ell]} \Pr\left[(X_{1},\ldots,X_{\ell},Y_{1},\ldots,Y_{\ell})\in R \mid X_{i}\in\mathcal{Q}\right] \cdot \Pr\left[X_{i}\notin\mathcal{Q}\right]$$
+
+$$\leq \sum_{i\in[\ell]} \sum_{\substack{a_{1},\ldots,a_{i-1},a_{i+1},\ldots,a_{\ell}\\a_{1},\ldots,a_{i-1},a_{i+1},\ldots,a_{\ell}}} \Pr\left[(q_{1},\ldots,q_{\ell},a_{1},\ldots,a_{i-1},Y_{i},a_{i+1},\ldots,a_{\ell})\in R\right] \cdot$$
+
+$$\Pr\left[\forall j\neq i:X_{j}=q_{j},Y_{j}=a_{j},X_{i}=a_{i}\right] \cdot \Pr\left[X_{i}\notin\mathcal{Q}\right]$$
+
+$$\leq p \cdot \sum_{i\in[\ell]} \Pr\left[X_{i}\notin\mathcal{Q}\right] \cdot \sum_{\substack{a_{1},\ldots,a_{i-1},a_{i+1},\ldots,a_{\ell}\\a_{1},\ldots,a_{\ell}=1,a_{\ell+1},\ldots,a_{\ell}}} \Pr\left[\forall j\neq i:X_{j}=q_{j},Y_{j}=a_{j},X_{i}=a_{i}\right]$$
+
+$$\leq p \cdot \sum_{i\in[\ell]} \Pr\left[X_{i}\notin\mathcal{Q}\right] \leq p \cdot \ell .$$
+
+8
+
+{10}------------------------------------------------
+
+We turn to prove the first case, where all the elements in the algorithm's output where queried. This case is where we pay the  $p \cdot T^k$  in the probability.
+
+Claim 3.6. For any T-query algorithm A it holds that:
+
+$$\Pr\left[(X_1,\ldots,X_\ell,Y_1,\ldots,Y_\ell)\in R\mid (X_1,\ldots,X_\ell)\in\mathcal{Q}^\ell\right]\leq p\cdot T^k.$$
+
+*Proof.* For any  $m \in [T]$ , let  $Z_m$  be an indicator random variable to the event that the  $m^{th}$  query of the algorithm  $\mathcal{A}$  along with some  $\ell-1$  previous queries form an instance in the relation. Formally, we define:
+
+$$Z_m = \begin{cases} 1 & \text{if } \exists i_1, \dots, i_\ell \in [m] \text{ such that } (Q_{i_1}, \dots, Q_{i_\ell}, A_{i_1}, \dots, A_{i_{\ell-1}}, A_m) \in R \text{ and } m \in \{i_1, \dots, i_\ell\} \\ 0 & \text{otherwise} \end{cases}$$
+
+Observe that using this notation, we have that if the event  $(X_1, \ldots, X_\ell, Y_1, \ldots, Y_\ell) \in R$  implies that there exist an  $m \in [T]$  such that  $Z_m = 1$ . Using the fact that R is p-sparse, we bound  $\Pr[Z_m = 1]$ , for any  $m \in [T]$  as follows:
+
+$$\Pr[Z_{m}] = 1 = \Pr[\exists i_{1}, \dots, i_{\ell} \in [m] \text{ such that } (Q_{i_{1}}, \dots, Q_{i_{\ell}}, A_{i_{1}}, \dots, A_{i_{\ell}}) \in R \text{ and } m \in \{i_{1}, \dots, i_{\ell}\}\}$$
+
+$$\leq \sum_{i_{1}, \dots, i_{\ell} \in [m], \ m \in \{i_{1}, \dots, i_{\ell}\}} \Pr[(Q_{i_{1}}, \dots, Q_{i_{\ell}}, A_{i_{1}}, \dots, A_{i_{\ell}}) \in R]$$
+
+$$\leq \sum_{i_{1}, \dots, i_{\ell} \in [m], \ m \in \{i_{1}, \dots, i_{\ell}\}} p \leq p \cdot \ell \cdot (m-1)_{\ell-1} .$$
+
+Then, we union bound over all  $z_m$  for  $m \in [T]$  and get that
+
+$$\Pr\left[ (X_1, \dots, X_\ell, Y_1, \dots, Y_\ell) \in R \mid (X_1, \dots, X_\ell) \in \mathcal{Q}^\ell \right] \leq \Pr\left[\exists m \in [T] : Z_m = 1\right]$$
+
+$$\leq \sum_{m=1}^T \Pr\left[ Z_m = 1 \right] \leq \sum_{m=1}^T p \cdot \ell \cdot (m-1)_{\ell-1} \leq p \cdot (T)_\ell .$$
+
+Finally, using the two claims we get that
+
+$$\Pr\left[(X_{1}, \dots, X_{\ell}, Y_{1}, \dots, Y_{\ell}) \in R\right]$$
+
+$$= \Pr\left[(X_{1}, \dots, X_{\ell}, Y_{1}, \dots, Y_{\ell}) \in R \mid (X_{1}, \dots, X_{\ell}) \in \mathcal{Q}^{\ell}\right] \cdot \Pr\left[(X_{1}, \dots, X_{\ell}) \in \mathcal{Q}^{\ell}\right]$$
+
+$$+ \Pr\left[(X_{1}, \dots, X_{\ell}, Y_{1}, \dots, Y_{\ell}) \in R \mid (X_{1}, \dots, X_{\ell}) \notin \mathcal{Q}^{\ell}\right] \cdot \Pr\left[(X_{1}, \dots, X_{\ell}) \notin \mathcal{Q}^{\ell}\right]$$
+
+$$\leq p \cdot (T)_{\ell} \cdot \Pr\left[(X_{1}, \dots, X_{\ell}) \in \mathcal{Q}^{\ell}\right] + p \cdot \ell \cdot \Pr\left[(X_{1}, \dots, X_{\ell}) \notin \mathcal{Q}^{\ell}\right]$$
+
+$$\leq p \cdot (T)_{\ell} \cdot \Pr\left[(X_{1}, \dots, X_{\ell}) \in \mathcal{Q}^{\ell}\right] + p \cdot (T)_{\ell} \cdot \Pr\left[(X_{1}, \dots, X_{\ell}) \notin \mathcal{Q}^{\ell}\right]$$
+
+$$= p \cdot (T)_{\ell} \leq p \cdot T^{\ell} .$$
+
+# <span id="page-10-0"></span>4 Our Construction
+
+We have defined the notion of a multi-input correlation intractable hash, and showed that they can be constructed in the random oracle model. We now construct a seeded family of codes that is pseudouniquely decodable against a large fraction of errors, using 2-input correlation intractable hash functions as a central tool (in a black-box way). Loosely speaking, our construction starts with any efficiently list-decodable code  $\mathcal{C}: \{0,1\}^k \to [q]^n$ , and modifies it in several steps.
+
+1. We first apply a decodability- and rate-preserving seeded transformation to  $\mathcal{C}$  to obtain (a seeded family of) stochastic codes in which with all pairs of messages are mapped to far apart codewords with overwhelmingly probability.
+
+Specifically, the seed is (loosely speaking) a pseudorandom permutation  $\pi \colon \{0,1\}^k \to \{0,1\}^k$ , and the stochastic code maps  $m' \in \{0,1\}^{k-\ell}$  to  $\mathcal{C}\left(\pi(m'\|r)\right)$  for uniformly random  $r \leftarrow \{0,1\}^{\ell}$ , where  $\ell$  satisfies  $\omega(k) \le \ell \le o(k)$ .
+
+{11}------------------------------------------------
+
+2. We derandomize these codes by generating randomness deterministically as a hash of the message.
+
+More formally, we will consider the following parameterized construction of a seeded code family.
+
+#### **Construction 4.1.** *Suppose that*
+
+- = { : {0*,* 1} → [] }∈Z<sup>+</sup> *is a fully explicit ensemble of codes,*
+- Π = {Π ⊆ {0*,*1} }∈Z<sup>+</sup> *is a fully explicit ensemble of permutation families, and*
+- ℋ = {ℋ} *is a fully explicit ensemble of hash function families, where functions in* ℋ *map* {0*,* 1} −*ℓ to* {0*,* 1} *<sup>ℓ</sup> for some ℓ* = *ℓ satisfying* (log ) ≤ *ℓ* ≤ ()*.*
+
+*Then we define a seeded family of codes* [*,* Π*,* ℋ] *by the following algorithms* (Setup*,* Enc)*:*
+
+- Setup *takes* 1 *as input, samples* ← Π *and ℎ* ← ℋ*, and outputs* (*, ℎ*)*.*
+- Enc *takes* (*, ℎ*) *as input, as well as a message* ∈ {0*,* 1} −*ℓ , and outputs* (︁ (︀ *, ℎ*() )︀ )︁ *.*
+
+[*,* Π*,* ℋ] inherits several basic properties from , including alphabet size and block length. We only consider hash family ensembles {ℋ} in which the output length *ℓ* of functions in ℋ satisfies *ℓ* ≤ (). With such parameters, the resulting coding scheme [*,* Π*,* ℋ] has the same rate as .
+
+# <span id="page-11-0"></span>**4.1 From 2-Input Correlation Intractability to Pseudodistance**
+
+In this section, we show that if is a sufficiently good ensemble of codes, ℋ is a two-input correlation intractable hash with an appropriate output length, and Π is pseudorandom, then [*,* Π*,* ℋ] has high pseudodistance.
+
+### <span id="page-11-1"></span>**Proposition 4.2.** *For any:*
+
+- *rate- (combinatorially) -list decodable ensemble of codes* { : {0*,* 1} → [] }∈Z<sup>+</sup> *;*
+- *ensemble* Π = {Π ⊆ {0*,*1} }∈Z<sup>+</sup> *of* (1)*-wise* (1)*-dependent (in Rényi* ∞*-divergence) permutation families;*
+- ∈ (0*,* 1) *satisfying* () − () *< , where* = lim→∞
+
+[*,* Π*,* ℋ] *has relative pseudodistance as long as* ℋ *is 2-input correlation intractable for a specific family of sparse relations.*
+
+*Proof.* By construction, [*,* Π*,* ℋ] has relative pseudodistance if and only if given ← Π and *ℎ* ← ℋ, it is hard to find 0*,* <sup>1</sup> ∈ {0*,* 1} −*ℓ* such that (︁ (︀ 0*, ℎ*(0) )︀ )︁ ≈ (︁ (︀ 1*, ℎ*(1) )︀ )︁ , i.e. if (︀ 0*,* 1*, ℎ*(0)*, ℎ*(1) )︀ is in the relation:
+
+$$\mathcal{R}^{\mathsf{close}}_{\mathcal{C},\pi,\delta,\ell_k} \subseteq \left(\{0,1\}^{k-\ell_k}\right)^2 \times \left(\{0,1\}^{\ell_k}\right)^2 \\ \mathcal{R}^{\mathsf{close}}_{\mathcal{C},\pi,\delta,\ell_k} \stackrel{\mathsf{def}}{=} \Big\{ (m_0,m_1,r_0,r_1) : C_k \Big(\pi \big(m_0,r_0\big)\Big) \approx_{\delta} C_k \Big(\pi \big(m_1,r_1\big)\Big) \Big\}.$$
+
+To finish the proof of Proposition [4.2,](#page-11-1) it suffices to show that this relation is sparse with high probability (over the choice of ← Π), which is established by the following claim.
+
+#### <span id="page-11-2"></span>**Claim 4.3.** *For any:*
+
+- *rate- combinatorially -list decodable ensemble of codes* { : {0*,* 1} → [] }∈Z<sup>+</sup> *;*
+- ∈ (0*,* 1) *satisfying* lim (︀ () − () )︀ *< ;*
+
+{12}------------------------------------------------
+
+for  $t_k \geq \omega(1)$  and all  $t_k$ -wise O(1)-dependent (in Rényi  $\infty$ -divergence) permutation families  $\{\Pi_k \subseteq S_{\{0,1\}^k}\}$  and all  $\ell_k \leq o(k)$ , it holds for random  $\pi \leftarrow \Pi_k$  that the relation  $\mathcal{R}_{C_k,\pi,\delta,\ell_k}^{\mathsf{close}}$  is  $t_k \cdot 2^{-\ell_k}$ -sparse with all but  $2^{-\Omega(k \cdot t_k)}$  probability.
+
+Proof of Claim 4.3. For simplicity of presentation, we omit the explicit dependencies of  $C_k$ ,  $\Pi_k$ ,  $q_k$ ,  $n_k$ ,  $t_k$ , and  $\ell_k$  on k, simply writing C, q, n, t, and  $\ell$  respectively in statements that are to be interpreted as holding for all sufficiently large k.
+
+Fix any  $(x_1, y_1) \in \{0, 1\}^{k-\ell} \times \{0, 1\}^{\ell}$  and consider the Hamming ball  $B \subseteq [q]^n$  of relative radius  $\delta$  around  $C(x_1, y_1)$ . Using Fact B.5, we get that B can be covered by  $q^{n \cdot (H_q(\delta) - H_q(\rho))} \cdot \text{poly}(n)$  balls of relative radius  $\rho$ . By C's combinatorial  $\rho$ -list decodability, each such ball contains at most poly(k) codewords of C. The total number of codewords in C is at most  $2^k \approx q^{rn}$  which lets us write:
+
+$$\Pr_{c \leftarrow C} \left[ c \approx_{\delta} C(x_1, y_1) \right] \leq \operatorname{poly}(k) \cdot \operatorname{poly}(n) \cdot q^{n \cdot \left( H_q(\delta) - H_q(\rho) \right)} \cdot q^{-nr} \leq q^{-\Omega(n)} \leq 2^{-\Omega(k)}.$$
+
+Now, observe that as long as  $t \ge 2$ , by the t-wise O(1)-dependence of  $\Pi$ , there exists a constant c such that for any  $x_1, x_2, y_1, y_2$  with  $x_1 \ne x_2$  it holds that:
+
+$$\Pr_{\pi}[(x_1, x_2, y_1, y_2) \in \mathcal{R}^{\mathsf{close}}_{\mathcal{C}, \pi, \delta, \ell}] \le c \cdot \Pr_{c \leftarrow C}[c \approx_{\delta} C(x_1, y_1)] \le 2^{-\Omega(k)}.$$
+
+Thus, the expected number  $\mu$  of  $y_2'$  for which  $(x_1, x_2, y_1, y_2') \in \mathcal{R}_{\mathcal{C}, \pi, \delta, \ell}^{\mathsf{close}}$  satisfies  $\mu \leq 2^{\ell - \Omega(k)}$ . Applying a concentration bound for t-wise almost-dependent random variables (Theorem A.2), we see that for any fixed  $x_1, x_2, y_1$  with  $x_1 \neq x_2$  it holds that
+
+$$\Pr_{\pi}\left[\Pr_{y_2 \leftarrow \{0,1\}^{\ell}}\left[(x_1, x_2, y_1, y_2) \in \mathcal{R}^{\mathsf{close}}_{\mathcal{C}, \pi, \delta, \ell}\right] \geq \frac{t+1}{2^{\ell}}\right] \leq O\left(\frac{\mu^t}{(t+1)!}\right) \leq O\left(\mu^t\right).$$
+
+<span id="page-12-1"></span>Thus, by a union bound over  $x_1, x_2, y_1$ , it holds that, with all but  $O(2^{2k-\ell} \cdot \mu^t)$  probability, for all  $x_1, x_2, y_1$ ,
+
+$$\Pr_{y_2 \leftarrow \{0,1\}^{\ell}} \left[ (x_1, x_2, y_1, y_2) \in \mathcal{R}^{\mathsf{close}}_{\mathcal{C}, \pi, \delta, \ell} \right] \le \frac{t}{2^{\ell}}. \tag{1}$$
+
+By a symmetric argument, it holds with all but  $O(2^{2k-\ell} \cdot \mu^t)$  probability that for all  $x_1, x_2, y_2$ ,
+
+$$\Pr_{y_1 \leftarrow \{0,1\}^{\ell}} \left[ (x_1, x_2, y_1, y_2) \in \mathcal{R}^{\mathsf{close}}_{\mathcal{C}, \pi, \delta, \ell} \right] \le \frac{t}{2^{\ell}}. \tag{2}$$
+
+<span id="page-12-2"></span>
+
+Applying one last union bound, Eqs. (1) and (2) hold simultaneously with probability all but
+
+$$O\left(2^{2k-\ell} \cdot \mu^t\right) \le 2^{2k-\ell} \cdot 2^{t\left(\ell-\Omega(k)\right)}$$
+
+$$\le 2^{-\Omega(tk)},$$
+
+where the last inequality is because  $\ell \leq o(k)$  and  $t \geq \omega(1)$ .
+
+This concludes the proof of Proposition 4.2
+
+## <span id="page-12-0"></span>4.2 From Efficient List Decodability to Pseudounique Decodability
+
+We next observe that if  $\mathcal{C}$  is efficiently  $\rho$ -list decodable then so is  $\mathcal{C}' = \mathcal{SC}[\mathcal{C}, \Pi, \mathcal{H}]$  (as long as  $\Pi$  and  $\mathcal{H}$  are fully explicit). We show that this, combined with the high pseudodistance that we have already established, implies that  $\mathcal{C}'$  has a pseudounique decoding algorithm against a large fraction of errors.
+
+We first define the straight-forward adaptation of list decoding for seeded families of codes.
+
+{13}------------------------------------------------
+
+**Definition 4.4.** *We say that* Dec *is an* (︀ (·)*,* )︀ -list decoding algorithm *for a seeded family of codes* (Setup*,* Enc) *if for all* pp *in the support of* Setup(1 )*, all* ∈ {0*,* 1} *, and all* ≈ Enc(pp*,* )*,* Dec(pp*,* ) *is an* ()*-sized set that contains . We say that* Dec *is simply a -list decoding algorithm if it is an* (︀ (·)*,* )︀ *-list decoding algorithm for some* () ≤ (1) *.*
+
+*We say that* = (Setup*,* Enc) *is* efficiently -list decodable *if there exists a polynomial-time -list decoding algorithm for .*
+
+<span id="page-13-1"></span>**Proposition 4.5.** *If* = {} *is* efficiently -list decodable *and* Π *and* ℋ *are fully explicit, then so is* [*,* Π*,* ℋ]*.*
+
+*Proof.* Given public parameters (*, ℎ*) ← Setup(1 ) and a noisy codeword ′ , we can list-decode by:
+
+- 1. Running the list-decoding algorithm for to obtain strings 1*, . . . ,*  ∈ {0*,* 1} ,
+- 2. Inverting each under to obtain pairs (1*,* 1)*, . . . ,*(*,* ),
+- 3. Outputting the set { : = *ℎ*() ∧ (( *,* )) ≈ ′}.
+
+<span id="page-13-2"></span>**Proposition 4.6.** *If* = (Setup*,* Enc) *is a seeded family of codes that:*
+
+- *is efficiently list-decodable against a fraction of errors; and*
+- *has relative pseudodistance* ˜*,*
+
+*then is efficiently pseudouniquely decodable against a* ′ *fraction of errors for any* ′ *<* min(*,* ˜ 2 )*.*
+
+*Proof.* Let = () and = () denote the alphabet and block length of , respectively. The efficient pseudounique decoding algorithm Dec operates as follows, given public parameters pp and corrupted codeword ∈ [] as input:
+
+- 1. Run the list-decoding algorithm for on (pp*,* ) to obtain a list of messages 1*, . . . ,*  (and corresponding codewords 1*, . . . ,* ).
+- 2. Output for the ∈ [] minimizing Δ( *,* ).
+
+This algorithm clearly runs in polynomial-time, so it suffices to analyze correctness. Suppose we have (*,* ) ← (pp), where is a polynomial-size adversary and Δ (︀ *,* Enc(pp*,* ) )︀ ≤ ′. We first observe that some = by the list-decodability of . No other can also have Δ (︀ *,* Enc(pp*,* ) )︀ ≤ ′, because otherwise we would have Δ( *,*  ) ≤ 2 ′ *<* ˜ by the triangle inequality. This contradicts the 's pseudodistance since the above process for generating {1*, . . . ,* } is efficient.
+
+In other words, is the closest codeword to , and the decoding algorithm outputs = as desired.
+
+# <span id="page-13-0"></span>**4.3 Main Theorem**
+
+We are now ready to state our main theorem:
+
+<span id="page-13-3"></span>**Theorem 4.7.** *For any:*
+
+- *rate- (efficiently) -list decodable fully explicit ensemble of codes* { : {0*,* 1} → [] }∈Z<sup>+</sup> *;*
+- *ensemble* Π = {Π ⊆ {0*,*1} }∈Z<sup>+</sup> *of* (1)*-wise* (1)*-dependent (in Rényi* ∞*-divergence) permutation families;*
+- *ensemble* ℋ = {ℋ} *of* 2*-input correlation intractable hash families, where functions in* ℋ *map* {0*,* 1} *to* {0*,* 1} −*ℓ for* (log ) ≤ *ℓ* ≤ ()*;*
+- ′ *<sup>&</sup>lt;* min (︂ *,* −<sup>1</sup> (︀ +() )︀ 2 )︂ *where* = lim→∞ *,*
+
+[*,* Π*,* ℋ] *is efficiently pseudouniquely decodable against a* ′ *fraction of errors.*
+
+*Proof.* Follows immediately by combining Propositions [4.2,](#page-11-1) [4.5](#page-13-1) and [4.6.](#page-13-2)
+
+{14}------------------------------------------------
+
+#### <span id="page-14-0"></span>Instantiations with Known Codes 4.4
+
+Finally, we apply Theorem 4.7 with some known codes, first recalling applicable results from coding theory. We focus on large alphabets  $(q_k \to \infty)$  and binary alphabets  $(q_k = 2)$ .
+
+**Imported Theorem 4.8** ([GR08]). For all  $r, \rho \in (0,1)$  satisfying  $r + \rho < 1$ , there is a rate-r, efficiently  $\rho$ -list decodable, fully explicit ensemble of codes  $\{C_k : \{0,1\}^k \to [q_k]^{n_k}\}_{k \in \mathbb{Z}^+}$  with  $q_k \leq \operatorname{poly}(k)$ .
+
+**Imported Theorem 4.9** ([GR09]). For all  $r, \rho$  satisfying  $0 < \rho < 1/2$  and
+
+<span id="page-14-4"></span>
+$$0 < r < R_{\mathsf{BZ}}(\rho) \stackrel{\mathsf{def}}{=} 1 - H(\rho) - \rho \cdot \int_0^{1 - H(\rho)} \frac{dx}{H^{-1}(1 - x)},\tag{3}$$
+
+there is a rate-r, efficiently  $\rho$ -list decodable, fully explicit ensemble of codes  $\{C_k : \{0,1\}^k \to \{0,1\}^{n_k}\}_{k \in \mathbb{Z}^+}$ . The bound of Eq. (3) is called the Blokh-Zyablov bound.
+
+Plugging these codes into Theorem 4.7, we get
+
+Corollary 4.10. For all r,  $\rho$  with  $r + \rho < 1$ , there is a rate-r seeded family of codes (with alphabet size  $q_k \leq \text{poly}(k)$ , that is efficiently pseudouniquely decodable against a  $\rho$  fraction of errors.
+
+This result should be contrasted with the Singleton bound, which states that if rate-r code is uniquely decodable against a  $\rho$  fraction of errors, then  $r + 2\rho \leq 1$ .
+
+<span id="page-14-2"></span>Corollary 4.11. For all  $0 < \rho < 1/2$  and all  $0 < r < R_{BZ}(\rho)$ , there is a rate-r seeded family of binary codes that is efficiently pseudouniquely decodable against a min  $\left(\rho, \frac{H^{-1}\left(r+H(\rho)\right)}{2}\right)$  fraction of errors.
+
+# Acknowledgments
+
+This work was done (in part) while the authors were visiting the Simons Institute for the Theory of Computing. Eylon Yogev is funded by the ISF grants 484/18, 1789/19, Len Blavatnik and the Blavatnik Foundation, and The Blavatnik Interdisciplinary Cyber Research Center at Tel Aviv University.
+
+#### <span id="page-14-1"></span>Limited Independence Tail Bound $\mathbf{A}$
+
+We rely on the following:
+
+<span id="page-14-5"></span>Imported Theorem A.1 ([LL14]). Let  $X_1, \ldots, X_N$  be  $\{0,1\}$ -valued random variables, let  $t, \tau \in \mathbb{Z}^+$  satisfy  $0 < t < \tau < N$ . Then
+
+$$\Pr\left[\sum_{i=1}^{N} X_i \ge \tau\right] \le \frac{1}{\binom{\tau}{t}} \cdot \sum_{A \in \binom{\lfloor N \rfloor}{t}} \mathbb{E}\left[\prod_{i \in A} X_i\right].$$
+
+We apply this theorem to obtain a concentration bound on t-wise almost-dependent random variables.
+
+<span id="page-14-3"></span>**Theorem A.2.** Let  $X_1, \ldots, X_n$  be  $\{0,1\}$ -valued random variables that are t-wise  $\beta$ -dependent in Rényi  $\infty$ -divergence with  $\mathbb{E}\left[\sum_{i}^{\tau}X_{i}\right]=\mu$ . Then for any  $\tau\in\mathbb{Z}^{+}$  with  $\tau>\mu$ ,
+
+$$\Pr\left[\sum_{i} X_{i} \geq \tau\right] \leq \beta \cdot \frac{\mu^{k}}{(\tau)_{k}},$$
+
+where  $k = \min(t, \lfloor \tau - \mu \rfloor)$  and  $(\tau)_k = \tau \cdot (\tau - 1) \cdots (\tau - k + 1)$  denotes the  $k^{th}$  falling factorial of  $\tau$ .
+
+{15}------------------------------------------------
+
+*Proof.* We invoke Imported Theorem [A.1.](#page-14-5) For any  *<*  and ≤ , we have
+
+$$\begin{split} \Pr\left[\sum_{i=1}^{N} X_{i} \geq \tau\right] &\leq \binom{\tau}{k}^{-1} \cdot \sum_{A \in \binom{[n]}{k}} \mathbb{E}\left[\prod_{i \in A} X_{i}\right] \\ &\leq \beta \cdot \binom{\tau}{k}^{-1} \cdot \sum_{A \in \binom{[n]}{k}} \prod_{i \in A} \mathbb{E}\left[X_{i}\right] \qquad \text{(by $k$-wise $\beta$-dependence)} \\ &= \beta \cdot \binom{\tau}{k}^{-1} \cdot \sum_{1 \leq i_{1} < \dots < i_{k} \leq [n]} \prod_{j \in [k]} \mathbb{E}\left[X_{i_{j}}\right] \\ &\leq \frac{\beta}{k!} \cdot \binom{\tau}{k}^{-1} \cdot \sum_{\text{distinct } i_{1}, \dots, i_{k}} \prod_{j \in [k]} \mathbb{E}\left[X_{i_{j}}\right] \\ &\leq \frac{\beta}{k!} \cdot \binom{\tau}{k}^{-1} \cdot \sum_{i_{1}, \dots, i_{k}} \prod_{j \in [k]} \mathbb{E}\left[X_{i_{j}}\right] \\ &= \frac{\beta}{k!} \cdot \binom{\tau}{k}^{-1} \cdot \mu^{k} \\ &= \beta \cdot \frac{\mu^{k}}{(\tau)_{k}}. \end{split}$$
+
+This is minimized by picking ≤ as large as possible subject to −+1 ≥ , i.e. = min(*,* ⌊ −+1⌋).
+
+# <span id="page-15-0"></span>**B Covering Number Bounds**
+
+**Definition B.1.** *-ary -dimensional Hamming space is the metric space* ([] *,* Δ)*, where* Δ(*,* ) = ⃒ ⃒{ : ̸= } ⃒ ⃒ *.*
+
+**Definition B.2.** *In a metric space* (*,* )*, the ball of radius centered at , which we denote by* ()*, is the set* { : (*,* ) ≤ }*. The sphere of radius centered at , which we denote by* ()*, is* { : (*,* ) = }*.*
+
+**Definition B.3.** *The -ary entropy function is* () def <sup>=</sup> log ( − 1) − log () − (1 − ) log (1 − )*.*
+
+The following bounds are well-known.
+
+**Fact B.4.** *In -ary -dimensional Hamming space, we have* ·(*/*) · <sup>−</sup>(1) ≤ |()| ≤ ·(*/*) *for all* ≤ · (1 − 1*/*)*.*
+
+<span id="page-15-3"></span>**Fact B.5.** *In -ary -dimensional Hamming space, any ball of radius* <sup>1</sup> ≤ · (1 − 1*/*) *can be covered by* poly() · ln() · · (︀ (1*/*)−(0*/*) )︀ *balls of radius* <sup>0</sup> *for any* <sup>0</sup> ≤ 1*.*
+
+# **References**
+
+- <span id="page-15-1"></span>[BGGZ19] Jeremiah Blocki, Venkata Gandikota, Elena Grigorescu, and Samson Zhou. Relaxed locally correctable codes in computationally bounded channels. In *2019 IEEE International Symposium on Information Theory (ISIT)*, pages 2414–2418. IEEE, 2019.
+- <span id="page-15-2"></span>[CCH<sup>+</sup>19] Ran Canetti, Yilei Chen, Justin Holmgren, Alex Lombardi, Guy N. Rothblum, Ron D. Rothblum, and Daniel Wichs. Fiat-shamir: from practice to theory. In *STOC*, pages 1082–1090. ACM, 2019.
+
+{16}------------------------------------------------
+
+- <span id="page-16-9"></span>[CCR16] Ran Canetti, Yilei Chen, and Leonid Reyzin. On the correlation intractability of obfuscated pseudorandom functions. In Eyal Kushilevitz and Tal Malkin, editors, *Theory of Cryptography - 13th International Conference, TCC 2016-A, Tel Aviv, Israel, January 10-13, 2016, Proceedings, Part I*, volume 9562 of *Lecture Notes in Computer Science*, pages 389–415. Springer, 2016.
+- <span id="page-16-12"></span>[CCRR18] Ran Canetti, Yilei Chen, Leonid Reyzin, and Ron D. Rothblum. Fiat-shamir and correlation intractability from strong kdm-secure encryption. In *EUROCRYPT (1)*, volume 10820 of *Lecture Notes in Computer Science*, pages 91–122. Springer, 2018.
+- <span id="page-16-8"></span>[CGH04] Ran Canetti, Oded Goldreich, and Shai Halevi. The random oracle methodology, revisited. *J. ACM*, 51(4):557–594, 2004.
+- <span id="page-16-3"></span>[DGL04] Yan Zhong Ding, Parikshit Gopalan, and Richard J Lipton. Error correction against computationally bounded adversaries. *Manuscript. Appeared initially as [Lip94]*, 2004.
+- <span id="page-16-1"></span>[Eli57] Peter Elias. List decoding for noisy channels. Technical Report 335, Research Laboratory of Electronics, MIT, 1957.
+- <span id="page-16-14"></span>[GR08] Venkatesan Guruswami and Atri Rudra. Explicit codes achieving list decoding capacity: Errorcorrection with optimal redundancy. *IEEE Trans. Inf. Theory*, 54(1):135–150, 2008.
+- <span id="page-16-15"></span>[GR09] Venkatesan Guruswami and Atri Rudra. Better binary list decodable codes via multilevel concatenation. *IEEE Trans. Inf. Theory*, 55(1):19–26, 2009.
+- <span id="page-16-4"></span>[GS16] Venkatesan Guruswami and Adam Smith. Optimal rate code constructions for computationally simple channels. *Journal of the ACM (JACM)*, 63(4):1–37, 2016.
+- <span id="page-16-0"></span>[Ham50] R. W. Hamming. Error detecting and error correcting codes. *The Bell System Technical Journal*, 29(2):147–160, 1950.
+- <span id="page-16-11"></span>[HL18] Justin Holmgren and Alex Lombardi. Cryptographic hashing from strong one-way functions (or: One-way product functions and their applications). In *FOCS*, pages 850–858. IEEE Computer Society, 2018.
+- <span id="page-16-6"></span>[HO08] Brett Hemenway and Rafail Ostrovsky. Public-key locally-decodable codes. In *Annual International Cryptology Conference*, pages 126–143. Springer, 2008.
+- <span id="page-16-5"></span>[HOSW11] Brett Hemenway, Rafail Ostrovsky, Martin J Strauss, and Mary Wootters. Public key locally decodable codes with short keys. In *Approximation, Randomization, and Combinatorial Optimization. Algorithms and Techniques*, pages 605–615. Springer, 2011.
+- <span id="page-16-7"></span>[KNR09] Eyal Kaplan, Moni Naor, and Omer Reingold. Derandomized constructions of *k*-wise (almost) independent permutations. *Algorithmica*, 55(1):113–133, 2009.
+- <span id="page-16-10"></span>[KRR17] Yael Tauman Kalai, Guy N. Rothblum, and Ron D. Rothblum. From obfuscation to the security of fiat-shamir for proofs. In Jonathan Katz and Hovav Shacham, editors, *Advances in Cryptology - CRYPTO 2017 - 37th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 20-24, 2017, Proceedings, Part II*, volume 10402 of *Lecture Notes in Computer Science*, pages 224–251. Springer, 2017.
+- <span id="page-16-2"></span>[Lip94] Richard J. Lipton. A new approach to information theory. In *STACS*, volume 775 of *Lecture Notes in Computer Science*, pages 699–708. Springer, 1994.
+- <span id="page-16-16"></span>[LL14] Nathan Linial and Zur Luria. Chernoff's inequality - a very elementary proof, 2014.
+- <span id="page-16-13"></span>[LV20] Alex Lombardi and Vinod Vaikuntanathan. Multi-input correlation-intractable hash functions via shift-hiding. Cryptology ePrint Archive, Report 2020/1378, 2020. [https://eprint.iacr.](https://eprint.iacr.org/2020/1378) [org/2020/1378](https://eprint.iacr.org/2020/1378).
+
+{17}------------------------------------------------
+
+- <span id="page-17-1"></span>[MPSW10] Silvio Micali, Chris Peikert, Madhu Sudan, and David A. Wilson. Optimal error correction for computationally bounded noise. *IEEE Trans. Inf. Theory*, 56(11):5673–5680, 2010.
+- <span id="page-17-3"></span>[OPS07] Rafail Ostrovsky, Omkant Pandey, and Amit Sahai. Private locally decodable codes. In *International Colloquium on Automata, Languages, and Programming*, pages 387–398. Springer, 2007.
+- <span id="page-17-5"></span>[PS19] Chris Peikert and Sina Shiehian. Noninteractive zero knowledge for NP from (plain) learning with errors. In Alexandra Boldyreva and Daniele Micciancio, editors, *Advances in Cryptology - CRYPTO 2019 - 39th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 18-22, 2019, Proceedings, Part I*, volume 11692 of *Lecture Notes in Computer Science*, pages 89–114. Springer, 2019.
+- <span id="page-17-2"></span>[SS16] Ronen Shaltiel and Jad Silbak. Explicit list-decodable codes with optimal rate for computationally bounded channels. In *Approximation, Randomization, and Combinatorial Optimization. Algorithms and Techniques (APPROX/RANDOM 2016)*. Schloss Dagstuhl-Leibniz-Zentrum fuer Informatik, 2016.
+- <span id="page-17-4"></span>[SS20] Ronen Shaltiel and Jad Silbak. Explicit uniquely decodable codes for space bounded channels that achieve list-decoding capacity. *Electronic Colloquium on Computational Complexity (ECCC)*, 27:47, 2020.
+- <span id="page-17-0"></span>[Woz58] John M Wozencraft. List decoding. *Quarterly Progress Report*, 48:90–95, 1958.

--- a/data/markdown/eprint/2020_1411/2020_1411_meta.json
+++ b/data/markdown/eprint/2020_1411/2020_1411_meta.json
@@ -1,0 +1,1408 @@
+{
+  "table_of_contents": [
+    {
+      "title": "Transparent Error Correcting in a Computationally Bounded World",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          71.71875,
+          110.21484375
+        ],
+        [
+          539.4840087890625,
+          110.21484375
+        ],
+        [
+          539.4840087890625,
+          127.62945556640625
+        ],
+        [
+          70.5234375,
+          127.62945556640625
+        ]
+      ]
+    },
+    {
+      "title": "Abstract",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          284.185546875,
+          214.62890625
+        ],
+        [
+          326.2610168457031,
+          214.62890625
+        ],
+        [
+          326.2610168457031,
+          223.84967041015625
+        ],
+        [
+          284.185546875,
+          223.84967041015625
+        ]
+      ]
+    },
+    {
+      "title": "Contents",
+      "heading_level": null,
+      "page_id": 1,
+      "polygon": [
+        [
+          71.419921875,
+          70.78662109375
+        ],
+        [
+          135.00851440429688,
+          70.78662109375
+        ],
+        [
+          135.00851440429688,
+          85.1328125
+        ],
+        [
+          71.419921875,
+          85.1328125
+        ]
+      ]
+    },
+    {
+      "title": "1 Introduction",
+      "heading_level": null,
+      "page_id": 2,
+      "polygon": [
+        [
+          72.0,
+          70.78662109375
+        ],
+        [
+          184.976318359375,
+          69.609375
+        ],
+        [
+          184.976318359375,
+          85.1328125
+        ],
+        [
+          72.0,
+          85.1328125
+        ]
+      ]
+    },
+    {
+      "title": "1.1 Our Contributions",
+      "heading_level": null,
+      "page_id": 2,
+      "polygon": [
+        [
+          71.71875,
+          577.4822692871094
+        ],
+        [
+          211.50526428222656,
+          576.59765625
+        ],
+        [
+          211.50526428222656,
+          589.4374694824219
+        ],
+        [
+          71.71875,
+          589.4374694824219
+        ]
+      ]
+    },
+    {
+      "title": "1.2 Main Definitions and Main Theorem Statement",
+      "heading_level": null,
+      "page_id": 3,
+      "polygon": [
+        [
+          70.5,
+          573.0
+        ],
+        [
+          384.0,
+          571.95703125
+        ],
+        [
+          384.0,
+          583.0
+        ],
+        [
+          70.5,
+          583.0
+        ]
+      ]
+    },
+    {
+      "title": "1.3 Related Work",
+      "heading_level": null,
+      "page_id": 4,
+      "polygon": [
+        [
+          72.0,
+          530.9023742675781
+        ],
+        [
+          184.4147491455078,
+          529.41796875
+        ],
+        [
+          184.4147491455078,
+          542.8575744628906
+        ],
+        [
+          72.0,
+          542.8575744628906
+        ]
+      ]
+    },
+    {
+      "title": "2 Preliminaries",
+      "heading_level": null,
+      "page_id": 5,
+      "polygon": [
+        [
+          70.0,
+          429.5
+        ],
+        [
+          190.0,
+          429.2578125
+        ],
+        [
+          190.0,
+          442.0
+        ],
+        [
+          70.0,
+          442.0
+        ]
+      ]
+    },
+    {
+      "title": "2.1 Combinatorics",
+      "heading_level": null,
+      "page_id": 5,
+      "polygon": [
+        [
+          70.5,
+          454.78125
+        ],
+        [
+          188.0,
+          453.234375
+        ],
+        [
+          188.0,
+          466.0
+        ],
+        [
+          70.5,
+          466.0
+        ]
+      ]
+    },
+    {
+      "title": "2.2 Codes",
+      "heading_level": null,
+      "page_id": 5,
+      "polygon": [
+        [
+          70.0,
+          647.75390625
+        ],
+        [
+          139.0,
+          647.75390625
+        ],
+        [
+          139.0,
+          659.0
+        ],
+        [
+          70.0,
+          659.0
+        ]
+      ]
+    },
+    {
+      "title": "2.3 Pseudorandomness",
+      "heading_level": null,
+      "page_id": 7,
+      "polygon": [
+        [
+          70.5,
+          138.4453125
+        ],
+        [
+          214.5,
+          136.8984375
+        ],
+        [
+          214.5,
+          149.0
+        ],
+        [
+          70.5,
+          149.0
+        ]
+      ]
+    },
+    {
+      "title": "2.3.1 Permutations",
+      "heading_level": null,
+      "page_id": 7,
+      "polygon": [
+        [
+          70.5,
+          267.22265625
+        ],
+        [
+          174.5,
+          265.67578125
+        ],
+        [
+          174.5,
+          277.5
+        ],
+        [
+          70.5,
+          277.5
+        ]
+      ]
+    },
+    {
+      "title": "3 Multi-input Correlation Intractability",
+      "heading_level": null,
+      "page_id": 8,
+      "polygon": [
+        [
+          70.0,
+          71.15625
+        ],
+        [
+          363.5,
+          71.15625
+        ],
+        [
+          363.5,
+          84.0
+        ],
+        [
+          70.0,
+          84.0
+        ]
+      ]
+    },
+    {
+      "title": "3.1 Multi-Input Correlation Intractability of Random Oracles",
+      "heading_level": null,
+      "page_id": 8,
+      "polygon": [
+        [
+          70.5,
+          517.04296875
+        ],
+        [
+          443.0,
+          515.49609375
+        ],
+        [
+          443.0,
+          528.0
+        ],
+        [
+          70.5,
+          528.64453125
+        ]
+      ]
+    },
+    {
+      "title": "4 Our Construction",
+      "heading_level": null,
+      "page_id": 10,
+      "polygon": [
+        [
+          70.0,
+          523.5
+        ],
+        [
+          221.0,
+          522.0
+        ],
+        [
+          221.0,
+          535.0
+        ],
+        [
+          70.0,
+          536.5
+        ]
+      ]
+    },
+    {
+      "title": "Construction 4.1. Suppose that",
+      "heading_level": null,
+      "page_id": 11,
+      "polygon": [
+        [
+          71.71875,
+          113.30859375
+        ],
+        [
+          218.7421875,
+          113.30859375
+        ],
+        [
+          218.6256103515625,
+          124.00177001953125
+        ],
+        [
+          70.5234375,
+          124.00177001953125
+        ]
+      ]
+    },
+    {
+      "title": "4.1 From 2-Input Correlation Intractability to Pseudodistance",
+      "heading_level": null,
+      "page_id": 11,
+      "polygon": [
+        [
+          71.71875,
+          322.91015625
+        ],
+        [
+          446.6642150878906,
+          321.36328125
+        ],
+        [
+          446.6642150878906,
+          334.9266357421875
+        ],
+        [
+          70.5234375,
+          334.9266357421875
+        ]
+      ]
+    },
+    {
+      "title": "Proposition 4.2. For any:",
+      "heading_level": null,
+      "page_id": 11,
+      "polygon": [
+        [
+          70.822265625,
+          386.7117614746094
+        ],
+        [
+          193.9356231689453,
+          385.55859375
+        ],
+        [
+          193.9356231689453,
+          396.6988830566406
+        ],
+        [
+          70.822265625,
+          396.6988830566406
+        ]
+      ]
+    },
+    {
+      "title": "Claim 4.3. For any:",
+      "heading_level": null,
+      "page_id": 11,
+      "polygon": [
+        [
+          71.419921875,
+          636.0686798095703
+        ],
+        [
+          165.57345581054688,
+          634.9921875
+        ],
+        [
+          165.57345581054688,
+          646.0558013916016
+        ],
+        [
+          71.419921875,
+          646.0558013916016
+        ]
+      ]
+    },
+    {
+      "title": "4.2 From Efficient List Decodability to Pseudounique Decodability",
+      "heading_level": null,
+      "page_id": 12,
+      "polygon": [
+        [
+          70.5,
+          605.5
+        ],
+        [
+          472.0,
+          604.0546875
+        ],
+        [
+          472.0,
+          616.5
+        ],
+        [
+          70.224609375,
+          616.5
+        ]
+      ]
+    },
+    {
+      "title": "4.3 Main Theorem",
+      "heading_level": null,
+      "page_id": 13,
+      "polygon": [
+        [
+          71.71875,
+          501.43035888671875
+        ],
+        [
+          190.08151245117188,
+          500.02734375
+        ],
+        [
+          190.08151245117188,
+          513.3855590820312
+        ],
+        [
+          71.71875,
+          513.3855590820312
+        ]
+      ]
+    },
+    {
+      "title": "Instantiations with Known Codes\n4.4",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          70.5,
+          71.9296875
+        ],
+        [
+          300.0,
+          71.9296875
+        ],
+        [
+          300.0,
+          83.0
+        ],
+        [
+          70.5,
+          83.0
+        ]
+      ]
+    },
+    {
+      "title": "Acknowledgments",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          70.5,
+          378.984375
+        ],
+        [
+          198.0,
+          377.4375
+        ],
+        [
+          198.0,
+          391.5
+        ],
+        [
+          70.5,
+          392.90625
+        ]
+      ]
+    },
+    {
+      "title": "Limited Independence Tail Bound\n\\mathbf{A}",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          70.5,
+          456.71484375
+        ],
+        [
+          341.0,
+          455.16796875
+        ],
+        [
+          341.0,
+          470.0
+        ],
+        [
+          70.5,
+          471.5
+        ]
+      ]
+    },
+    {
+      "title": "B Covering Number Bounds",
+      "heading_level": null,
+      "page_id": 15,
+      "polygon": [
+        [
+          71.419921875,
+          375.8927001953125
+        ],
+        [
+          283.8503112792969,
+          374.73046875
+        ],
+        [
+          283.8503112792969,
+          390.2388916015625
+        ],
+        [
+          71.419921875,
+          390.2388916015625
+        ]
+      ]
+    },
+    {
+      "title": "References",
+      "heading_level": null,
+      "page_id": 15,
+      "polygon": [
+        [
+          71.12109375,
+          586.8216247558594
+        ],
+        [
+          147.4753875732422,
+          586.265625
+        ],
+        [
+          147.4753875732422,
+          601.1678314208984
+        ],
+        [
+          71.12109375,
+          601.1678314208984
+        ]
+      ]
+    }
+  ],
+  "page_stats": [
+    {
+      "page_id": 0,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          42
+        ],
+        [
+          "Line",
+          12
+        ],
+        [
+          "Footnote",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "Text",
+          2
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 1,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          82
+        ],
+        [
+          "TableCell",
+          51
+        ],
+        [
+          "Line",
+          19
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "TableOfContents",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 2,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          169
+        ],
+        [
+          "Line",
+          50
+        ],
+        [
+          "Text",
+          10
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 3,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          113
+        ],
+        [
+          "Line",
+          61
+        ],
+        [
+          "Text",
+          11
+        ],
+        [
+          "ListItem",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 4,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          624
+        ],
+        [
+          "Line",
+          114
+        ],
+        [
+          "Text",
+          12
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 5,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          80
+        ],
+        [
+          "Line",
+          59
+        ],
+        [
+          "Text",
+          10
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 6,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          389
+        ],
+        [
+          "Line",
+          89
+        ],
+        [
+          "TableCell",
+          60
+        ],
+        [
+          "ListItem",
+          5
+        ],
+        [
+          "Text",
+          3
+        ],
+        [
+          "Table",
+          1
+        ],
+        [
+          "Caption",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "TableGroup",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 7,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          161
+        ],
+        [
+          "Line",
+          56
+        ],
+        [
+          "Text",
+          13
+        ],
+        [
+          "Reference",
+          4
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "ListItem",
+          2
+        ],
+        [
+          "Equation",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 8,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          119
+        ],
+        [
+          "Line",
+          56
+        ],
+        [
+          "Text",
+          10
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 9,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          554
+        ],
+        [
+          "Line",
+          73
+        ],
+        [
+          "Text",
+          10
+        ],
+        [
+          "ListItem",
+          3
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 10,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          64
+        ],
+        [
+          "Line",
+          49
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "Equation",
+          5
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 11,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          685
+        ],
+        [
+          "Line",
+          105
+        ],
+        [
+          "ListItem",
+          10
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "SectionHeader",
+          4
+        ],
+        [
+          "ListGroup",
+          4
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "Equation",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 12,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          137
+        ],
+        [
+          "Line",
+          51
+        ],
+        [
+          "Text",
+          13
+        ],
+        [
+          "Equation",
+          6
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 13,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          698
+        ],
+        [
+          "Line",
+          93
+        ],
+        [
+          "Text",
+          13
+        ],
+        [
+          "ListItem",
+          11
+        ],
+        [
+          "ListGroup",
+          4
+        ],
+        [
+          "Reference",
+          4
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 14,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          102
+        ],
+        [
+          "Line",
+          34
+        ],
+        [
+          "Text",
+          15
+        ],
+        [
+          "Reference",
+          6
+        ],
+        [
+          "SectionHeader",
+          3
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 15,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          552
+        ],
+        [
+          "Line",
+          137
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Reference",
+          4
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "ListItem",
+          2
+        ],
+        [
+          "Equation",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 16,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          174
+        ],
+        [
+          "Line",
+          43
+        ],
+        [
+          "ListItem",
+          17
+        ],
+        [
+          "Reference",
+          17
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 17,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          67
+        ],
+        [
+          "Line",
+          19
+        ],
+        [
+          "ListItem",
+          6
+        ],
+        [
+          "Reference",
+          6
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    }
+  ],
+  "debug_data_path": "debug_data/2020_1411",
+  "eprint": {
+    "title": "Transparent Error Correcting in a Computationally Bounded World",
+    "authors": [
+      {
+        "name": "Ofer Grossman",
+        "email": "eylony@gmail",
+        "affiliation": ""
+      },
+      {
+        "name": "Justin Holmgren",
+        "email": "",
+        "affiliation": ""
+      },
+      {
+        "name": "Eylon Yogev",
+        "email": "",
+        "affiliation": ""
+      }
+    ],
+    "abstract": "We construct uniquely decodable codes against channels which are computationally bounded. Our construction requires only a public-coin (transparent) setup. All prior work for such channels either required a setup with secret keys and states, could not achieve unique decoding, or got worse rates (for a given bound on codeword corruptions). On the other hand, our construction relies on a strong cryptographic hash function with security properties that we only instantiate in the random oracle model.",
+    "keywords": [
+      "error correcting codes",
+      "list decodable",
+      "random oracle model"
+    ],
+    "category": "Foundations",
+    "publication_info": "A minor revision of an IACR publication in TCC 2020",
+    "last_updated": "2020-11-17",
+    "license": "CC BY",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2020_1411/conversion_info.json
+++ b/data/markdown/eprint/2020_1411/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "marker",
+  "converted_at": "2026-04-14T19:05:53.287938+00:00",
+  "elapsed_seconds": 388.72,
+  "pdf_sha256": "7daf61c80722489fbe2fe1f53f4695670b7ee4dd52c1cf833cfb24966a870893",
+  "source_pdf": "2020_1411.pdf",
+  "output_path": "2020_1411/2020_1411.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "socs-MacBook-Pro.local",
+    "os": "Darwin",
+    "os_version": "25.4.0",
+    "arch": "arm64",
+    "python_version": "3.13.11",
+    "cpu_count": 14,
+    "provider": "",
+    "gpu_count": 0,
+    "gpu_name": "",
+    "gpu_vram_mb": 0,
+    "cuda_version": ""
+  },
+  "estimated_cost_usd": null
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2020/1411

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 7177717)
Website: https://papyrus.badaas.eu