### PR TITLE
Add markdown for 2026/527

### DIFF
--- a/data/markdown/eprint/2026_527/2026_527.md
+++ b/data/markdown/eprint/2026_527/2026_527.md
@@ -1,0 +1,9 @@
+
+
+{0}------------------------------------------------
+
+## **Too Many Requests**
+
+The user has sent too many requests in a given amount of time.
+
+*Apache/2.4.66 Server at eprint.iacr.org Port 443*

--- a/data/markdown/eprint/2026_527/2026_527_meta.json
+++ b/data/markdown/eprint/2026_527/2026_527_meta.json
@@ -1,0 +1,71 @@
+{
+  "table_of_contents": [
+    {
+      "title": "Too Many Requests",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          60.822265625,
+          76.70098876953125
+        ],
+        [
+          328.1620178222656,
+          76.70098876953125
+        ],
+        [
+          328.1620178222656,
+          100.70098876953125
+        ],
+        [
+          60.822265625,
+          100.70098876953125
+        ]
+      ]
+    }
+  ],
+  "page_stats": [
+    {
+      "page_id": 0,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          5
+        ],
+        [
+          "Line",
+          3
+        ],
+        [
+          "Text",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    }
+  ],
+  "debug_data_path": "debug_data/tmp03u0ttmq",
+  "eprint": {
+    "title": "",
+    "authors": [],
+    "abstract": "",
+    "keywords": [],
+    "category": "",
+    "publication_info": "",
+    "last_updated": "",
+    "license": "",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2026_527/conversion_info.json
+++ b/data/markdown/eprint/2026_527/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "marker",
+  "converted_at": "2026-04-25T17:02:09.783281+00:00",
+  "elapsed_seconds": 6.93,
+  "pdf_sha256": "1bc9e7b913ccfc75e89d8d21eede0f4230a33603ea30ff90eda7f6fc66ccc024",
+  "source_pdf": "2026_527.pdf",
+  "output_path": "2026_527/2026_527.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "socs-MacBook-Pro.local",
+    "os": "Darwin",
+    "os_version": "25.4.0",
+    "arch": "arm64",
+    "python_version": "3.13.11",
+    "cpu_count": 14,
+    "provider": "",
+    "gpu_count": 0,
+    "gpu_name": "",
+    "gpu_vram_mb": 0,
+    "cuda_version": ""
+  },
+  "estimated_cost_usd": null
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2026/527

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit 7177717)
Website: https://papyrus.badaas.eu