### PR TITLE
Add markdown for 2026/575

### DIFF
--- a/data/markdown/eprint/2026_575/2026_575.md
+++ b/data/markdown/eprint/2026_575/2026_575.md
@@ -1,0 +1,1719 @@
+
+
+{0}------------------------------------------------
+
+## RoKoko<sup>⋆</sup> : Lattice-based Succinct Arguments, a Committed Refinement
+
+Michael Klooß<sup>1</sup> , Russell W. F. Lai<sup>2</sup> , Ngoc Khanh Nguyen<sup>3</sup> , Micha l Osadnik<sup>2</sup> , and Lorenzo Tucci<sup>2</sup>
+
+> <sup>1</sup> KASTEL, Karlsruhe Institute of Technology, Karlsruhe, Germany <sup>2</sup> Aalto University, Espoo, Finland <sup>3</sup> King's College London, London, UK
+
+Abstract. We present RoKoko, a new lattice-based succinct argument system that achieves a lineartime prover alongside polylogarithmic communication and verifier complexity. Asymptotically, our construction improves upon RoK and Roll (ASIACRYPT 2025), the first post-quantum SNARK with O˜(λ) proof size, by a multiplicative factor of Θ(log λ). Practically, our system yields proofs of roughly 200KB, while outperforming the state-of-the-art polynomial commitment scheme Greyhound (CRYPTO 2024) with a 100× faster verification time, similar prover time, and competitive proof size. Our framework natively supports (tensor-)structured relations, such as polynomial evaluation and sumcheck relations.
+
+At a high level, our construction follows the recursive split-and-fold paradigm: the prover first splits the witness into ρ sub-witnesses, sends the corresponding cross-terms, and then folds them into a single witness that is shorter by a factor of ρ using verifier challenges. Prior works typically restrict ρ = O(1) to preserve succinct verification and maintain the optimal O˜(λ) proof size. We overcome this "constant barrier", which enables larger ρ and thereby reduces the proof size. To achieve this, we introduce the following technical contributions.
+
+- (i) Committed folding. Instead of sending O(ρ) cross-terms in the clear, the prover commits to the messages and later proves that the committed vector satisfies the verification relations. This enables the use of a larger shrinking factor, thereby reducing the number of recursion rounds. While this strategy has been successfully used in LaBRADOR (CRYPTO 2023), additional care is required here to preserve succinct verification.
+- (ii) Recursive commitments. We generalise the double-commitment technique from LaBRADOR into a framework for recursive commitments, yielding further compression in commitment size. This results in concrete improvements in communication within each recursion round.
+- (iii) Sumcheck-driven structured recursion. We extend the sumcheck framework from SALSAA (ePrint 2025/2124) to prove substantially more complex constraints arising in our construction (and open for future extensions), including correctness of random projections, inner-product claims and wellformedness of recursive commitments. While expressing these constraints as sumcheck relations requires considerable technical effort, the resulting protocols compose seamlessly with the structured recursion, yielding both linear-time proving and succinct verification.
+
+# <span id="page-0-0"></span>1 Introduction
+
+Succinct argument systems [\[Kil92,](#page-49-0) [Mic94\]](#page-50-0) allow a prover to convince a verifier of a statement's validity using communication that is significantly shorter than the witness itself. This powerful compression capability underlies some of the most impactful applications in modern cryptography, including verifiable outsourced computation [\[KP16,](#page-49-1)[Lee21,](#page-49-2)[GSW23\]](#page-49-3), verifiable fully-homomorphic encryption [\[GBK](#page-48-0)+24, [LLZ](#page-49-4)+25, [ABPS24,](#page-47-0) [ZLW](#page-50-1)+25], aggregate signatures [\[BK20,](#page-48-1) [AAB](#page-47-1)+24], and verifiable delay functions [\[LM23,](#page-49-5)[OKC](#page-50-2)+25].
+
+As quantum computers threaten the security foundations of group-based cryptography, the demand for post-quantum secure succinct arguments has become increasingly urgent. Lattice-based
+
+<sup>⋆</sup> also known as "late baRoK".
+
+{1}------------------------------------------------
+
+constructions offer a compelling direction as they rely on well-studied hardness assumptions believed to remain secure against quantum attacks, while their rich algebraic structure enables efficiency advantages that hash-based approaches cannot easily match.
+
+# 1.1 Two Approaches in Lattice-Based Succinct Arguments
+
+At the core of lattice-based arguments lies an efficient proof of knowledge of a low-norm witness vector w ∈ R<sup>m</sup> satisfying
+
+<span id="page-1-0"></span>
+$$\mathbf{F}\mathbf{w} = \mathbf{y} \bmod q \quad \text{and} \quad \|\mathbf{w}\| \le \beta, \tag{1}$$
+
+where R = Z[ζ] denotes the ring of integers of the f-th cyclotomic field K := Q(ζ) of degree φ = φ(f). While the linear relation can be shown relatively directly, the main challenge is to prove that the witness w is short. Existing constructions either prove a relaxed variant of the equation—which affects parameter choices—or rely on additional machinery to enforce shortness.
+
+A prominent instance of the former category is the lattice adaptation of the Bulletproofs protocol [\[BLNS20,](#page-48-2)[AL21,](#page-47-2)[ACK21,](#page-47-3)[BCS21\]](#page-47-4) which was the first lattice-based argument system with poly(log m, λ) proof size. Let ρ ∈ N be the shrinking factor. To prove [\(1\)](#page-1-0), the prover and verifier parse the matrix F := [F<sup>0</sup> | F<sup>1</sup> | · · · | Fρ−1], while the prover decomposes the witness w := (wi)i∈[k] into ρ smaller vectors w0, . . . , wρ−<sup>1</sup> ∈ Rm/ρ. The prover then transmits all ρ 2 cross-terms
+
+$$\mathbf{g}_{i,j} := \mathbf{F}_i \mathbf{w}_j \mod q \qquad \forall i, j \in [\rho],$$
+
+to the verifier, who immediately checks that
+
+<span id="page-1-1"></span>
+$$\sum_{i=0}^{\rho-1} \mathbf{g}_{i,i} = \sum_{i=0}^{\rho-1} \mathbf{F}_i \mathbf{w}_i = \mathbf{F} \mathbf{w} = \mathbf{y} \pmod{q}.$$
+ (2)
+
+The verifier then samples challenges c0, . . . , cρ−<sup>1</sup> ← C from a challenge space C ⊆ R consisting of short ring elements. The key observation is that the folded witness
+
+$$\mathbf{z} := \sum_{i=0}^{\rho-1} c_i \mathbf{w}_i \in \mathcal{R}^{m/\rho}$$
+
+satisfies
+
+<span id="page-1-2"></span>
+$$\left(\sum_{i=0}^{\rho-1} c_i \mathbf{F}_i\right) \mathbf{z} = \sum_{i=0}^{\rho-1} \sum_{j=0}^{\rho-1} c_i c_j \mathbf{g}_{i,j} \mod q \quad \text{and} \quad \|\mathbf{z}\| \le \beta_z$$
+(3)
+
+for an appropriately chosen bound βz. As this statement retains the structure of [\(1\)](#page-1-0), the prover can recursively repeat the procedure O(log m) times until the final folded witness is small enough to reveal directly.
+
+As analysed in [\[AL21,](#page-47-2)[ACK21,](#page-47-3)[BCS21\]](#page-47-4), the lattice Bulletproofs protocol suffers from several efficiency drawbacks. Most notably, the knowledge-soundness argument critically depends on subtractive sets C, in which the difference between any two distinct elements c, c′ ∈ C must be invertible in R<sup>q</sup> := R/qR, and the inverse must itself be short. This constraint inherently limits C to polynomial size [\[AL21\]](#page-47-2), implying an inverse-polynomial soundness error. Soundness amplification is required for a soundness error of 2−<sup>λ</sup> , where λ is the security parameter. This increases communication a factor of Ω(λ/ log λ). As a consequence, lattice Bulletproofs have practically and theoretically large communication.
+
+{2}------------------------------------------------
+
+Subsequent work in this area has diverged into two main directions. One path focuses on constructing succinct arguments with concretely efficient proof sizes, while the other aims at asymptotically efficient arguments with polylogarithmic verification. We elaborate on both directions below.
+
+<span id="page-2-2"></span>Path 1: Concrete efficiency and proof size. The lattice Bulletproofs protocol was substantially advanced by LaBRADOR [\[BS23\]](#page-48-3), which introduces several key modifications. The first is that it departs from subtractive sets and instead adopts the random-projection technique of [\[BL17,](#page-48-4)[LNS21,](#page-50-3) [GHL22,](#page-49-6) [LNP22,](#page-50-4) [BS23\]](#page-48-3). To demonstrate that w is (approximately) short, the verifier samples a random integer matrix J ∈ Z <sup>r</sup>×mφ with small entries (e.g. from {−1, 0, 1}). The prover computes the projected vector v := Jcf(w) mod q ∈ Z r q , where cf(w) ∈ Z mφ is the standard coefficient embedding of the ring vector w. The verifier checks that v has small norm, while the prover must additionally prove that v is well-formed; this can be expressed as a linear relation over R<sup>q</sup> as shown in [\[LNP22\]](#page-50-4). Crucially, this technique removes the dependence on subtractive sets, and thus the protocol requires no additional repetitions.
+
+The second change is that the prover no longer transmits all ρ 2 cross-terms gi,j . Instead, the prover commits to the concatenated vector g := (gi,j )i∈[ρ],j∈[ρ] , and later proves that the committed value satisfies the linear constraints required for verification, namely those in Equations [\(2\)](#page-1-1) and [\(3\)](#page-1-2). This committed folding approach allows LaBRADOR to select large shrinking factors ρ = O(m1/<sup>3</sup> ), yielding only O(log log m) recursive rounds.
+
+Finally, in LaBRADOR the witness w is committed in a double-commitment fashion[4](#page-2-0) . Specifically, the commitment tout to a short vector w is defined by
+
+$$\mathbf{t}_{\mathsf{in}} := (\mathbf{F}_{\mathsf{in}} \otimes \mathbf{I}_{\rho})\mathbf{w} \bmod q, \text{ and } \mathbf{t}_{\mathsf{out}} := \mathbf{F}_{\mathsf{out}}(\mathbf{G}^{-1}(\mathbf{t}_{\mathsf{in}})) \bmod q,$$
+
+where G−<sup>1</sup> (·) denotes the standard gadget decomposition map. This two-layer design enables a reduction in the final commitment size: the (Module-)SIS rank of the outer commitment matrix Fout becomes essentially independent of the witness length m, unlike in classical Ajtai commitments [\[Ajt96\]](#page-47-5).
+
+As a consequence of the aforementioned improvements, LaBRADOR achieves concretely efficient proof sizes, around 60KB even for large statements (with witness consisting of ≈ 2 <sup>20</sup> ring elements). Its main drawback is the linear verification time. Indeed, even processing the random projection matrix J already takes time Ω(m). The subsequent work Greyhound [\[NS24\]](#page-50-5) addresses this limitation by invoking LaBRADOR as a subroutine, where each invocation is on a witness of length O( √ m). As a result, Greyhound inherits the appealing proof sizes of LaBRADOR while achieving sublinear verification time.
+
+<span id="page-2-1"></span>Path 2: Succinct verification. Motivated by the growing interest in constructing SNARKs from Polynomial Interactive Oracle Proofs, there has been much research on lattice-based polynomial commitment schemes (PCS). In this direction, [\[CLM23\]](#page-48-5) first adapted lattice Bulletproofs to support succinct verification by endowing the commitment matrix F with a tensor structure. This modification leads to a commitment that is binding under a new assumption, called the Vanishing SIS (vSIS) assumption. Independently, [\[BCS23\]](#page-47-6) achieved fast verification for lattice Bulletproofs via additional preprocessing. However, both constructions inherit all the underlying limitations of lattice Bulletproofs itself [\[BCS23,](#page-47-6)[CLM23\]](#page-48-5).
+
+<span id="page-2-0"></span><sup>4</sup> In [\[BS23\]](#page-48-3), the authors refer to this as "inner" and "outer" commitments.
+
+{3}------------------------------------------------
+
+A different line of work [AFLN24, CMNW24, KLNO24b] develops succinct arguments with polylogarithmic verification time by applying FRI-style [BBHR18] split-and-fold techniques. These protocols still require repetitions due to the use of subtractive sets, but they yield more efficient proofs than Bulletproofs, since they involve only  $O(\rho)$  cross-terms, compared to  $O(\rho^2)$  required in lattice Bulletproofs.
+
+The reliance on subtractive sets was later removed by [KLNO25], which adapts the random projection strategy to demonstrate shortness. Directly using LaBRADOR-style random projections is infeasible here due to the goal of achieving fast verification. To address this, the authors employ tensor-structured projection matrices of the form  $\mathbf{J} := \mathbf{I} \otimes \mathbf{J}'$ , where  $\mathbf{I}$  is the identity matrix and  $\mathbf{J}'$  is a short random challenge matrix with  $O(\lambda)$  rows and columns. Consequently, the verifier only needs to operate on  $\mathbf{J}'$ , and with a carefully designed split-and-fold protocol, succinct verification becomes possible. As a result, [KLNO25] achieves asymptotically optimal  $\tilde{O}(\lambda)$ -sized proofs, notable since all prior post-quantum argument systems, including hash-based ones [ACFY24, ACFY25], only obtained  $\tilde{O}(\lambda^2)$  proofs. Despite this attractive asymptotic behaviour, concrete efficiency remains limited as proof sizes scale to low-order megabytes for large circuits (with witness consisting of  $\approx 2^{23}$  ring elements).
+
+While random projections can demonstrate that the committed witness is approximately short, they cannot on their own certify exact norm bounds. To address this, [KLNO24b, KLNO25] showed how to prove inner products between committed vectors modulo q. Provided that  $\mathbf{w}$  is sufficiently short, no modular wrap-around occurs, enabling the prover to establish inner products over  $\mathbb{Z}$ . Building on this, SALSAA [KLOT25] incorporates sumcheck protocols [LFKN92] to verify exact  $\ell_2$  norm bounds. Unlike [KLNO24b, KLNO25], SALSAA enjoys linear-time prover.
+
+<span id="page-3-0"></span>Bridging the gap. LaBRADOR [BS23] achieves remarkably small proof sizes, owing to its use of super-constant folding, double-layer commitments, and random projections for establishing shortness. However, its principal limitation is the linear verification time, and even with the improvement offered by Greyhound [NS24], the verifier remains more than two orders of magnitude slower than hash-based alternatives. Conversely, argument systems that support succinct verification are still far from concretely competitive. Although recent work has addressed the challenge of incorporating structured Johnson–Lindenstrauss projections into this setting, it remains unclear whether the other key techniques underpinning LaBRADOR can be adapted to the succinct-verifier regime while preserving practical efficiency. This raises a natural question: can one design a lattice-based argument system that admits polylogarithmic verification time while achieving proof sizes and concrete performance comparable to those of LaBRADOR [BS23] and Greyhound [NS24]?
+
+#### 1.2 Our contributions
+
+We present RoKoko - a lattice-based argument system that unifies the strengths of both paths, achieving nearly the best of both worlds:
+
+- (i) **Succinct verification:** polylogarithmic verifier runtime, matching the strongest constructions on Path 2;
+- (ii) Optimal prover complexity: linear-time proving that matches the theoretical lower bound;
+- (iii) Compact proofs: proof sizes that substantially improve upon prior work in the succinct-verification regime, narrowing the gap to the LaBRADOR line; and
+- (iv) **Rich expressiveness:** native support for structured relations, polynomial commitments, and many natural arithmetisations, e.g. R1CS.
+
+{4}------------------------------------------------
+
+<span id="page-4-1"></span>Technical innovations. Our main technical contribution is to adapt committed superconstant folding – a technique pioneered by LaBRADOR [\[BS23\]](#page-48-3) – to the vSIS-based framework that supports succinct verification. In the LaBRADOR line, the verifier performs work proportional to the witness size, so the folding structure can remain opaque to the verifier. In the succinct-verification regime, however, the verifier must efficiently check consistency of the folded instances without implicitly reading the full witness, which requires the folding to respect the algebraic structure of the underlying commitment scheme. Concretely:
+
+- Structured superconstant folding. We show how to fold by a superconstant factor within the vSIS-based framework while preserving the structure needed for succinct verification. We extend the random projection technique of [\[KLNO25\]](#page-49-8) to handle this more aggressive folding, yielding a significant reduction in the number of rounds.
+- Recursive commitments. We introduce a recursive commitment structure where the outermost commitment – the only one the verifier inspects explicitly – has low rank independent of the witness size. This compresses the commitment component of the proof, which dominates proof size in prior constructions from Path 2 (the succinct-verification regime); such recursive commitments were not previously available in this setting.
+- Sumcheck-based linear-time proving. Building on [\[KLOT25\]](#page-49-9), we integrate sumcheck protocols to efficiently prove well-formedness of the recursive commitments and correctness of projections. The sumcheck machinery is particularly well-suited to the recursive commitment structure: it allows the prover to demonstrate that each layer of commitments is correctly formed without materialising intermediate witnesses, achieving optimal linear-time proving without sacrificing succinctness.
+- Implementation and evaluation. We implement RoKoko and conduct experiments, demonstrating that our improvements translate to practice: competitive proof sizes alongside faster verification compared to prior lattice-based constructions. We also provide a complete asymptotic analysis and show how to instantiate RoKoko as a SNARK for structured relations and a polynomial commitment scheme.
+- Incomplete-NTT library As a side achievement, we provide the most efficient, to date, open-source implementation of the "almost-splitting" cyclotomic ring arithmetic (in our concrete settings) for that underpins our construction, which is of independent interest.
+
+We summarise the concrete performance of RoKoko compared to prior post-quantum SNARKs and PCSs in Table [1.](#page-5-0) Compared to SALSAA [\[KLOT25\]](#page-49-9), the closest prior work with succinct verification, RoKoko achieves an order-of-magnitude improvement in proof size and prover runtime, and 20–30× faster verification. Compared to Greyhound [\[NS24\]](#page-50-5), which optimises for proof size and concrete efficiency but lacks succinct verification, RoKoko offers even 100× faster verification while remaining competitive in proof size and prover runtime.
+
+## 1.3 Related work
+
+<span id="page-4-0"></span>Group- and hash-based succinct arguments. Group-based arguments such as Groth16 [\[Gro16\]](#page-49-11), PLONK [\[GWC19\]](#page-49-12) and others [\[PHGR13,](#page-50-6)[GGPR13,](#page-49-13)[WTs](#page-50-7)+18,[MBKM19,](#page-50-8)[XZZ](#page-50-9)+19,[BFS20,](#page-48-7)[CHM](#page-48-8)+20] achieve strong efficiency but rely on assumptions like discrete logarithm, and are thus insecure against quantum adversaries. Hash-based argument systems, such as FRI [\[BBHR18\]](#page-47-8), Ligero [\[AHIV23\]](#page-47-11), Aurora [\[BCR](#page-47-12)+19], Brakedown [\[GLS](#page-49-14)+23], and WHIR [\[ACFY25\]](#page-47-10), offer post-quantum security and transparent setup. In particular, WHIR achieves extremely efficient verification time. However,
+
+{5}------------------------------------------------
+
+<span id="page-5-0"></span>Table 1. Concrete performance of our work vs. prior post-quantum SNARKs/PCSs ( $|\pi|$  = proof size in KB). Hash-based: Brakedown [GLS<sup>+</sup>23], Ligero [AHIV17], FRI [BBHR18], WHIR [ACFY25]. Lattice-based: CMNW24 [CMNW24], HSS24 [HSS24], Papercraft [OKC<sup>+</sup>25], KLNO25 [KLNO25], Greyhound [NS24], SALSAA [KLOT25] ( $\varphi$ =256). For non-lattice schemes and HSS24, times and sizes are from the original papers. For Greyhound and SALSAA, we ran their open-source code ourselves. For SALSAA, we reduced the number of threads to 1 to remove the parallelisation effect. Due to the scheme's memory requirement exceeding 64 GB, the experiments marked with "†" were performed on a separate machine. To ensure a fair comparison, the results were scaled to match the performance of the system used in the remaining experiments.
+
+|                               |                | $\#\mathbb{Z}_q$ = | $=2^{26}$        |                    |                 | $\#\mathbb{Z}_q$ = | $=2^{28}$                                                          |                    |                                        | $\#\mathbb{Z}_q$                            | $=2^{30}$                            |                 |
+|-------------------------------|----------------|--------------------|------------------|--------------------|-----------------|--------------------|--------------------------------------------------------------------|--------------------|----------------------------------------|---------------------------------------------|--------------------------------------|-----------------|
+| Scheme                        | Comm.          | Р                  | V                | $ \pi $            | Comm.           | Р                  | V                                                                  | $ \pi $            | Comm.                                  | Р                                           | V                                    | $ \pi $         |
+| Brakedown<br>Ligero           | 36s<br>39.9s   | 3.21s<br>3.11s     | 0.703s<br>0.196s | 49157<br>7256      | 150s<br>169s    | 13s<br>12.4s       | $\frac{2.56s}{0.402s}$                                             | 93767<br>14383     | 605s<br>717s                           | $\begin{array}{c} 48.6s \\ 50s \end{array}$ | 2.96s<br>0.846s                      | 181948<br>28631 |
+| FRI<br>WHIR<br>CMNW24         | -              | 185s<br>l0s<br>-   | 0.041s<br>5.4ms  | 740<br>689<br>1546 | - 86            | 60s<br>-           | 6.1ms                                                              | 770<br>-           | -<br>37(<br>-                          | 00s<br>-                                    | 6.6ms                                | $848 \\ 5296$   |
+| HSS24<br>Papercraft<br>KLNO25 | 18<br>-<br>-   | 88s<br>-<br>-      | 1.07s<br>-<br>-  | 48640<br>-<br>2181 | -<br>15<br>-    | -<br>93s<br>-      | 5.10s                                                              | -<br>18940<br>2604 | -<br>698<br>-                          | -<br>86s<br>-                               | 6.00s                                | 29790<br>3152   |
+| Greyhound<br>SALSAA           | 4.80s<br>1.71s | 1.41s<br>108.59s   | 0.42s $0.289s$   | 46<br>1005         | 18.62s<br>6.76s | 5.41s<br>439.73s   | $\begin{array}{c} 0.75 \mathrm{s} \\ 0.359 \mathrm{s} \end{array}$ | 53                 | $83.54s^{\dagger} \\ 24.49s^{\dagger}$ |                                             | $1.50s^{\dagger}$ $0.419s^{\dagger}$ | 53<br>1459      |
+| RoKoko                        | 1.42s          | 1.41s              | 6.91ms           | 187                | 5.33s           | 2.87s              | $7.02 \mathrm{ms}$                                                 | 187                | 22.33s                                 | 8.08s                                       | 11.43ms                              | 187             |
+
+hash-based schemes generally fall short in prover efficiency and proof size compared to lattice-based alternatives.
+
+<span id="page-5-1"></span>Non-succinct lattice-based arguments. Non-succinct lattice-based arguments [LNSW13,BLS19, ALS20,LNP22] have proof size and verification time linear in the witness size, offering high concrete efficiency for small relations. These protocols typically focus on the zero-knowledge property rather than succinctness.
+
+<span id="page-5-2"></span>Folding schemes. Orthogonal to "monolithic" SNARKs discussed above (following the terminology of [BCFW25]), a line of works [BC25a, FKNP24, BMNW25a, BMNW25b, NS25, BC25b, BCFW25] have proposed post-quantum folding schemes (or accumulation schemes) that can be used as building blocks of incrementally-verifiable computation protocols [Val08] and proof-carrying data [CT10]. Folding schemes can also be generically compiled into SNARKs using the transformation from [KST21].
+
+Among recent quantum-safe folding schemes, several rely on lattice assumptions [BC25a,FKNP24, NS25,BC25b]. As in our setting, the prover must prove (exact) shortness of the witness. To achieve this, [BC25a,NS25,BC25b] apply the sumcheck protocol to prove the  $\ell_{\infty}$  norm bound. However, as the communication complexity scales linearly with the range, this approach becomes impractical for large  $\ell_{\infty}$  bounds and is not well-suited to prove  $\ell_2$  norms.
+
+### 2 Technical Overview
+
+We give a high-level overview of our lattice-based succinct argument construction, its applications and its implementation.
+
+## 2.1 Background
+
+Let  $\mathcal{R} \cong \mathbb{Z}[x]/\langle \Phi_{\mathfrak{f}}(x) \rangle$  be a cyclotomic ring and  $\mathcal{R}_q = \mathcal{R}/q\mathcal{R}$  for a prime q. Works on lattice-based succinct arguments typically consider a sufficiently expressive relation defined over  $\mathcal{R}_q$  where the
+
+{6}------------------------------------------------
+
+witness is a matrix  $\mathbf{W} \in \mathcal{R}^{m_{\mathbf{w}} \times r}$  of norm at most some  $\beta_{\mathbf{w}}$ . Intuitively, think of  $\mathbf{W}$  as a very tall matrix, e.g. of height  $m_{\mathbf{w}} = 2^{20}$ , with a relatively much smaller width. The goal is always to progressively shrink the witness dimension  $m_{\mathbf{w}}$  until it is small enough to be sent in the clear. Two intertwined challenges must be addressed:
+
+- 1. Witness folding. The basic idea of shrinking the witness **W** is to fold **W** into **Wc** by some verifier challenge **c**, and then repack the witness into a smaller matrix **W**'. The shrink factor  $\rho$ , i.e. the rate at which the witness dimension is reduced, is roughly the dimension of **c**. What distinguishes the semi-<sup>6</sup> and fully-succinct settings is that, in the latter, the verifier must be able to check (among other constraints to due to norm control) the correctness of folding in polylogarithmic time.
+- <span id="page-6-2"></span>2. Norm control. In the process of shrinking the witness dimension, we have to control the norm of the witness at around the same level, say  $\beta_{\tt w}$ . In more detail, this is split into two sub-challenges: Completeness, i.e. the honest prover can produce a valid witness for the reduced instance. Simply folding  ${\bf W}$  into  ${\bf Wc}$  may increase the norm, causing the reduced instance to have a relaxed norm bound. This relaxation could accumulate throughout composition. An established technique to solve this issue is by decomposing the folded witness  ${\bf Wc}$ . If the shrinking effect by  ${\bf c}$  outweighs the expansion of the decomposition then there is a net reduction in the witness dimension. In the following, we will take this technique for granted and omit it from out discussion. Extraction, i.e. the extractor can recover a valid witness for the original instance. As is common for lattice-based arguments, the extractor does not recover a witness satisfying the relation exactly, but rather a "relaxed" witness  $({\bf W},{\bf s})$  where  ${\bf s}$  is a short "slack" vector. This witness is relaxed in two ways. First, the extractor may only guarantee  $\|{\bf W}\cdot{\bf diag}({\bf s})\| \le \beta'_{\bf w}$  but not necessarily  $\|{\bf W}\| \le \beta'_{\bf w}$ . Second, this norm bound may not be as tight as the original, i.e.  $\beta'_{\bf w} > \beta_{\bf w}$ . This relaxation could, again, accumulate throughout composition.
+
+Numerous prior works in the lattice-based succinct arguments literature have proposed various ways to address subsets of the above challenges with different trade-offs. We highlight some that are more relevant to this work.
+
+Regarding witness folding, [CLM23] proposes using vSIS commitments so that the witness can be folded in a structured way that enables a polylogarithmic verifier. This method is refined in [KLNO24b] and adopted in [KLNO25, KLOT25]. In [KLNO24b, KLNO25, KLOT25], folding the witness by a factor  $\rho$  requires communication proportional to  $\rho$  per round, forcing them to pick  $\rho = O(1)$  upon optimisation. LaBRADOR [BS23] achieves a shrink factor of  $\rho = O(m_w^{1/3})$  with essentially constant communication per round by having the prover commit to the communication. However, this method of folding breaks whatever structure the original relation might have, causing the verifier to run in time proportional to  $m_w$ .
+
+Regarding norm control, LaBRADOR [BS23] uses random projections to eliminate the slack vector  $\mathbf{s}$ . However, the projection matrices are unstructured, which again causes the verifier to run in time proportional to  $m_{\mathbf{w}}$ . RoK and Roll [KLNO25] adapted this technique to the fully-succinct setting by introducing structured projections. Then, to force the extracted witness norm  $\beta'_{\mathbf{w}}$  to be the same as the original norm  $\beta_{\mathbf{w}}$ , SALSAA [KLOT25] adapted the sumcheck protocol to prove the exact norm of the witness with a prover that runs in strict- (as opposed to quasi-)linear time, improving upon the norm-check RoK of [KLNO24b].
+
+<span id="page-6-0"></span><sup>&</sup>lt;sup>5</sup> Prior works typically describe this in the other way around – first repack the witness to create many columns then fold to a fewer number of columns. The fold-then-split perspective is more convenient for this work.
+
+<span id="page-6-1"></span><sup>&</sup>lt;sup>6</sup> In the semi-succinct setting, only the proof size but not the verifier time must be polylogarithmic in the witness size.
+
+{7}------------------------------------------------
+
+The main contribution of this work is to adapt LaBRADOR's [BS23] committed folding technique to the fully-succinct setting while retaining all techniques introduced in [KLNO24b, KLNO25, KLOT25] for structure-preserving norm control. This will ultimately allow us to achieve a more favourable trade-off than the state-of-the-art. Our construction of succinct arguments is built by composing a small number of reductions of knowledge (RoKs) which maps between two relations – a committed-linear relation  $\Xi_{\text{COM}}^{\text{lin}}$  and a functional-sumcheck relation  $\Xi_{\text{COM}}^{\text{sum}}$ , both defined over  $\mathcal{R}_q$ . While either relation can be taken as the "starting" relation, in this exposition we start from the committed-linear relation  $\Xi_{\text{COM}}^{\text{lin}}$  which is easier to explain. In other words, we will build a succinct argument system for  $\Xi_{\text{COM}}^{\text{lin}}$ .
+
+#### 2.2 Core Design
+
+At a high level, in  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  the prover's witness wit mainly consists of a matrix  $\mathbf{W} \in \mathcal{R}^{m_{\mathsf{w}} \times r}$  satisfying linear constraints  $\mathbf{F}_i \mathbf{W} = \mathbf{H}_i \mathbf{Y}_i \mod q$  for all i, where we can think of  $\mathbf{Y}_1$  as a commitment of  $\mathbf{W}$ . The matrices  $\mathbf{Y}_i$  on the right-hand side are auxiliary witness components which are themselves (recursively) committed. The main witness component  $\mathbf{W}$  additionally satisfies a linear constraint of the form  $\mathbf{l}^T \mathbf{W} \mathbf{r} = t \mod q$ . Intuitively, think of  $\mathbf{W}$  as a very tall matrix, e.g. of height  $m_{\mathsf{w}} = 2^{20}$ , while  $\mathbf{Y}_i$  is relatively much smaller. Furthermore, the witness components  $\mathbf{W}, \mathbf{Y}_i$  must be low-norm.
+
+Our goal is to iteratively reduce a large  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  instance into progressively smaller ones while maintaining full-succinctness – the verifier's runtime (and hence the proof size) must be at most  $\mathsf{poly}(\lambda, \log |\mathsf{wit}|) = \mathsf{poly}(\lambda, \log m_{\mathsf{w}} r)$ . In a nutshell, each round of our protocol consists of three RoKs:  $\Pi^{\mathsf{proj}}$  for random projection;  $\Pi^{\mathsf{fold-split}}$  for folding, splitting and encoding constraints into functional-sumcheck claims, and  $\Pi^{\mathsf{lin}}$  for turning sumcheck claims back into linear constraints. Symbolically, each round is a sequential composition of
+
+$$\Pi^{\mathsf{fold\text{-}split}} \circ \Pi^{\mathsf{proj}} \colon \varXi_{\mathsf{COM}}^{\mathsf{lin}} \to \varXi_{\mathsf{COM}}^{\mathsf{sum}} \qquad \text{and} \qquad \qquad \Pi^{\mathsf{lin}} \colon \varXi_{\mathsf{COM}}^{\mathsf{sum}} \to \varXi_{\mathsf{COM}}^{\mathsf{lin}}.$$
+
+After each round, the witness dimension  $m_w$  is reduced by a factor of  $\rho$  while other parameters remain essentially unchanged. In the following, we explain these RoKs in more detail.
+
+<span id="page-7-0"></span>Committed random projection  $\Pi^{\text{proj}}$ :  $\Xi_{\text{COM}}^{\text{lin}} \to \Xi_{\text{COM}}^{\text{lin}}$ . This RoK addresses norm control: inspired by [KLNO25], it is a self-reduction on  $\Xi_{\text{COM}}^{\text{lin}}$  that eliminates the extraction-side norm slack. The key idea relies on a variant of the Johnson-Lindenstrauss (JL) lemma: a random matrix  $\mathbf{J} \in \mathbb{Z}^{n_{\text{rp}} \times m_{\text{rp}}}$  with small i.i.d. entries maps  $\mathbf{x} \in \mathbb{Z}^{m_{\text{rp}}}$  so that the ratio  $\|\mathbf{J}\mathbf{x}\|/\|\mathbf{x}\|$  lies in a bounded interval  $[\alpha_{\text{rp}}, \beta_{\text{rp}}]$  with high probability – the norm is scaled up but tightly controlled. Naively, one would apply such a  $\mathbf{J}$  to the entire witness of dimension  $m_{\mathbf{w}}$ , but the verifier would then need to read all  $n_{\text{rp}} \times m_{\mathbf{w}}$  entries of  $\mathbf{J}$ , breaking succinctness. Instead, the prover applies a structured variant ( $\mathbf{I} \otimes \mathbf{J}$ ) where  $\mathbf{J} \in \mathbb{Z}^{n_{\text{rp}} \times m_{\text{rp}}}$  with  $m_{\text{rp}} \ll m_{\mathbf{w}}$ : the verifier only samples the small matrix  $\mathbf{J}$ , and the block-diagonal structure preserves the JL guarantee on each block. The JL guarantee ensures that a short projection image implies the original witness is short – without any extraction slack. The protocol is lightweight and computationally efficient – projection reduces to additions and subtractions of ring elements, and the verifier only needs to sample  $\mathbf{J}$ .
+
+We instantiate this idea in three variants. The coarse variant  $(\Pi^{\text{proj-c}})$  projects ring elements directly and is used while  $m_{\text{w}} \geq m_{\text{rp}}$ . The fine variant  $(\Pi^{\text{proj-f}})$  projects their coefficients via the trace-dual embedding (used once  $m_{\text{w}}$  drops below  $m_{\text{rp}}$ , relaxing the dimension requirement to  $m_{\text{rp}} \mid \varphi m_{\text{w}}$ ), and then batches the projection and lifts to constraints over  $\mathcal{R}_q$ . The batch-and-lift variant  $(\Pi^{\text{proj-fl}})$  generalises the fine variant by exploiting the chain of intermediate subfields  $\mathbb{F}_{q^a}$ 
+
+{8}------------------------------------------------
+
+of  $\mathcal{R}_q$  to gradually lift the projection image instead of immediately lifting to  $\mathcal{R}_q$ , yielding further asymptotic improvements. All variants share the same  $(\mathbf{I} \otimes \mathbf{J})$  structure, and – crucially – the prover commits to the (gadget-decomposed) projection image rather than sending it in the clear.
+
+Whereas coarse projections are similar to the random "structured" projection protocol in [KLNO25] aside from operating on different input and output relations, the fine and batch-and-lift variants introduce additional structure not present in the corresponding variant from [KLNO25]. This structure serves to keep the verifier efficient as the projection matrix grows wider – a necessity when matching the compression effect of larger shrinking factors  $\rho$ . In [KLNO25], the fine and batch-and-lift projection image (presented jointly as "unstructured" projection) has linear communication in both the projection height and the witness width, and is sent in the clear; in our setting, widening the witness and increasing the projection height to accommodate a large  $\rho$  would make this image prohibitively large for uncompressed transmission. Committing to the image reduces the communication overhead.
+
+<span id="page-8-1"></span>Committed folding-splitting  $\Pi^{\text{fold-split}} \colon \Xi_{\text{COM}}^{\text{lin}} \to \Xi_{\text{COM}}^{\text{sum}}$ . This RoK primarily addresses witness folding but also encodes all resulting constraints into sumcheck claims. The protocol starts from a committed-linear instance of width r, samples a low-norm challenge  $\mathbf{c} \in \mathcal{C}^r$ , folds the witness to  $\mathbf{W}\mathbf{c}$ , and packs all derived data into  $\widehat{\mathbf{w}}$ . It then computes the norm witness  $v = \langle \widehat{\mathbf{w}}, \overline{\widehat{\mathbf{w}}} \rangle$  and reshapes  $\widehat{\mathbf{w}}$  to a new witness matrix  $\mathbf{U}$  of width r'. Then, it derives a commitment  $\mathbf{F}\mathbf{U} = \mathbf{G}_{\ell''}\mathbf{Y} \mod q$  (with  $\mathbf{Y}$  being further recursively committed). Rather than returning a new  $\Xi_{\text{COM}}^{\text{lin}}$  with additional constraints, the second part of this RoK encodes all constraints – folded linear constraints, commitment well-formedness, right/global linear constraints and the exact norm check via v – into sumcheck claims while preserving succinct verification (in a similar manner as [KLOT25]). Due to the specific structure of the linear constraint arising in our protocol – they are either Kronecker row-tensors (originating from vSIS commitment keys) or sparse matrices (from auxiliary constraints) – the resulting multilinear extensions are efficiently evaluable, enabling a succinct sumcheck verifier.
+
+Linearisation with sumcheck  $\Pi^{\text{lin}} \colon \Xi_{\text{COM}}^{\text{sum}} \to \Xi_{\text{COM}}^{\text{lin}}$ . This RoK completes each round by re-encoding the sumcheck claims as linear constraints, enabling the next iteration. It executes the sumcheck protocol as a subroutine to reduce all accumulated sumcheck claims into evaluation claims on the committed witness. In our construction, it retains the constraint matrices (com, F, H) from the original instance and linearises the sumcheck claims into structured linear constraints, yielding a fresh  $\Xi_{\text{COM}}^{\text{lin}}$  instance with  $m_{\text{w}} \mapsto m_{\text{w}}/\rho^7$ . Our key optimisation is subfield batching: while combining multiple sumcheck claims via a random linear combination is standard, we additionally apply a random  $\mathbb{F}_{q^a}$ -linear map  $\Phi \colon \mathcal{R}_q \to \mathbb{F}_{q^a}$  (for a subfield  $\mathbb{F}_{q^a} \subseteq \mathcal{R}_q$ ) that collapses the  $\varphi/a$  components of the  $\mathbb{F}_{q^a}$ -decomposition of  $\mathcal{R}_q$  into one, so that each sumcheck round communicates only a single  $\mathbb{F}_{q^a}$  element. This keeps verifier work and communication low.
+
+## 2.3 Putting Everything Together
+
+<span id="page-8-2"></span>Composition and asymptotics. The full composition proceeds in two phases: first, a coarse chain  $(\Pi^{\mathsf{lin}} \circ \Pi^{\mathsf{fold-split}} \circ \Pi^{\mathsf{proj-c}})$  is iterated while  $m_{\mathtt{w}} \geq m_{\mathtt{rp}}$ ; once  $m_{\mathtt{w}}$  drops below  $m_{\mathtt{rp}}$ , the fine chain
+
+<span id="page-8-0"></span><sup>&</sup>lt;sup>7</sup> The "fresh"  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  instance does not shrink  $m_{\mathtt{w}}$  by the full folding width r, because the witness accumulates additional data over the course of the composition – projection images, auxiliary recursive-commitment information, gadget-decomposition overhead, etc. The parameter  $\rho$  therefore captures the *effective* compression factor per complete round, which is smaller than the number of columns r folded in  $\Pi^{\mathsf{fold-split}}$ .
+
+{9}------------------------------------------------
+
+ $(\Pi^{\text{lin}} \circ \Pi^{\text{fold-split}} \circ \Pi^{\text{proj-f}})$  takes over for the remaining rounds. With  $\rho = \lambda$ , the full composition yields a prover runtime of  $O(m_{\mathtt{w}})$   $\mathcal{R}_q$  operations (linear-time), verifier runtime of  $O(\lambda^3 \log m_{\mathtt{w}}/\log \lambda)$ , and proof size of  $O(\lambda \log^3 m_{\mathtt{w}}/\log^2 \lambda)$  bits. Compared to SALSAA [KLOT25], which is effectively limited to  $\rho = O(1)$  because their verifier complexity grows linearly in  $\rho$ , we reduce proof size by a factor of  $\log \lambda$  while matching prover complexity, at the cost of a theoretically larger verifier runtime. Practically, our verifier optimisations significantly reduce the overhead of processing random projection constraints, improving upon the verifier time of SALSAA as shown in our experiments.
+
+Applications. A succinct argument for  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  immediately yields a polynomial commitment scheme (PCS): the polynomial evaluation claim  $p(\mathbf{v}) = t$  is a linear constraint  $\mathbf{l}^{\mathsf{T}}\mathbf{Wr} = t \bmod q$  on the committed coefficient matrix  $\mathbf{W}$ , which is already a  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  instance (as noted above). If we instead take the more expressive  $\Xi_{\mathsf{COM}}^{\mathsf{sum}}$  as the starting relation, we obtain a SNARK for R1CS: the R1CS constraints are naturally expressible as sumcheck constraints captured by  $\Xi_{\mathsf{COM}}^{\mathsf{sum}}$ , though the verifier must additionally evaluate multilinear extensions on the public R1CS matrices, so verifier complexity grows by the cost of computing these MLE evaluations on public data.
+
+<span id="page-9-0"></span>Implementation. We implement RoKoko in Rust, targeting almost-splitting power-of-two cyclotomic rings ( $\mathcal{R}_q \cong (\mathbb{F}_{q^2})^{\varphi/2}$ , with  $\varphi = 128$ ,  $q \approx 2^{50}$ ). The choice of almost-splitting rings (residue degree e = 2) is driven by two requirements: it provides large enough NTT slots  $\mathbb{F}_{q^2}$  for sufficient soundness error per round, while still admitting efficient arithmetic via an incomplete NTT – each slot stores a degree-1 residue polynomial, and ring multiplication reduces to  $\varphi/2$  independent quadratic multiplications. We release the ring arithmetic layer as an independent open-source library. On top of it, we build a sumcheck module with a generic interface for expressing sumcheck relations, and instantiate it to deliver a PCS. For a PCS over  $2^{26}$  coefficients in  $\mathbb{Z}_q$  (single-threaded,  $\lambda = 128, \kappa = 2^{-100}$ ), our implementation produces a 214 KB proof in 4.4 s (commit + prove), with verification in 8.6 ms. Compared to SALSAA [KLOT25], this is a  $\sim 5 \times$  reduction in proof size,  $\sim 25 \times$  faster proving, and  $\sim 34 \times$  faster verification; compared to Greyhound [NS24], we offer  $\sim 50 \times$  faster verification.
+
+#### 2.4 Paper Organisation
+
+We define the relations  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  and  $\Xi_{\mathsf{COM}}^{\mathsf{sum}}$  in Section 4. The committed random projection protocols  $\Pi^{\mathsf{proj-c}}$  and  $\Pi^{\mathsf{proj-f}}$  are presented in Section 5, committed folding  $\Pi^{\mathsf{fold-split}}$  in Section 6, and the linearisation-with-sumcheck protocol  $\Pi^{\mathsf{lin}}$  in Section 7. The composition of these RoKs and the asymptotic analysis are given in Section 8, and implementation details with experimental results in Section 9.
+
+## 3 Preliminaries
+
+For  $n \in \mathbb{N}$ , we write  $[n] := \{0, 1, \dots, n-1\}$ , i.e. we count from 0. For vectors, we typically use lowercase bold letters, e.g.  $\mathbf{v}$ , and for matrices we use uppercase bold letters, e.g.  $\mathbf{M}$ . For a matrix  $\mathbf{M}$ , we write  $\mathbf{vec}(\mathbf{M})$  for the (column-style) vectorisation of  $\mathbf{M}$ . Conversely, we write  $\mathbf{V} = \mathsf{reshape}_k(\mathbf{v})$  to reshape a vector into a k-column matrix, such that  $\mathsf{vec}(\mathbf{V}) = \mathbf{v}$ , assuming compatible dimensions. Recall that for matrices  $\mathbf{A}, \mathbf{B}, \mathbf{C}$  with compatible dimensions the mixed-product property  $\mathsf{vec}(\mathbf{ABC}) = (\mathbf{C}^T \otimes \mathbf{A}) \cdot \mathsf{vec}(\mathbf{B})$  holds, where  $\otimes$  denotes the Kronecker product. We use  $\mathbf{A} \parallel \mathbf{B}$  to denote the horizontal concatenation of matrices  $\mathbf{A}$  and  $\mathbf{B}$  with the same number
+
+{10}------------------------------------------------
+
+of rows. We use  $(\mathbf{A}, \mathbf{B})$  to denote the vertical concatenation of matrices  $\mathbf{A}$  and  $\mathbf{B}$  with the same number of columns. We use  $\mathbf{A} \bullet \mathbf{B}$  to denote the row-wise tensor product of matrices  $\mathbf{A}$  and  $\mathbf{B}$  with the same number of rows. To highlight the row-tensor structure of a matrix  $\mathbf{A} = \mathbf{A}_0 \bullet \dots \bullet \mathbf{A}_{k-1}$  defined over ring  $\mathcal{R}$  (resp.,  $\mathcal{R}_q$ ), we write  $\mathbf{A} \in \mathcal{R}^{n \times 2^{\otimes k}}$  (resp.,  $\mathcal{R}_q^{n \times 2^{\otimes k}}$ ). We write minpowtwo(x) to denote the smallest power of two greater than or equal to x.
+
+### <span id="page-10-0"></span>3.1 Algebraic Number Theory
+
+Throughout, we let  $\mathcal{K} = \mathbb{Q}(\zeta)$  be a cyclotomic field with conductor  $\mathfrak{f}$  and degree  $\varphi = \varphi(\mathfrak{f})$  and  $\mathcal{R} = \mathcal{O}_{\mathcal{K}}$  its ring of integers. We write  $\mathsf{trace} = \mathsf{trace}_{\mathcal{K}/\mathbb{Q}}$  for the field trace and, by abuse of notation, the natural adaptation of the map from  $\mathcal{R}_q$  to  $\mathbb{Z}_q$ . If  $\mathbf{M}$  is a matrix then  $\mathsf{trace}(\mathbf{M})$  denotes taking trace entry-wise. For a prime modulus  $q \in \mathbb{N}$ , we write  $\mathcal{R}_q \coloneqq \mathcal{R}/q\mathcal{R}$ . We denote by  $\mathcal{R}^{\times}$  and  $\mathcal{R}_q^{\times}$  the sets of units in  $\mathcal{R}$  and  $\mathcal{R}_q$  respectively.
+
+Embeddings. We endow  $\mathcal{R}$  with two geometries via the coefficient embedding  $\mathsf{cf}_{\mathbf{b}}: \mathcal{R} \to \mathbb{Z}^{\varphi}$  (for a given basis  $\mathbf{b}$ ) and the canonical embedding  $\sigma: \mathcal{K} \to \mathbb{C}^{\varphi}$  (of  $\mathcal{K}$ ). Specifically, for a given  $\mathbb{Z}$ -basis  $\mathbf{b} = (b_i)_{i \in [\varphi]}$  of  $\mathcal{R}$  and an element  $x = \sum_{i \in [\varphi]} x_i b_i \in \mathcal{R}$ , we write  $\mathsf{cf}_{\mathbf{b}}(x) \coloneqq (x_i)_{i \in [\varphi]}$  and  $\sigma(x) \coloneqq (\sigma_j(x))_{j \in [\varphi]}$ , where  $\sigma_j \in \mathsf{Gal}(\mathcal{K}/\mathbb{Q})$ . We define the powerful basis of  $\mathcal{R}$  as  $\mathbf{b} = (1, \zeta, \dots, \zeta^{\varphi-1})$  for prime-power conductor  $\mathfrak{f}$ . The basis generalises to the composite conductor  $\mathfrak{f} = \prod_{i \in [k]} \mathfrak{f}_i^{e_i}$  for prime  $\mathfrak{f}_i$  via tensor product,  $\mathbf{b} = \bigotimes_{i \in [k]} \left(1, \zeta_{\mathfrak{f}_i}, \dots, \zeta_{\mathfrak{f}_i}^{\varphi(\mathfrak{f}_i)-1}\right)$ . If  $\mathbf{b}$  is the standard powerful basis, we may omit  $\mathbf{b}$  from the subscript of  $\mathsf{cf}_{\mathbf{b}}$ . We extend the notation of  $\mathsf{cf}_{\mathbf{b}}$  and  $\sigma$  naturally to vectors, i.e. if  $\mathbf{x} = (x_i)_{i \in [m]}^{\mathsf{T}} \in \mathcal{R}^m$ , then  $\mathsf{cf}_{\mathbf{b}}(\mathbf{x}) \coloneqq (\mathsf{cf}_{\mathbf{b}}(x_i))_{i \in [m]}^{\mathsf{T}}$  and  $\sigma(\mathbf{x}) \coloneqq (\sigma(x_i))_{i \in [m]}^{\mathsf{T}}$  are defined as concatenations. For matrices, we define  $\mathsf{cf}_{\mathbf{b}}$  and  $\sigma$  entry-wise so that  $\mathsf{cf}_{\mathbf{b}}$  is a map from  $\mathcal{R}^{n \times m}$  to  $\mathbb{Z}^{n\varphi \times m}$  and  $\sigma$  is a map from  $\mathcal{R}^{n \times m}$  to  $\mathbb{C}^{n\varphi \times m}$ . The inverse of  $\mathsf{cf}_{\mathbf{b}}$  is denoted by  $\mathsf{cf}_{\mathbf{b}}^{-1}$ , and we write  $\mathsf{cf}^{-1}$  when  $\mathbf{b}$  is the powerful basis.
+
+<span id="page-10-2"></span>Lemma 1 (Dual modulo prime [KLNO25, Lemma 1]). Let q be an unramified prime, i.e.  $q \nmid \mathfrak{f}$ , and  $\mathcal{R}$  be the ring of integers of a cyclotomic field  $\mathcal{K}$ . For any  $\mathbb{Z}$ -basis  $\mathbf{b} = (b_i)_{i \in [\varphi]} \in \mathcal{R}^{\varphi}$  of  $\mathcal{R}$ , there exists  $\mathbf{b}^{\vee} = (b_i^{\vee})_{i \in [\varphi]} \in \mathcal{R}^{\varphi}$  such that  $\operatorname{trace}(b_i \cdot b_j^{\vee}) = \delta_{i,j} \mod q$ , where  $\delta_{i,j}$  denotes the Kronecker delta, for all  $i, j \in [\varphi]$ .
+
+While considering the coefficient embedding with respect to the vector  $\mathbf{b}^{\vee}$ , when  $\mathbf{b}$  is a powerful basis, we may omit  $\mathbf{b}^{\vee}$  and write only  $\mathsf{cf}_{\vee}$ .
+
+Norms and Norm Conversion. The coefficient  $\ell_p$ -norm and canonical  $\ell_p$ -norm of an element  $x \in \mathcal{R}$  are defined as  $\|x\|_p := \|\mathsf{cf}_{\mathbf{b}}(x)\|_p$  and  $\|x\|_{\sigma,p} := \|\sigma(x)\|_p$  respectively, where  $\|\cdot\|_p$  is the standard  $\ell_p$ -norm on vectors. We extend the definitions naturally to vectors  $\mathbf{x} \in \mathcal{R}^m$  by defining  $\|\mathbf{x}\|_p := \|\mathsf{cf}_{\mathbf{b}}(\mathbf{x})\|_p$  and  $\|\mathbf{x}\|_{\sigma,p} := \|\sigma(\mathbf{x})\|_p$ . For a matrix  $\mathbf{B} = (\mathbf{b}_0, \dots, \mathbf{b}_{m-1}) \in \mathcal{R}^{n \times m}$ , we define  $\|\mathbf{B}\|_p = \max_{i \in [m]} \|\mathbf{b}_i\|_p$  and similarly for  $\|\mathbf{B}\|_{\sigma,p}$ . By default, we use "norm" to refer to the  $\ell_2$ -norm over the coefficient embedding, i.e.  $\|\mathbf{x}\| := \|\mathsf{cf}_{\mathbf{b}}(\mathbf{x})\|_2$ .
+
+<span id="page-10-1"></span>Lemma 2 (Relations between norms ( [KLNO24a, Lemma 1])). Let  $x \in \mathcal{K} = \mathbb{Q}(\zeta_{\mathfrak{f}})$  and  $\varphi = \varphi(\mathfrak{f})$ . Let  $\hat{\mathfrak{f}}$  be  $\mathfrak{f}$  if  $\mathfrak{f}$  is odd and  $\mathfrak{f}/2$  if it is even; let  $\mathsf{rad}(\mathfrak{f})$  be the radical (i.e. the product of all primes dividing  $\mathfrak{f}$ ). Then we have  $\|x\|_2 \leq \sqrt{\frac{\mathsf{rad}(\mathfrak{f})}{\mathfrak{f}}} \|x\|_{\sigma,2}$  and  $\|x\|_{\sigma,2} \leq \sqrt{\hat{\mathfrak{f}}} \cdot \|x\|_2$ .
+
+Operator norm and expansion factor. Fix the coefficient embedding cf above. For  $c \in \mathcal{R}_q$ , let  $\|c\|_{op} := \sup_{t \in \mathcal{R}_q \setminus \{0\}} \frac{\|t \cdot c\|}{\|t\|}$ . For some set  $S \subseteq \mathcal{R}_q$ , we let  $\gamma_S := \max_{c \in S} \|c\|_{op}$ .
+
+{11}------------------------------------------------
+
+Challenge set. Given any ring  $\mathcal{R}_q$ , we call a set  $\mathcal{C}$  a challenge set if for all  $c_1 \neq c_2 \in \mathcal{C}$  the difference  $c_1 - c_2$  is invertible (modulo q). For example, any field embedded in the ring is a challenge set. We say that  $\mathcal{C}$  is of norm  $\gamma$  if  $\gamma_{\mathcal{C}} \leq \gamma$ , i.e.  $||c||_{\mathsf{op}} \leq \gamma$  for all  $c \in \mathcal{C}$ .
+
+Gadget decomposition. Let  $\mathbf{x} \in \mathcal{R}^m$  be of norm at most  $\beta$  and dimension m. Let  $\mathbf{y} := \mathbf{G}_{\ell}^{-1}(\mathbf{x}) \in \mathcal{R}^{\ell m}$ , i.e. the gadget decomposition of  $\mathbf{x}$  into  $\ell m$  coefficients in  $\mathcal{R}$ . We denote the inverse operation by  $\mathbf{x} = \mathbf{G}_{\ell}(\mathbf{y})$ . We omit the subscript  $\ell$  when it is clear from the context. The (most pessimistic) bound on the base b of the gadget decomposition is  $b \geq \lceil \beta^{1/\ell} \rceil$ . Then, the norm of  $\mathbf{y}$  is at most  $\beta' = \sqrt{\varphi m \ell} \cdot b/2$ . We write  $\beta' = \mathsf{dcmp}_{m,\ell}(\beta)$  or simply  $\beta' = \mathsf{dcmp}(\beta)$  to denote this transformation. We also write  $\beta = \mathsf{cmp}_{m,\ell}(\beta')$  or simply  $\beta = \mathsf{cmp}(\beta')$  to denote the inverse transformation.
+
+NTT decomposition. We assume that the cyclotomic polynomial  $\Phi_{\mathfrak{f}}(X)$  splits modulo q into  $\varphi/e$  irreducible factors of equal degree e, i.e.  $\Phi_{\mathfrak{f}}(X) \equiv \prod_{j=0}^{\varphi/e-1} f_j(X) \pmod{q}$ , By the Chinese Remainder Theorem, this induces a ring isomorphism  $\mathsf{NTT} \colon \mathcal{R}_q \to \mathbb{F}_{q^e}^{\varphi/e}$ ,  $a \mapsto (a \bmod f_j)_{j \in [\varphi/e]}$ , The inverse map  $\mathsf{NTT}^{-1} \colon \mathbb{F}^{\varphi/e} \to \mathcal{R}_q$  recovers the ring element from its components via CRT reconstruction.
+
+#### 3.2 Polynomials and Multilinear Extension
+
+Let  $\mathbf{x} = (\mathbf{x}_0, \dots, \mathbf{x}_{\mu-1})$  and  $\mathbf{z} = (\mathbf{z}_0, \dots, \mathbf{z}_{\mu-1})$  be formal variables. We write  $\mathcal{R}_q[\mathbf{z}]^{\leq \delta}$  for the set of all (multivariate) polynomials over  $\mathcal{R}_q$  with variables  $\mathbf{z}$  with individual degree at most  $\delta$ . For a vector  $\mathbf{w} \in \mathcal{R}_q^m$  for  $m = 2^{\mu}$ , we write  $\mathsf{MLE}[\mathbf{w}](\mathbf{z}) \in \mathcal{R}_q[\mathbf{z}]^{\leq 1}$  for the multilinear extension of (the function  $\{0,1\}^{\mu} \to \mathcal{R}_q$  whose truth table is represented by)  $\mathbf{w}$ . We identify  $\{0,1\}^{\mu} = [2^{\mu}]$  via bit decomposition with most significant bits first. We define the equality polynomial  $\mathbf{eq} \in \mathcal{R}_q[\mathbf{x}, \mathbf{z}]$  as
+
+$$\mathsf{eq}(\mathsf{x},\mathsf{z}) := \prod_{i \in [\mu]} \left( \mathsf{x}_i \cdot \mathsf{z}_i + (1-\mathsf{x}_i) \cdot (1-\mathsf{z}_i) \right).$$
+
+For boolean inputs  $\mathbf{x}, \mathbf{z} \in \{0,1\}^{\mu}$ ,  $eq(\mathbf{x}, \mathbf{z}) = 1$  if  $\mathbf{x} = \mathbf{z}$  and 0 otherwise. Sometimes, we abuse notation and write  $eq(\mathbf{z}) \in \mathcal{R}_q[\mathbf{x}]$  to denote the equality polynomial being partially evaluated at  $\mathbf{z} \in \mathcal{R}_q^{\mu}$ .
+
+For  $\mathbf{x} = (x_0, \dots, x_{k-1}) \in \mathcal{R}_q^k$ , we write  $\mathsf{tensor}(\mathbf{x}) = ((1 - x_0, x_0) \otimes \dots \otimes (1 - x_{k-1}, x_{k-1}))^\mathsf{T} \in \mathcal{R}_q^{2^k}$ . By definition, it holds that  $\mathsf{MLE}[\mathbf{w}](\mathbf{x}) = \mathsf{tensor}(\mathbf{x})^\mathsf{T} \cdot \mathbf{w}$ .
+
+#### 3.3 Computational Assumptions
+
+Vanishing Short Integer Solution (vSIS) is a variant of the SIS problem, where the adversary is given access to a family of matrices  $\mathbf{A}_{n,2^{\mu}}$  and must find a short vector  $\mathbf{w}$  in the kernel of some matrix  $\mathbf{A}_{n,2^{\mu}}$ . The main distinction between vSIS and the ring-based variant of SIS is that the matrix  $\mathbf{A}_{n,2^{\mu}} \in \mathcal{R}_q^{n \times 2^{\otimes \mu}}$  is not sampled uniformly at random but instead has a structured form: it is obtained via iterated row-tensor products of smaller matrices from the family, i.e.  $\mathbf{A}_{n,2^{\mu}} = \mathbf{B}_{n,0} \bullet \mathbf{B}_{n,1} \bullet \cdots \bullet \mathbf{B}_{n,\mu-1}$  for  $\mathbf{B}_{n,i} \in \mathcal{R}_q^{n \times 2}$  for  $i \in [\mu]$ .
+
+<span id="page-11-0"></span>**Definition 1 (vSIS Assumption (adapted from [CLM23])).** A vSIS setup Setup is a PPT algorithm that takes as input  $(1^{\lambda}, \mathcal{R}, q, 1^{N}, 1^{M})$ , where  $N, M \in \mathbb{N}$ , and outputs an efficient description of family  $\mathfrak{A}$  of matrices  $\mathbf{A}_{n,2^{\mu}} \in \mathcal{R}_{q}^{n \times 2^{\otimes \mu}}$ , for all  $n \leq N$ ,  $\mu \leq \log_2 M$ .
+
+{12}------------------------------------------------
+
+Let  $par = (\mathcal{R}, q, n, m, \beta)$  be parametrised by  $\lambda$ . The  $vSIS_{par}$  assumption w.r.t. Setup states that, for any PPT adversary  $\mathcal{A}$ , the following advantage function is negligible:
+
+$$\mathsf{Adv}^{\mathsf{vsis}}_{\mathsf{par},\mathcal{A}}(\lambda) \coloneqq \Pr \begin{bmatrix} \mathbf{w} \in \mathcal{R}^m, n \leq N, m \leq M \\ m \ is \ a \ power \ of \ 2 \\ \mathbf{A}_{n,m} \mathbf{w} = \mathbf{0} \ \mathrm{mod} \ q \\ 0 \neq \|\mathbf{w}\|_2 \leq \beta \end{bmatrix} \begin{pmatrix} (1^N, 1^M, st) \leftarrow \mathcal{A}(1^\lambda, \mathsf{par}) \\ \mathfrak{A} \leftarrow \mathsf{Setup}(1^\lambda, \mathcal{R}, q, 1^N, 1^M) \\ \mathbf{w} \leftarrow \mathcal{A}(st, \mathfrak{A}) \end{pmatrix}.$$
+
+## <span id="page-12-1"></span>3.4 Cryptographic Primitives
+
+<span id="page-12-2"></span>**Reduction of Knowledge (RoK)** In [KP23], ternary relations  $\Xi \subseteq \{0,1\}^* \times \{0,1\}^* \times \{0,1\}^*$  are considered, where a tuple (ppar, stmt, wit)  $\in \Xi$  consists of public parameters ppar, statement stmt, and witness wit. For simplicity, ppar is omitted when it is clear from the context. Our definition of a reduction of knowledge is a streamlined variant of [KLNO24b].
+
+<span id="page-12-3"></span>**Definition 2 (Reduction of Knowledge (adapted from [KLNO24b])).** Let  $\Xi_0$ ,  $\Xi_1$  be ternary relations. A reduction of knowledge (RoK)  $\Pi$  from  $\Xi_0$  to  $\Xi_1$ , short  $\Pi: \Xi_0 \to \Xi_1$ , is defined by two PPT algorithms  $\Pi = (\mathsf{P}, \mathsf{V})$ , the prover  $\mathsf{P}$ , and the verifier  $\mathsf{V}$ , with the following interface:
+
+- $\mathsf{P}(\mathsf{ppar},\mathsf{stmt}_0,\mathsf{wit}_0) \to (\mathsf{stmt}_1,\mathsf{wit}_1) \colon \mathit{Interactively reduce the input statement} (\mathsf{ppar},\mathsf{stmt}_0,\mathsf{wit}_0) \in \Xi_0 \ to \ an \ output \ statement (\mathsf{ppar},\mathsf{stmt}_1,\mathsf{wit}_1) \in \Xi_1 \ or \perp.$
+- V(ppar, stmt<sub>0</sub>)  $\rightarrow$  stmt<sub>1</sub>: Interactively reduce the task of checking the input statement (ppar, stmt<sub>0</sub>)  $w.r.t \; \Xi_0 \; to \; checking \; the \; output \; statement \; (ppar, stmt<sub>1</sub>) \; w.r.t. \; \Xi_1$ .
+
+A RoK  $\Pi$  is *correct*, if for any honest protocol run (with correct inputs), the prover outputs a witness for the reduced statement (which the verifier outputs). A RoK  $\Pi$  is *knowledge sound* from  $\Xi_0^{\mathsf{KS}}$  to  $\Xi_1^{\mathsf{KS}}$  with knowledge error  $\kappa(\mathsf{ppar},\mathsf{stmt})$  if there is a *black-box* expected polynomial-time extractor Ext, which succeeds with probability  $\epsilon - \kappa(\mathsf{ppar},\mathsf{stmt})$  if the malicious prover outputs a valid witness for the reduced statement with probability  $\epsilon$  (on verifier's input (ppar, stmt)).<sup>8</sup>
+
+**Definition 3 (Knowledge Soundness).** A reduction of knowledge  $\Pi = (P*, V)$  from  $\Xi_0^{\mathsf{KS}}$  to  $\Xi_1^{\mathsf{KS}}$  is knowledge sound with knowledge error  $\kappa : \mathbb{N} \to [0, 1]$  if there exists a knowledge extractor Ext, such that for every statement  $x \in \Xi_0^{\mathsf{KS}}$  and any prover  $P^*$ , the extractor  $\mathsf{Ext}^{\mathsf{P}^*}(x)$  runs in expected time polynomial in |x| (counting calls to  $P^*$  as unit-cost operations) and outputs a witness w such that
+
+$$\Pr[(x;\mathsf{Ext}^{\mathsf{P}^*}(x)) \in \varXi_0^{\mathsf{KS}}] \ge \epsilon(\mathsf{P}^*,x) - \kappa(|x|),$$
+ where  $\epsilon(\mathsf{P}^*,x) \coloneqq \Pr(\varXi_1^{\mathsf{KS}} \leftarrow (\mathsf{P}^*,\mathsf{V})(x)).$ 
+
+## 3.5 Commitments
+
+Commitment schemes allow one to commit to a message while hiding it and ensuring binding. Our construction uses the recursive Ajtai commitment  $\mathsf{COM}_{\mathsf{par}_{\mathsf{com}},\boldsymbol{\beta}} = (\mathsf{Setup}, \mathsf{Com}_{\mathsf{par}_{\mathsf{com}}}, \mathsf{Verify}_{\mathsf{par}_{\mathsf{com}},\boldsymbol{\beta}})$  defined in Fig. 1, where  $\mathsf{par}_{\mathsf{com}} = (d, \mathbf{l}, \mathbf{n})$  and  $\boldsymbol{\beta} = (\beta_0, \dots, \beta_{d-1})$  are parameters consisting of (i) a depth  $d \in \mathbb{N}$ , (ii) a list  $\mathbf{l} = (\ell_0, \dots, \ell_{d-2})$  of d-1 gadget decomposition lengths, (iii) a list
+
+<span id="page-12-0"></span><sup>&</sup>lt;sup>8</sup> We postulate a black-box extractor that handles any (unbounded) prover. Hence, though the notion is stated as non-adaptive, it is straightforward to use in adaptive settings. Moreover, our success bound  $\epsilon - \kappa$  is stricter than usual.
+
+{13}------------------------------------------------
+
+| $Com_{par_{com}}(ck,\mathbf{w}\in\mathcal{R}^{2^{\mu}})\to (com,aux)$                                                                                                                                   | $Verify_{par_{com},\boldsymbol{\beta}}(ck,\mathbf{w}\in\mathcal{R}^{2^{\mu}},com,aux)$              |  |  |  |  |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|--|--|--|--|
+| $(n_i)_{i\in[d]}:=\mathbf{n}$                                                                                                                                                                           | $\boldsymbol{\beta'} := (\beta_1, \dots, \beta_{d-1})$                                              |  |  |  |  |
+| $\mathbf{y} := \mathbf{A}_{n_0, 2^{\mu}} \cdot \mathbf{w} \bmod q$                                                                                                                                      | $\ \mathbf{w}\ _2 \stackrel{?}{\leq} \beta_0$                                                       |  |  |  |  |
+| if $d = 1$ : return $(\mathbf{y}, \emptyset)$                                                                                                                                                           | $\mathbf{y}^* := com$                                                                               |  |  |  |  |
+| $(\ell_i)_{i\in[d-1]}:=\mathbf{l}$                                                                                                                                                                      | $(n_i)_{i\in[d]}:=\mathbf{n}$                                                                       |  |  |  |  |
+| $\begin{aligned} \widetilde{\mathbf{x}} &= \mathbf{G}_{\ell_0}^{-1}(\mathbf{y}) \ \mathbf{x} &:= \mathbf{x} \  0 \in \mathcal{R}^{minpowtwo(\ell_0 n_0)} & \text{//} \text{ Pad with } 0 \end{aligned}$ | if $d=1$ :                                                                                          |  |  |  |  |
+|                                                                                                                                                                                                         | $\mathbf{y}^* \stackrel{?}{=} \mathbf{A}_{n_0,2^{\mu}} \cdot \mathbf{w} \bmod q$                    |  |  |  |  |
+| $\mathbf{l}' := (\ell_1, \dots, \ell_{d-2})  \mathbf{n}' := (n_1, \dots, n_{d-1})$                                                                                                                      | $(\ell_i)_{i\in[d-1]}:=\mathbf{l}$                                                                  |  |  |  |  |
+| $(\mathbf{y}^*, \mathbf{x}^*) := Com_{d-1, \mathbf{l}', \mathbf{n}'}(ck, \mathbf{x})$ $aux := (\mathbf{x}^*, \mathbf{x})$                                                                               | $\mathbf{l}' := (\ell_1, \dots, \ell_{d-2})  \mathbf{n}' := (n_1, \dots, n_{d-1})$                  |  |  |  |  |
+| $return (y^*, aux)$                                                                                                                                                                                     | $(\mathbf{x}^*, \mathbf{x}) := aux$                                                                 |  |  |  |  |
+|                                                                                                                                                                                                         | $\mathbf{A}_{n_0,2^{\mu}}\cdot\mathbf{w}\stackrel{?}{=}(\mathbf{G}_{\ell_0}\ 0)(\mathbf{x})$        |  |  |  |  |
+|                                                                                                                                                                                                         | $Verify_{d-1,\mathbf{l'},\mathbf{n'},\boldsymbol{\beta'}}(ck,\mathbf{x},\mathbf{y}^*,\mathbf{x}^*)$ |  |  |  |  |
+
+<span id="page-13-0"></span>Fig. 1. Commitment scheme  $\mathsf{COM}_{\mathsf{par}_{\mathsf{com}},\boldsymbol{\beta}}$  for compressing claims, where  $\mathsf{par}_{\mathsf{com}} = (d,\mathbf{l},\mathbf{n})$  and  $\boldsymbol{\beta} = (\beta_0,\ldots,\beta_{d-1})$  are parameters. If  $\beta_0 = \beta_{\mathtt{y}}$  and  $\beta_1 = \ldots = \beta_{d-1} = \beta_{\mathtt{x}}$  we write  $\mathsf{COM}_{\mathsf{par}_{\mathsf{com}},\beta_{\mathtt{y}},\beta_{\mathtt{x}}}$  instead of  $\mathsf{COM}_{\mathsf{par}_{\mathsf{com}},\boldsymbol{\beta}}$ . The algorithm  $\mathsf{ck} \leftarrow \mathsf{Setup}(1^{\lambda})$  samples a vSIS family (Definition 1) via  $\mathsf{ck} \coloneqq \mathfrak{A} \leftarrow \mathsf{vSIS}.\mathsf{Setup}(1^{\lambda},1^{N},1^{M})$ , where N,M are asymptotic maximal bounds, e.g.,  $N = M = \lambda$ . Recall that  $\mathfrak{A}$  specifies matrices  $\mathbf{A}_{n,2^{\mu}} \in \mathcal{R}_q^{n \times 2^{\otimes \mu}}$  for all  $n \leq N, \mu \leq M$ .
+
+ $\mathbf{n}=(n_0,\ldots,n_{d-1})$  of d output dimensions and (iv) a list  $\boldsymbol{\beta}=(\beta_0,\ldots,\beta_{d-1})$  of d bounds on the norms of the witness and auxiliary information. Typically, we will write  $(\mathsf{par}_{\mathsf{com}},\beta_{\mathsf{y}},\beta_{\mathsf{x}})$  to denote the verification configuration, where  $\beta_{\mathsf{y}}$  serves as a bound for the witness and  $\beta_{\mathsf{x}}$  serves as a bound for the remaining layers, i.e. we set  $\beta_0=\beta_{\mathsf{y}}$  and  $\beta_1=\ldots=\beta_{d-1}=\beta_{\mathsf{x}}$ . We write  $m_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]$  to denote the combined dimension of all vectors in the auxiliary information, i.e.  $m_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]=\sum_{i\in[d-1]}n_i\cdot\ell_i$ . We will also write  $\beta_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]$  to denote the bound on the norm of the auxiliary information (obtained from its decomposition), i.e.  $\beta_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]^2=\sum_{i\in[d-1]}\mathsf{dcmp}_{n_i,\ell_i}(q/2)^2$ .
+
+Remark 1. Verify<sub>par<sub>com</sub></sub>,  $\beta$  has an additional parameter  $\beta$  compared to  $\mathsf{Com}_{\mathsf{par}_{\mathsf{com}}}$ , which gives us the flexibility to discuss the verification of commitment openings with different norm bounds. In the context of our argument system, this flexibility allows us to capture the difference between the norm bounds that arises from decomposition and those from witness extraction.
+
+We will write  $\#\text{constraints}(\mathsf{par}_{\mathsf{com}}) = \sum_{i \in [d]} n_i$  to denote the number of linear constraints over  $\mathcal{R}_q$  that need to be checked for the verification.<sup>9</sup>
+
+#### 3.6 Packing
+
+We define the packing function  $\operatorname{pack}: (\mathcal{R}_q^{m_0}, \dots, \mathcal{R}_q^{m_{k-1}}) \to \mathcal{R}_q^m$ , where each  $m_i$  is a power of two,  $m' = \sum_{i \in [k]} m_i$ , and  $m = 2^{\lceil \log m' \rceil}$  is the smallest power of two greater than or equal to m'. The function  $\operatorname{pack}$  first reorders the input vectors by decreasing dimension (i.e. so that  $m_0 \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m_1 \geq \cdots \geq m$ 
+
+<span id="page-13-1"></span><sup>&</sup>lt;sup>9</sup> Throughout the rest of the paper, we consider our commitment COM to be the "recursive Ajtai commitment" defined in Fig. 1. Nevertheless, if desired, one can instantiate COM with any commitment scheme that allows for the verification to be expressed as a set of linear low-norm constraints with auxiliary data of length and norm upper-bounded by parameters  $m_x[par_{com}]$  and  $\beta_x$ .
+
+{14}------------------------------------------------
+
+ $m_{k-1}$ ), then concatenates them and pads the result with zeros to obtain a vector of dimension m: For  $i \in [k]$ , we define the offset  $\omega_i := \sum_{j < i} m_j$  as the starting index of  $\mathbf{w}_i$  within the packed vector.
+
+Remark 2. Since  $m' \le m < 2m'$ , the zero-padding adds at most m - m' < m' entries, so less than half of the packed vector consists of zeros.
+
+<span id="page-14-1"></span>Lemma 3 (Packing and Multilinear Extensions). Let  $\mathbf{w}_i \in \mathcal{R}_q^{m_i}$  for  $i \in [k]$  and suppose that  $m_0 \geq m_1 \geq \ldots \geq m_{k-1}$  and all  $m_i$  are powers of two. Let  $\mathbf{w} = \mathsf{pack}(\mathbf{w}_0, \ldots, \mathbf{w}_{k-1}) \in \mathcal{R}_q^m$ . Let  $f = \mathsf{MLE}[\mathbf{w}] \in \mathcal{R}_q[\mathsf{z}_0, \ldots, \mathsf{z}_{\mu-1}]$  with  $\mu = \log m$ , and let  $f_i = \mathsf{MLE}[\mathbf{w}_i] \in \mathcal{R}_q[\mathsf{z}_0, \ldots, \mathsf{z}_{\mu_i-1}]$  with  $\mu_i = \log m_i$  for each  $i \in [k]$ . Let  $\mathbf{p}_i \in \{0, 1\}^{\mu-\mu_i}$  be the binary representation of  $\omega_i/m_i$  (i.e. the  $(\mu - \mu_i)$ -bit prefix identifying the block where  $\mathbf{w}_i$  resides). Then, for all  $i \in [k]$ :
+
+$$f(\mathbf{p}_i, \mathbf{z}) = f_i(\mathbf{z}) \bmod q.$$
+
+*Proof.* We first show that the offset  $\omega_i$  is a multiple of  $m_i$ , i.e. that the lower-order  $\mu_i$  bits of  $\omega_i$  are all zero. Since the vectors are ordered by decreasing dimension, for each j < i we have  $m_j \ge m_i$ , and since each  $m_j$  is a power of two,  $m_j$  is a multiple of  $m_i$ . Therefore,  $\omega_i = \sum_{j < i} m_j$  is a sum of multiples of  $m_i$ , hence itself a multiple of  $m_i$ .
+
+We now verify that  $\mathbf{p}_i$  correctly identifies the position of  $\mathbf{w}_i$ . Since  $\mathbf{w}_i$  starts at offset  $\omega_i$  and has dimension  $m_i = 2^{\mu_i}$ , the indices occupied by  $\mathbf{w}_i$  in  $\mathbf{w}$  are  $\{\omega_i, \omega_i + 1, \ldots, \omega_i + m_i - 1\}$ .
+
+For any index  $j \in \{0, \ldots, m_i - 1\}$ , the corresponding global index in **w** is  $\omega_i + j$ . Writing  $\omega_i + j$  in binary with  $\mu$  bits, the high-order  $(\mu - \mu_i)$  bits encode  $\lfloor (\omega_i + j)/m_i \rfloor$ . Since  $0 \le j < m_i$ , we have  $\lfloor (\omega_i + j)/m_i \rfloor = \lfloor \omega_i/m_i \rfloor = \omega_i/m_i$  (using the divisibility established above). Thus, all indices in the range  $[\omega_i, \omega_i + m_i - 1]$  share the common prefix  $\mathbf{p}_i$ .
+
+Now, by definition of the multilinear extension, for  $\mathbf{z} \in \{0, 1\}^{\mu_i}$  we have  $f(\mathbf{p}_i, \mathbf{z}) = w_{\langle (\mathbf{p}_i, \mathbf{z}) \rangle}$ , where  $\langle \cdot \rangle$  denotes the integer with the given binary representation. Since  $\langle (\mathbf{p}_i, \mathbf{z}) \rangle = \langle \mathbf{p}_i \rangle \cdot m_i + \langle \mathbf{z} \rangle = \omega_i + \langle \mathbf{z} \rangle$ , we have
+
+$$f(\mathbf{p}_i, \mathbf{z}) = w_{\omega_i + \langle \mathbf{z} \rangle} = \mathbf{w}_{i, \langle \mathbf{z} \rangle} = f_i(\mathbf{z}) \bmod q.$$
+
+For our applications of pack, we can w.l.o.g. reorder the vectors in decreasing dimension. Hence Lemma 3 is applicable.
+
+### <span id="page-14-0"></span>4 Relations
+
+In this section, we define the relations that we will use in our reductions of knowledge. All relations implicitly take as parameters  $(\mathcal{R}, q, \mathsf{ck})$ , which are typically omitted for brevity; here  $\mathsf{ck}$  is a commitment key for the commitment scheme COM (Fig. 1) specifying a family  $\mathbf{A}_{n,2^{\mu}}$  of matrices. If  $\Xi$  is a relation and  $(\mathsf{par}, \mathsf{stmt}, \mathsf{wit}) \in \Xi$ , we write  $(\mathsf{stmt}, \mathsf{wit}) \in \Xi[\mathsf{par}]$ .
+
+Committed-linear relation. Let  $COM = COM_{par_{com}, \beta_y, \beta_x} = (Setup, Com, Verify)$  be the commitment scheme from Fig. 1.
+
+We define the committed-linear relation  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  with respect to the commitment schemes  $\mathsf{COM}$ :
+
+- Parameters: 
+$$par = (k_{lin}, k_{lr}, n, m_{w}, r, \beta_{w}, (\underbrace{par_{lin,i}})_{i \in [k_{lin}]}, \underbrace{\varrho}).$$
+
+$$(n_i, par_{com,i}, m_{y,i}, \beta_{x,i}, \beta_{y,i})$$
+
+- Statement: stmt = 
+$$((com_i, \mathbf{F}_i \in \mathcal{R}_q^{n_i \times m_w}, \mathbf{H}_i \in \mathcal{R}_q^{n_i \times m_{y,i}})_{i \in [k_{\text{lin}}]}, (\mathbf{l}_j \in \mathcal{R}_q^{m_w}, \mathbf{r}_j \in \mathcal{R}_q^r, t_j)_{j \in [k_{\text{lr}}]}, \mathbf{A} \in \mathcal{R}_q^{n \times \sum_{i \in [k_{\text{lin}}]} m_{y,i} \cdot r}, \mathbf{b} \in \mathcal{R}_q^n)$$
+
+{15}------------------------------------------------
+
+```
+- \text{ Witness: wit} = (\mathbf{W} \in \mathcal{R}^{m_{\mathtt{w}} \times r}, (\mathbf{Y}_i \in \mathcal{R}^{m_{\mathtt{y},i} \times r}, \mathbf{x}_i \in \mathcal{R}^{m_{\mathtt{x}}[\mathsf{par}_{\mathtt{com},i}]})_{i \in [k_{\mathtt{lin}}]}, \mathbf{s} \in \mathcal{R}^r)
+```
+
+- Constraints:
+  - For all  $i \in |k_{\text{lin}}|$ :
+    - $* \mathsf{COM.Verify}_{\mathsf{par}_{\mathsf{com},i},\beta_{\mathsf{y},i},\beta_{\mathsf{x},i}}(\mathsf{ck},\mathsf{com}_i,\mathsf{vec}(\mathbf{Y}_i),\mathbf{x}_i) = 1 \\ * \mathbf{F}_i\mathbf{W} = \mathbf{H}_i\mathbf{Y}_i \bmod q$
+
+    - \*  $\|\operatorname{vec}(\mathbf{Y}_i)\| \le \beta_{\mathbf{y},i}, \|\mathbf{x}_i\| \le \beta_{\mathbf{x},i}$
+  - For all  $j \in [k_{1r}], \mathbf{l}_i^{\mathsf{T}} \cdot \mathbf{W} \cdot \mathbf{r}_j = t_j \mod q$
+  - $\mathbf{A} \cdot (\operatorname{vec}(\mathbf{Y}_i))_{i \in [k_{\text{lin}}]} = \mathbf{b} \mod q$
+  - $\|\mathbf{W} \cdot \mathsf{diag}(\mathbf{s})\|_2 \le \beta_{\mathtt{w}}$
+  - $\|\mathsf{diag}(\mathbf{s})\|_{\mathsf{op},2} \leq \varrho$
+
+We say that  $\mathcal{Z}_{\mathsf{COM}}^{\mathsf{lin-rel}}$  is relaxed if  $\varrho > 1$ . We take  $\varrho = 1$  if omitted and in which case we can assume without loss of generality that s = 1 is the all-one vector.
+
+Functional-sumcheck relation. Let  $COM = COM_{par_{com}, \beta_y, \beta_x} = (Setup, Com, Verify)$  be the commitment scheme from Fig. 1. We define the functional-sum check relation  $\Xi_{\mathsf{COM}}^{\mathsf{sum}}$  as follows:
+
+- Parameters:  $\mathsf{par} = (k_{\mathtt{sc}}, n, m_{\mathtt{w}}, r, \mathsf{par}_{\mathtt{com}}, m_{\mathtt{y}}, \beta_{\mathtt{w}}, \beta_{\mathtt{x}}, \beta_{\mathtt{y}}, \delta_{\mathtt{sc}}), \ m_{\mathtt{w}} \cdot r = 2^{\nu} \ \text{is a power of } 2$
+- Statement: stmt =  $(\text{com}, \mathbf{F} \in \mathcal{R}_q^{n \times m_w}, \mathbf{H} \in \mathcal{R}_q^{n \times m_y}, (f_{sc}^{(i)})_{i \in [k_{sc}]})$  where
+  - For  $i \in [k_{sc}]$ , each  $f_{sc}^{(i)} \in (\mathcal{R}_q[\mathbf{y}])[\mathsf{x}_0,\mathsf{x}_1]$  is a polynomial in variables  $\mathsf{x}_0,\mathsf{x}_1$  over the polynomial ring  $\mathcal{R}_q|\mathbf{y}|$ .
+  - $\mathcal{R}_q[\mathbf{y}]$  is the polynomial ring over  $\mathcal{R}_q$  in variables  $\mathbf{y} := (\mathsf{y}_0, \dots, \mathsf{y}_{\nu-1}).$
+  - For any multilinear  $x_0, x_1 \in \mathcal{R}_q[\mathbf{y}]^{\leq 1}$ , it holds that  $f_{\mathtt{sc}}^{(i)}(x_0, x_1) \in \mathcal{R}[\mathbf{y}]^{\leq \delta_{\mathtt{sc}}}$  for all  $i \in [k_{\mathtt{sc}}]$ .
+- Witness: wit =  $(\mathbf{W} \in \mathcal{R}^{m_{w} \times r}, \mathbf{Y} \in \mathcal{R}^{m_{y} \times r}, \mathbf{x} \in \mathcal{R}^{m_{x}[\mathsf{par}_{\mathsf{com}}]})$
+- Constraints:
+  - $\mathbf{FW} = \mathbf{HY} \mod q$
+  - $\bullet \; \; \mathsf{COM.Verify}_{\mathsf{par}_{\mathsf{com}},\beta_{\mathtt{v}},\beta_{\mathtt{x}}}(\mathsf{ck},\mathsf{com},\mathsf{vec}(\mathbf{Y}),\mathbf{x}) = 1$
+  - For  $i \in [k_{sc}]$ :  $\sum_{\mathbf{z} \in \{0,1\}^{\nu}} f_{sc}^{(i)} \left( \mathsf{MLE}[\mathsf{vec}(\mathbf{W})], \mathsf{MLE}[\overline{\mathsf{vec}(\mathbf{W})}] \right) (\mathbf{z}) = 0 \bmod q$
+  - $\|\mathbf{W}\|_2 \leq \beta_{\mathbf{w}}$ ,  $\|\mathbf{vec}(\mathbf{Y})\|_2 \leq \beta_{\mathbf{v}}$ ,  $\|\mathbf{x}\|_2 \leq \beta_{\mathbf{x}}$
+
+SIS relation. We rely on (v)SIS-assumptions of varying dimension and norm bounds, chosen with approximately the same concrete hardness. Below, we define the corresponding (v)SIS-family relation  $\Xi^{sis}$ . We recall that  $\mathfrak{A} \leftarrow vSIS.Setup(1^{\lambda}, 1^{N}, 1^{M})$  is the vSIS family generation algorithm, which samples a family  $\mathfrak{A}$  of matrices  $\mathbf{A}_{n,2^{\mu}}$  for all  $n \leq N$ ,  $\mu \leq M$  as in Definition 1.
+
+- Parameters:  $\mathsf{par} = (\mathsf{ck} = \mathfrak{A}, \{\mathsf{par}_i\}_{i \in [T]})$  where
+  - $\mathfrak{A} = (\mathbf{A}_{n,2^{\mu}})_{n \leq N, \mu \leq M}$  for  $N, M \in \mathbb{N}$ ,
+  - $\operatorname{par}_i = (n_i, m_{\mathbf{w},i}, \beta_{\mathbf{w},i}) \text{ for } m_{\mathbf{w},i} = 2^{\mu_i} \text{ for } \mu_i \in \mathbb{N}.$
+- Statement:  $\mathsf{stmt} = \varepsilon$
+- Witness: wit =  $(\mathbf{w} \in \mathcal{R}^{m_{\mathbf{w},i}})$  for some  $i \in [T]$ .
+- Constraints:  $\exists i \in [T]$  s.t.
+  - $\bullet \ \mathbf{A}_{n_i,m_{\mathbf{w},i}}\mathbf{w} = \mathbf{0} \bmod q,$
+  - $0 \neq \|\mathbf{w}\|_2 \leq \beta_{\mathbf{w},i}$ .
+
+{16}------------------------------------------------
+
+<span id="page-16-1"></span>Table 2. Individual parameters appearing in relations.
+
+#### Symbol Type Description
+
+| $\overline{k_{\texttt{lin}}}$                   | $\mathbb{N}$          | Number of committed-linear blocks                                                   |  |  |
+|-------------------------------------------------|-----------------------|-------------------------------------------------------------------------------------|--|--|
+| $k_{\tt lr}$                                    | $\mathbb{N}$          | Number of left-right inner-product constraints                                      |  |  |
+| $k_{\mathtt{sc}}$                               | $\mathbb{N}$          | Number of sumcheck polynomials                                                      |  |  |
+| n                                               | $\mathbb{N}$          | Number of rows of global linear constraint                                          |  |  |
+| $m_{\mathtt{w}}$                                | $\mathbb{N}$          | Number of rows of main witness $\mathbf{W}$                                         |  |  |
+| r                                               | $\mathbb{N}$          | Number of columns of main witness $\mathbf{W}$                                      |  |  |
+| $m_{\mathtt{y}} \ / \ m_{\mathtt{y}, \cdot}$    | $_{i}$ $\mathbb{N}$   | Dimension of committed vector $\mathbf{Y}$ / $\mathbf{Y}_i$                         |  |  |
+| $m_{\mathrm{x}}[par_{\mathtt{com}}]$            | $]$ $\mathbb{N}$      | Derived auxiliary information dimension: $\sum_{i \in [d-1]} n_i \cdot \ell_i$      |  |  |
+| $\beta_{\mathtt{w}}$                            | $\mathbb{R}_{>0}$     | Norm bound on the main witness $\mathbf{W}$                                         |  |  |
+| $\beta_{\mathtt{x}} / \beta_{\mathtt{x},i}$     | $\mathbb{R}_{>0}$     | Norm bound on commitment auxiliary information $\mathbf{x}$ / $\mathbf{x}_i$        |  |  |
+| $\beta_{\mathtt{x}}[par_{\mathtt{com}}]$        | $\mathbb{R}_{>0}$     | Derived auxiliary norm: $\sqrt{\sum_{i \in [d-1]} dcmp_{n_i,\ell_i}(q/2)^2}$        |  |  |
+| $\beta_{\mathtt{y}} \ / \ \beta_{\mathtt{y},i}$ | $\mathbb{R}_{>0}$     | Norm bound on committed right-hand sides $\mathbf{Y}$ / $\mathbf{Y}_i$ (vectorised) |  |  |
+| $n_i$                                           | $\mathbb{N}$          | Output dimension at layer $i$ of the commitment / SIS rank                          |  |  |
+| $\delta_{\tt sc}$                               | $\mathbb{N}$          | Degree bound for sumcheck polynomials                                               |  |  |
+| $\varrho$                                       | $\mathbb{R}_{\geq 1}$ | Relaxation factor; $\varrho = 1$ means non-relaxed                                  |  |  |
+| T                                               | $\mathbb{N}^-$        | Number of SIS-parameter tuples in $\Xi^{sis}$                                       |  |  |
+|                                                 |                       |                                                                                     |  |  |
+
+Commitment breaks to SIS break. Let  $\mathsf{COM} = \mathsf{COM}_{\mathsf{par}_{\mathsf{com}}} = (\mathsf{Setup}, \mathsf{Com}, \mathsf{Verify})$  be the commitment scheme from Fig. 1. A commitment binding break consists of a commitment com and of two openings  $(\mathbf{w}_b \in \mathcal{R}^{m_{\mathsf{w}}}, \mathbf{x}_b \in \mathcal{R}^{m_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]})_{b \in [2]}$  such that  $\mathbf{w}_0 \neq \mathbf{w}_1$ , and yet  $\mathsf{COM}.\mathsf{Verify}_{\mathsf{par}_{\mathsf{com}}}(\mathsf{ck}, \mathsf{com}, \mathbf{w}_b, \mathbf{x}_b) = 1$  for  $b \in [2]$ . The following result follows immediately from the definition of  $\mathsf{COM}.\mathsf{Verify}_{\mathsf{par}_{\mathsf{com}},\boldsymbol{\beta}}$ .
+
+<span id="page-16-2"></span>Lemma 4 (Binding break to SIS break). Let  $COM_{par_{com},\beta} = (Setup, Com_{par_{com}}, Verify_{par_{com},\beta})$  be the commitment scheme from Fig. 1 where  $par_{com} = (d, l, n)$ . Let  $par_{break}[par_{com}, m_y, \beta] = \{(n_0, m_y, 2\beta_y)\} \cup \{(n_{i+1}, \ell_i \cdot n_i, 2\beta_{x,i})\}_{i \in [d-1]}$  where  $\beta = (\beta_y, \beta_{x,0}, \ldots, \beta_{x,d-2})$ . Consider a SIS relation  $\Xi^{sis}[par_{sis}]$  where  $par_{sis} \supseteq par_{break}[par_{com}, m_y, \beta]$ . Given a binding break  $(\mathbf{w}_b \in \mathcal{R}^{m_y}, \mathbf{x}_b \in \mathcal{R}^{m_x[par_{com}]})_{b \in [2]}$  for com, one can efficiently compute a witness  $\mathbf{z}$  for  $\Xi^{sis}[par_{sis}]$  with parameters  $(n_0, m_y, 2\beta_y)$  or  $(n_{i+1}, \ell_i \cdot n_i, 2\beta_{x,i})$  for some  $i \in [d-1]$ . As in Section 3.4, we will typically write  $par_{break}[par_{com}, m_y, \beta_y, \beta_x]$  instead of  $par_{break}[par_{com}, m_y, \beta]$  if  $\beta_0 = \beta_y$  and  $\beta_1 = \ldots = \beta_{d-1} = \beta_x$ .
+
+Parameter reference. For the reader's convenience, Table 2 collects all parameters used across the relations above, and Table 3 lists the compound parameter sets.
+
+# <span id="page-16-0"></span>5 Committed Random Projection
+
+Random projection controls the norm growth during extraction. The extractor for folding (Section 6) outputs a witness with a "slack" factor  $\varrho$ : the extracted **W** satisfies  $\|\mathbf{W}\mathbf{s}\|_2 \leq \beta'_{\mathbf{w}}$  for some **s** with  $\|\mathbf{s}\|_2 \leq \varrho$ . In recursive composition, this slack would accumulate and blow up the norm bound. Applying random projection before folding ensures that the projected witness satisfies a strict norm bound (without slack) with high probability. We give two projection RoKs, inspired by [KLNO25]. A coarse variant  $\Pi^{\text{proj-c}}$  (Fig. 2) applies a random projection matrix to full ring elements; it is simple and efficient but requires the witness dimension to be large enough for the projection to compress.
+
+{17}------------------------------------------------
+
+<span id="page-17-0"></span>Table 3. Parameter sets.
+
+| Parameter Set                                                                                                                                                                                   | Description                                                                                                                                                                                                                                                                                                                                                         |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| $par_{\mathtt{com}} = (d, \mathbf{l}, \mathbf{n})$                                                                                                                                              | Commitment parameters: depth $d$ , gadget-decomposition lengths $\mathbf{l} = (\ell_0, \dots, \ell_{d-2})$ , output dimensions $\mathbf{n} = (n_0, \dots, n_{d-1})$ . Together with the verification norms $\boldsymbol{\beta} := (\beta_0, \dots, \beta_{d-1})$ , this defines the configuration for the commitment scheme $Com_{par_{com}, \boldsymbol{\beta}}$ . |
+| $par_{\mathtt{lin}} = \begin{pmatrix} k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, \\ (par_{\mathtt{lin},i})_{i \in [k_{\mathtt{lin}}]}, \varrho \end{pmatrix}$ | Parameter set for the committed-linear relation $\mathcal{Z}_{COM}^{lin}$ .                                                                                                                                                                                                                                                                                         |
+| $par_{\mathtt{lin},i} = (n_i, par_{\mathtt{com},i}, m_{\mathtt{y},i}, \beta_{\mathtt{x},i}, \beta_{\mathtt{y},i})$                                                                              | Per-block parameters for the $i$ -th committed-linear block: output dimension, commitment config, committed-vector dimension, auxiliary norm bound, committed-vector norm bound.                                                                                                                                                                                    |
+| $par_{sc} = \begin{pmatrix} k_{sc}, n, m_{\mathtt{w}}, r, par_{com}, \ m_{\mathtt{y}}, \beta_{\mathtt{w}}, \beta_{\mathtt{x}}, \beta_{\mathtt{y}}, \delta_{sc} \end{pmatrix}$                   | Parameter set for the functional-sum<br>check relation $\varXi_{COM}^{sum}.$                                                                                                                                                                                                                                                                                        |
+| $\begin{aligned} & par_{sis} = \{par_i\}_{i \in [T]} \text{ where} \\ & par_i = (n_i, m_{\mathtt{w},i}, \beta_{\mathtt{w},i}) \end{aligned}$                                                    | SIS-family relation parameters: a set of (rank, dimension, norm-bound) tuples.                                                                                                                                                                                                                                                                                      |
+| $par_{\mathtt{break}}[par_{\mathtt{com}}, m_{\mathtt{y}}, \boldsymbol{\beta}] \text{ or } \\ par_{\mathtt{break}}[par_{\mathtt{com}}, m_{\mathtt{y}}, \beta_{\mathtt{y}}, \beta_{\mathtt{x}}]$  | SIS parameters arising from a commitment binding break (Lemma 4), with $\boldsymbol{\beta} = (\beta_{y}, \beta_{x,0}, \dots, \beta_{x,d-2})$ : $\{(n_0, m_y, 2\beta_y)\} \cup \{(n_{i+1}, \ell_i \cdot n_i, 2\beta_{x,i})\}_{i \in [d-1]}$ . Simplified variant uses the collective bound $\beta_x^2 = \sum_{i \in [d-1]} \beta_{x,i}^2$ .                          |
+
+A fine variant  $\Pi^{\mathsf{proj-f}}$  (Fig. 3) instead projects the coefficients of the witness ring elements, handling smaller witness dimensions.
+
+Both are self-reductions for the committed linear relation  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$ , adding fresh commitments to the projected witnesses.
+
+## <span id="page-17-2"></span>5.1 Johnson-Lindenstrauss Lemma
+
+We first recall the following lemma, which is a ring variant of the Johnson-Lindenstrauss lemma taken from [BS23] and adapted to our setting.
+
+**Lemma 5.** Let  $\chi$  be a distribution over  $\{-1, 0, 1\}$  with  $\Pr[\chi = 0] = \frac{1}{2}$ ,  $\Pr[\chi = 1] = \Pr[\chi = -1] = \frac{1}{4}$ ,  $q \in \mathbb{N}$  and  $\kappa \in (0, 1)$ . There exist parameters  $n_{\mathtt{rp}} = n_{\mathtt{rp}}(\kappa)$ ,  $\alpha_{\mathtt{rp}} = \alpha_{\mathtt{rp}}(\kappa)$ ,  $\beta_{\mathtt{rp}} = \beta_{\mathtt{rp}}(\kappa)$  and  $b = b(\kappa)$  such that for any  $m_{\mathtt{rp}} \in \mathbb{N}$  and any  $\mathbf{w} \in \mathbb{Z}^{m_{\mathtt{rp}}}$  such that  $\|\mathbf{w}\|_2 \leq q/b$ , we have
+
+<span id="page-17-1"></span>
+$$\Pr\left[\frac{\|\mathbf{J}\mathbf{w} \bmod q\|_2}{\|\mathbf{w}\|_2} \notin [\alpha_{\mathtt{rp}}, \beta_{\mathtt{rp}}] \mid \mathbf{J} \leftarrow \$ \chi^{n_{\mathtt{rp}} \times m_{\mathtt{rp}}}\right] \leq \kappa_{\mathtt{rp}}.$$
+
+Concretely, for  $\kappa_{\rm rp} = 2^{-128}$ , we take  $n_{\rm rp} = 256$ ,  $\alpha_{\rm rp} = \sqrt{30}$ ,  $\beta_{\rm rp} = \sqrt{337}$  and b = 125 [BS23, Lemma 4.1 and 4.2].
+
+{18}------------------------------------------------
+
+Moreover, for  $n_{rp} = \Theta(\log(1/\kappa))$  we conjecture the asymptotics: <sup>10</sup>
+
+$$\alpha_{\rm rp}(\kappa) = \Theta(\sqrt{\log(1/\kappa)}) \ \beta_{\rm rp}(\kappa) = \Theta(\sqrt{\log(1/\kappa)}) \ b(\kappa) = \Theta(\sqrt{\log(1/\kappa)}).$$
+
+We extend Lemma 5 to cover structured projections:
+
+<span id="page-18-1"></span>**Lemma 6.** Let  $\mathbf{W} \in \mathbb{Z}^{m_{\mathbf{w}} \times r}$  and  $q \in \mathbb{N}$ . Let  $\mathbf{J} \leftarrow \$ \chi^{n_{\mathrm{rp}} \times m_{\mathrm{rp}}}$  be a random matrix as in Lemma 5 and define  $\mathbf{V} \coloneqq (\mathbf{I}_{m_{\mathbf{w}}/m_{\mathrm{rp}}} \otimes \mathbf{J}) \cdot \mathbf{W} \bmod q \in \mathbb{Z}^{m_{\mathbf{w}} \cdot \frac{n_{\mathrm{rp}}}{m_{\mathrm{rp}}} \times r}$  with columns  $\mathbf{v}_0, \dots, \mathbf{v}_{r-1}$ . Then, it holds that
+
+$$\Pr\left[\frac{\|\mathbf{V}\|_2}{\|\mathbf{W}\|_2} \notin [\alpha_{\mathtt{rp}}, \beta_{\mathtt{rp}}]\right] \leq \kappa_{\mathtt{rp}} \cdot rm_{\mathtt{w}}/m_{\mathtt{rp}},$$
+
+where  $\alpha_{rp}$ ,  $\beta_{rp}$ ,  $\kappa_{rp}$  are as in Lemma 5.
+
+*Proof.* Since we define norm on matrices as the largest Euclidean norm of its columns, it suffices to prove the statement for each column of  $\mathbf{W}$  and  $\mathbf{V}$  separately and then apply the union bound.
+
+By definition of the Euclidean norm on matrices, we have that
+
+$$\|\mathbf{W}\|_2 = \max_{j \in [r]} \|\mathbf{w}_j\|_2, \quad \|\mathbf{V}\|_2 = \max_{j \in [r]} \|\mathbf{v}_j\|_2,$$
+
+where  $\mathbf{w}_j$  and  $\mathbf{v}_j$  are the j-th columns of  $\mathbf{W}$  and  $\mathbf{V}$ , respectively. Let us fix an arbitrary  $j \in [r]$  with the largest norm. We split the vector  $\mathbf{w}_j$  into  $m_{\mathbf{w}}/m_{\mathbf{rp}}$  chunks of height  $m_{\mathbf{rp}}$  each:  $\mathbf{w}_{j,1}, \ldots, \mathbf{w}_{j,m_{\mathbf{w}}/m_{\mathbf{rp}}}$ . Similarly, we split  $\mathbf{v}_j$  into  $m_{\mathbf{w}}/m_{\mathbf{rp}}$  chunks of height  $n_{\mathbf{rp}}$  each:  $\mathbf{v}_{j,1}, \ldots, \mathbf{v}_{j,m_{\mathbf{w}}/m_{\mathbf{rp}}}$ .
+
+By construction of **V**, it holds that  $\mathbf{v}_{j,i} = \mathbf{J}\mathbf{w}_{j,i}$  for all  $i \in [m_{\mathtt{w}}/m_{\mathtt{rp}}]$ . By Lemma 5, for each  $i \in [m_{\mathtt{w}}/m_{\mathtt{rp}}]$ , it holds that
+
+$$\Pr\left[\frac{\|\mathbf{v}_{j,i}\|_2}{\|\mathbf{w}_{j,i}\|_2} \not\in [\alpha_{\mathtt{rp}}, \beta_{\mathtt{rp}}]\right] \leq \kappa_{\mathtt{rp}}.$$
+
+Assuming that  $\frac{\|\mathbf{v}_{j,i}\|_2}{\|\mathbf{w}_{j,i}\|_2} \in [\alpha_{rp}, \beta_{rp}]$ , we observe that the Euclidean norm behaves under concatenation as follows:
+
+$$\|\mathbf{v}_{j}\|_{2}^{2} = \sum_{i \in [m_{\mathtt{w}}/m_{\mathtt{rp}}]} \|\mathbf{v}_{j,i}\|_{2}^{2} \in \left[\alpha_{\mathtt{rp}}^{2} \sum_{i \in [m_{\mathtt{w}}/m_{\mathtt{rp}}]} \|\mathbf{w}_{j,i}\|_{2}^{2}, \beta_{\mathtt{rp}}^{2} \sum_{i \in [m_{\mathtt{w}}/m_{\mathtt{rp}}]} \|\mathbf{w}_{j,i}\|_{2}^{2}\right] = \left[\alpha_{\mathtt{rp}}^{2} \|\mathbf{w}_{j}\|_{2}^{2}, \beta_{\mathtt{rp}}^{2} \|\mathbf{w}_{j}\|_{2}^{2}\right].$$
+
+It follows that
+
+$$\frac{\|\mathbf{V}_j\|_2}{\|\mathbf{W}_i\|_2} \in [\alpha_{\mathtt{rp}}, \beta_{\mathtt{rp}}],$$
+
+which concludes the proof by the union bound over all  $(i,j) \in [m_{\mathtt{w}}/m_{\mathtt{rp}},r]$  with failure probability at most  $\kappa_{\mathtt{rp}} \cdot rm_{\mathtt{w}}/m_{\mathtt{rp}}$ .
+
+From this point onwards, we fix parameters  $n_{rp}$ ,  $m_{rp}$ ,  $\alpha_{rp}$ ,  $\beta_{rp}$ ,  $\kappa_{rp}$  as in Lemma 5.
+
+<span id="page-18-0"></span>This scaling matches the second-moment behaviour of  $\mathbf{J}\mathbf{w}$ . For a row  $\mathbf{r}$  of  $\mathbf{J}$ , the inner product  $\langle \mathbf{r}, \mathbf{w} \rangle$  has variance  $\mathbb{E}[r_i^2] \|\mathbf{w}\|_2^2 = \frac{1}{2} \|\mathbf{w}\|_2^2$  (the entries  $r_i$  are i.i.d. with zero mean, so cross terms vanish), hence  $\mathbb{E}\|\mathbf{J}\mathbf{w}\|_2^2 = \frac{n_{\rm rp}}{2} \|\mathbf{w}\|_2^2$  and, with high probability,  $\|\mathbf{J}\mathbf{w}\|_2/\|\mathbf{w}\|_2 = \Theta(\sqrt{n_{\rm rp}})$ . Concentration for sums of independent sub-exponential variables gives  $\Pr[\|\mathbf{J}\mathbf{w}\|_2^2 - \frac{n_{\rm rp}}{2} \|\mathbf{w}\|_2^2] > \epsilon \frac{n_{\rm rp}}{2} \|\mathbf{w}\|_2^2] \le \exp(-\Theta(\epsilon^2 n_{\rm rp}))$ , so enforcing failure probability  $\kappa$  forces  $\epsilon = \Theta(\sqrt{\log(1/\kappa)/n_{\rm rp}})$ . For  $n_{\rm rp} = \Theta(\log(1/\kappa))$  this gives  $\epsilon = \Theta(1)$ , i.e. a constant-factor window around the mean scale  $\sqrt{n_{\rm rp}/2}$ , yielding endpoints of order  $\sqrt{n_{\rm rp}}$ . Following [BS23, Lemma 4.2, proof case 2], the restriction  $\|\mathbf{w}\|_2 \le q/b(\kappa)$  should have  $b(\kappa) \in \Theta(\alpha_{\rm rp})$  so the same asymptotics carry over to  $\|\mathbf{J}\mathbf{w} \bmod q\|_2$ , following the argument of [BS23].
+
+{19}------------------------------------------------
+
+```
+P(stmt, wit)
+                                                                                                                                                                                                                                                         V(stmt)
+                                         \mathbf{parse} \; \mathsf{stmt} = ((\mathsf{com}_i, \mathbf{F}_i, \mathbf{H}_i)_{i \in [k_{\mathtt{lin}}]}, (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [k_{\mathtt{lr}}]}, \mathbf{A}, \mathbf{b})
+\mathbf{parse} \ \mathsf{wit} = (\mathbf{W}, (\mathbf{Y}_i, \mathbf{x}_i)_{i \in [k_{\mathtt{lin}}]})
+                            /\!\!/ \quad (\mathsf{stmt}, \mathsf{wit}) \in \varXi_{\mathsf{COM}}^{\mathsf{lin}} \left[ k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n_i, \mathsf{par}_{\mathtt{com},i}, m_{\mathtt{y},i}, \beta_{\mathtt{x},i}, \beta_{\mathtt{y},i})_{i \in [k_{\mathtt{lin}}]} \right] 
+\mathbf{V}\coloneqq (\mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}}\otimes \mathbf{J})\cdot \mathbf{W}\in \mathcal{R}^{m_{\mathtt{w}}\cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}}\times r}
+\mathbf{Y}_{k_{\mathtt{lin}}} \coloneqq \mathbf{G}_{\ell}^{-1}(\mathbf{V}) \in \mathcal{R}^{\ell \cdot m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}} \times r}
+(\mathsf{com}_{k_{\mathtt{lin}}}, \mathbf{x}_{k_{\mathtt{lin}}}) \coloneqq \mathsf{Com}_{\mathsf{par}_{\mathtt{com}}}(\mathsf{ck}, \mathsf{vec}(\mathbf{Y}_{k_{\mathtt{lin}}})) \quad \underline{\hspace{1cm}} \mathsf{com}_{k_{\mathtt{lin}}}
+    /\!\!/ \; (\mathbf{I}_{m_{\mathtt{W}}/m_{\mathtt{rp}}} \otimes \mathbf{J}) \cdot \mathbf{W} = \mathbf{G}_{\ell} \cdot \mathbf{Y}_{k_{\mathtt{lin}}} \bmod q
+\mathbf{F}_{k_{\mathtt{lin}}}\coloneqq \mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}}\otimes \mathbf{J},\ \mathbf{H}_{k_{\mathtt{lin}}}\coloneqq \mathbf{G}_{\ell}
+n_{k_{\text{lin}}} \coloneqq m_{\text{w}} \cdot \frac{n_{\text{rp}}}{m_{\text{rp}}}, \; \mathsf{par}_{\mathsf{com}, k_{\text{lin}}} = \mathsf{par}_{\mathsf{com}}, \; m_{\text{y}, k_{\text{lin}}} \coloneqq \ell \cdot n_{k_{\text{lin}}}
+\beta_{\mathtt{x},k_{\mathtt{lin}}} \coloneqq \beta_{\mathtt{x}}, \ \beta_{\mathtt{y},k_{\mathtt{lin}}} \coloneqq \mathsf{dcmp}_{\ell}(\beta_{\mathtt{rp}} \cdot \beta_{\mathtt{w}})
+\mathsf{wit}' \coloneqq (\mathbf{W}, (\mathbf{Y}_i, \mathbf{x}_i)_{i \in [k_{\mathtt{lin}} + 1]})
+                                                \mathsf{stmt}' \coloneqq ((\mathsf{com}_i, \mathbf{F}_i, \mathbf{H}_i)_{i \in [k_1, n+1]}, (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [k_1, n]}, \mathbf{A}, \mathbf{b})
+               /\!\!/ \quad (\mathsf{stmt'}, \mathsf{wit'}) \in \varXi_\mathsf{COM}^\mathsf{lin} \left[ \underline{k_\mathsf{lin}} + 1, k_\mathsf{lr}, n, m_\mathsf{w}, r, \beta_\mathsf{w}, (n_i, \mathsf{par}_{\mathsf{com}, i}, m_{\mathsf{y}, i}, \beta_{\mathsf{x}, i}, \beta_{\mathsf{y}, i})_{i \in [k_\mathsf{lin} + 1]} \right] 
+                                                                                                                                                                                                                                                        return stmt
+return (stmt', wit')
+```
+
+<span id="page-19-0"></span>**Fig. 2.**  $\Pi_{\ell,\mathsf{par}_{\mathsf{com}}}^{\mathsf{proj-c}}$ : The commit-project self-RoK for  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$ .
+
+## 5.2 Committed Coarse Random Projection
+
+The committed coarse random projection RoK  $\Pi_{\ell,m_x,\beta_x}^{\mathsf{proj-c}}$  is given in Fig. 2. On a technical level, it compresses the witness **W** into a shorter witness with closely related norm by using a random projection matrix **J**. To keep the specification of the projection succinct, a structured block-diagonal  $\mathbf{I} \otimes \mathbf{J}$  matrix is used. The projection **V** has dimension  $m_{\mathbf{w}} \cdot \frac{n_{\mathrm{rp}}}{m_{\mathrm{rp}}}$ , where  $\frac{n_{\mathrm{rp}}}{m_{\mathrm{rp}}}$ . After gadget decomposition as  $\mathbf{Y}_{k_{\mathrm{lin}}}$ , it is committed within  $\mathsf{com}_{k_{\mathrm{lin}}}$ . The relation is updated with  $\mathsf{com}_{k_{\mathrm{lin}}}$  and consistency checks that  $\mathbf{Y}_{k_{\mathrm{lin}}}$  does contain the random projection of **W**.
+
+The key feature of  $\Pi^{\text{proj-c}}$  is that it asserts strict norm-bounds on **W**: The **Y**<sub>i</sub> in  $\Xi_{\text{COM}}^{\text{lin}}$  have small norm and no slack (i.e.  $\varrho = 1$ ) by definition of  $\Xi_{\text{COM}}^{\text{lin}}$ . Thus, by properties of random projections, it follows that **W** must have no slack and its norm relative to **Y** is controlled by  $\frac{n_{\text{rp}}}{m_{\text{rr}}}$ .
+
+<span id="page-19-1"></span>**Lemma 7.** Let  $\ell$  be a gadget decomposition parameter and  $\mathsf{par}_{\mathsf{com}}$  be parameters for COM so that  $\beta_{\mathtt{x}} = \beta_{\mathtt{x}}[\mathsf{par}_{\mathsf{com}}]$ . Let  $m_{\mathtt{rp}}|m_{\mathtt{w}}$ . The RoK  $\Pi_{\ell,\mathsf{par}_{\mathsf{com}}}^{\mathsf{proj-c}}$  (Fig. 2) satisfies the following properties:
+
+- It is  $\epsilon$ -complete, with  $\epsilon = \kappa_{\rm rp} \cdot \varphi r m_{\rm w}/m_{\rm rp}$ , for  $\Xi_{\rm COM}^{\rm lin} \to \Xi_{\rm COM}^{\rm lin}$  with parameter change  $k_{\rm lin} \mapsto k_{\rm lin} + 1$  where
+
+$$\mathsf{par}_{\mathtt{lin},k_{\mathtt{lin}}} = \left(m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}}, \mathsf{par}_{\mathtt{com}}, \ell \cdot m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}}, \beta_{\mathtt{x}}, \mathsf{dcmp}_{\ell}(\beta_{\mathtt{rp}} \cdot \beta_{\mathtt{w}})\right).$$
+
+- It is  $\kappa$ -knowledge-sound, with  $\kappa = \kappa_{\rm rp} \cdot \varphi r m_{\rm w}/m_{\rm rp}$ , for
+
+$$\begin{split} \boldsymbol{\Xi}^{\mathrm{sis}}[\mathsf{par}_{\mathtt{sis}}] \vee \boldsymbol{\Xi}^{\mathsf{lin}}_{\mathsf{COM}}\left[k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \mathsf{cmp}(\beta'_{\mathtt{y}, k_{\mathtt{lin}}}) / \alpha_{\mathtt{rp}}, \quad (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta'_{\mathtt{x}, i}, \beta'_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}}]}\right] \\ \leftarrow \boldsymbol{\Xi}^{\mathsf{lin-rel}}_{\mathsf{COM}}[k_{\mathtt{lin}} + 1, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta'_{\mathtt{w}}, (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta'_{\mathtt{x}, i}, \beta'_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}} + 1]}, \varrho'], \end{split}$$
+
+{20}------------------------------------------------
+
+where
+
+$$\mathsf{par}_{\mathtt{sis}} \supseteq \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},k_{\mathtt{lin}}}, m_{\mathtt{y},k_{\mathtt{lin}}}, \beta'_{\mathtt{y},k_{\mathtt{lin}}}, \beta'_{\mathtt{x},k_{\mathtt{lin}}}] \cup \{(n_0, m_{\mathtt{w}}, 2\beta'_{\mathtt{w}}\varrho')\}$$
+
+- It has the following efficiency measures:
+  - Prover runtime:  $O(m_{\mathtt{w}}rn_{\mathtt{rp}})$   $\mathcal{R}_q$  operations and  $\mathsf{com}_{k_{\mathtt{lin}}}$  computation,
+  - Verifier runtime:  $O(n_{\tt rp}m_{\tt rp})$  samplings from  $\chi$ ,
+  - Prover-to-verifier communication:  $|com_{k_{lin}}|$ .
+
+### Proof.
+
+#### Completeness:
+
+Let **W** be the witness held by an honest prover and  $\beta_{\mathbf{w}}$  be the norm bound from the parameters. Then, by Lemma 6 (applied on each coefficient), except with probability at most  $\epsilon \coloneqq \kappa_{\rm rp} \cdot \varphi r m_{\tt w}/m_{\tt rp}$ , we have that  $\|\mathbf{V}\|_2 \leq \beta_{rp} \cdot \beta_{w}$ . Therefore, the norm of the committed witness  $\mathbf{Y}_{k_{lin}}$  is at most  $\mathsf{dcmp}(\beta_{\mathtt{rp}} \cdot \beta_{\mathtt{w}}).$ 
+
+### Knowledge-soundness:
+
+Let  $\mathcal{A}$  be a prover so that the verifier accepts with probability at least  $\epsilon$ . We construct an extractor Ext that extracts a witness  $\mathbf{W}^*$  from  $\mathcal{A}$ . The extractor runs the prover  $\mathcal{A}$  to obtain witness-statement pair (stmt', wit'). If the verifier rejects, the extractor aborts. If the verifier accepts, the extractor checks if  $\mathbf{W}'$  from the witness  $(\mathbf{W}', \mathbf{s}')$  satisfies the input constraints and outputs the witness if so. If not, the extractor rewinds A and repeats the process to obtain a second witness-statement pair  $(\mathsf{stmt''}, \mathsf{wit''}).$ 
+
+Now, let  $(\mathbf{W}', (\mathbf{Y}'_i, \mathbf{x}'_i)_{i \in [k_{\text{lin}}+1]}, \mathbf{s}') \coloneqq \text{wit}'$ , and likewise for wit". If it holds that  $(\mathbf{W}', \mathbf{s}') \neq$  $(\mathbf{W}'', \mathbf{s}'')$ , then the extractor outputs a non-zero column  $\mathbf{W}'\mathbf{s}'' - \mathbf{W}''\mathbf{s}'$  which satisfies  $\boldsymbol{\Xi}^{\mathsf{sis}}[\mathsf{par}_{\mathtt{sis}}]$ branch for extraction, where  $\mathsf{par}_{\mathtt{sis}} \ni (n_0, m_{\mathtt{w}}, 2\beta'_{\mathtt{w}}\varrho')$ . If it holds  $\mathbf{Y}'_{k_{\mathtt{lin}}} \neq \mathbf{Y}''_{k_{\mathtt{lin}}}$ , extractor outputs  $(\mathsf{vec}(\mathbf{Y}'_{k_{\mathtt{lin}}}), \mathbf{x}'_{k_{\mathtt{lin}}}), (\mathsf{vec}(\mathbf{Y}''_{k_{\mathtt{lin}}}), \mathbf{x}''_{k_{\mathtt{lin}}})$  which satisfies  $\Xi^{\mathsf{sis}}[\mathsf{par}_{\mathtt{sis}}]$  relation for the extraction, where  $\mathsf{par}_{\mathtt{sis}} \supseteq \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},k_{\mathtt{lin}}}, m_{\mathtt{y},k_{\mathtt{lin}}}, \beta'_{\mathtt{y},k_{\mathtt{lin}}}, \beta'_{\mathtt{x},k_{\mathtt{lin}}}], \text{ which is a valid extraction due to Lemma 4.}$  Let us now assume that  $(\mathbf{W}', \mathbf{s}') = (\mathbf{W}'', \mathbf{s}'') =: (\mathbf{W}^*, \mathbf{s}^*).$  Let  $\mathbf{V}^* \coloneqq \mathbf{G} \mathbf{Y}^*_{k_{\mathtt{lin}}}$  and  $\mathbf{J}$  be the random
+
+matrix sampled by  $\mathcal{A}$  in the second execution.
+
+Since J is now independent from  $W^*$ , by Lemma 6, it holds that
+
+$$\|\mathbf{W}^*\|_2 \le \|\mathbf{V}^*\|_2/\alpha_{\mathtt{rp}} \le \mathsf{cmp}(\beta'_{\mathtt{y},k_{\mathtt{lin}}})/\alpha_{\mathtt{rp}},$$
+
+unless with the failure probability  $\kappa_1 := \kappa_{\rm rp} \cdot \varphi r m_{\rm w}/m_{\rm rp}$  by Lemma 5 and the union bound, which concludes the extractability proof as the extractor outputs  $\mathbf{W}^*$  for relation  $\Xi_{\mathsf{COM}}^{\mathsf{lin-rel}}$ .
+
+#### Extractor runtime:
+
+To find an accepting transcript with probability at least  $\epsilon$ , the extractor needs to rewind  $\mathcal{A}$  at most  $1/\epsilon$  times in expectation. Since the extractor only rewinds if the initial uniform challenge was successful, and the challenges are sampled uniformly at random, it follows by a standard argument that  $\epsilon \cdot \frac{1}{\epsilon}$  rewinds are required in expectation. Hence, the extractor is expected polynomial-time.
+
+### Efficiency:
+
+For the prover, the cost is dominated by computing V. The cost of computing V is  $O(m_{\tt w}rn_{\tt rp})$  ring operations. Further, the prover needs to compute one commitment for  $\mathbf{Y}_{k_{\text{lin}}}$ . For the verifier, the cost is dominated by sampling **J**, which costs  $O(n_{rp}m_{rp})$  samplings from  $\chi$ . The communication cost is dominated by sending the commitment  $com_{k_{1in}}$ . 
+
+{21}------------------------------------------------
+
+#### 5.3 Committed Fine Random Projection
+
+The committed fine random projection RoK  $\Pi_{n_{\text{bat}},\ell,\ell',\text{par}_{\text{com}},\text{par}'_{\text{com}}}^{\text{proj-f}}$  is given in Fig. 3. Clearly, for the projection to be compressing, we need  $m_{\text{rp}} > n_{\text{rp}}$ , which fails at  $m_{\text{rp}} = n_{\text{rp}}$ . However, there are two dimensions in consideration: The dimension  $m_{\text{w}} = \dim_{\mathcal{R}}(\mathbf{w})$  of  $\mathbf{w}$  as a vector of  $\mathcal{R}$ -elements (which is how  $\Pi^{\text{proj-c}}$  operates), and the dimension  $\dim_{\mathbb{Z}}(\mathbf{w}) = \varphi \cdot m_{\text{w}}$  as a vector of  $\mathbb{Z}$ -elements. In the latter case, we can compress as long as  $\varphi m_{\text{rp}} > n_{\text{rp}}$ , which is what  $\Pi^{\text{proj-f}}$  does.
+
+To realise the above, the random projection  $\mathbf{J}$  and  $\mathbf{W}$  are multiplied on the coefficient level, i.e., we use  $\mathsf{trace}(\mathbf{V}) = \mathbf{J} \cdot \mathsf{cf}(\mathbf{W}) = \mathsf{trace}(\mathsf{cf}_{\vee}(\mathbf{J}) \cdot \mathbf{W})$ . This is more sophisticated and expensive than in  $\Pi^{\mathsf{proj-c}}$ , hence we switch from coarse  $\Pi^{\mathsf{proj-c}}$  to fine  $\Pi^{\mathsf{proj-f}}$  as late as possible.<sup>11</sup>
+
+On a technical level,  $\Pi^{\text{proj-f}}$  projects over the coefficient embedding, using the trace and the trace-dual basis. The projected witness  $\mathbf{V}_{\text{tr}}$  (over  $\mathbb{Z}$ ) is re-embedded into  $\mathcal{R}$ , and committed as  $\mathsf{com}_{k_{\text{lin}}}$ . Note that constraints in  $\Xi^{\text{lin}}_{\mathsf{COM}}$  are over  $\mathcal{R}$  (not  $\mathbb{Z}$ ). Therefore, we cannot directly express the consistency of  $\mathbf{V}_{\text{tr}}$  via constraints. Instead, constraints are converted to equations over  $\mathcal{R}$ , where the verifier checks the trace. Moreover, to check the consistency of the witness and its projection, the prover batches the linear constraints using random row-tensor matrices  $\mathbf{Z}^{(0)}, \mathbf{Z}^{(1)}$  and  $\mathbf{Z}^{(2)}$  (sampled by the verifier) over  $\mathbb{Z}_q$ , by embedding the batching challenges via trace-dual embedding. Due to batching, the vector  $\mathbf{r}$  (sent in the last move) consists of only  $n_{\text{bat}}$  elements. Lastly, the batch-verify equations are encoded into an " $\mathbf{A} \cdot \mathsf{vec}(\mathbf{Y}) = \mathbf{b}$ " and two " $\mathbf{F}_i \mathbf{W} = \mathbf{Y}_i$ " constraints.
+
+<span id="page-21-1"></span>**Lemma 8.** Let  $n_{\text{bat}} \in \mathbb{N}$  be a batching parameter,  $\ell, \ell' \in \mathbb{N}$  be gadget decomposition parameters and  $\operatorname{\mathsf{par}}_{\mathsf{com}}$ ,  $\operatorname{\mathsf{par}}'_{\mathsf{com}}$  be parameters for COM so that  $\beta_{\mathsf{x}} = \beta_{\mathsf{x}}[\operatorname{\mathsf{par}}_{\mathsf{com}}]$  and  $\beta'_{\mathsf{x}} = \beta_{\mathsf{x}}[\operatorname{\mathsf{par}}'_{\mathsf{com}}]$ . Let  $m_{\mathsf{rp}}|\varphi m_{\mathsf{w}}$ . The RoK  $\Pi^{\mathsf{proj-f}}_{n_{\mathsf{bat}},\ell,\ell',\operatorname{\mathsf{par}}_{\mathsf{com}},\operatorname{\mathsf{par}}'_{\mathsf{com}}}$  (Fig. 3) satisfies the properties:
+
+- It is  $\epsilon$ -complete, with  $\epsilon = (\varphi r m_{\mathtt{w}} / m_{\mathtt{rp}}) \kappa_{\mathtt{rp}}$ , for  $\Xi_{\mathsf{COM}}^{\mathsf{lin}} \to \Xi_{\mathsf{COM}}^{\mathsf{lin}}$  with parameter changes  $k_{\mathtt{lin}} \mapsto k_{\mathtt{lin}} + 2$ ,  $n \mapsto n + n_{\mathtt{bat}}$ , where
+
+$$\begin{split} \mathsf{par}_{\mathtt{lin},k_{\mathtt{lin}}} &\coloneqq \left(0,\mathsf{par}_{\mathtt{com}},\ell m_{\mathtt{w}} \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}},\beta_{\mathtt{x}},\mathsf{dcmp}_{\ell}(\beta_{\mathtt{rp}}\cdot\beta_{\mathtt{w}})\right), \\ \mathsf{par}_{\mathtt{lin},k_{\mathtt{lin}}+1} &\coloneqq \left(n_{\mathtt{bat}},\mathsf{par}'_{\mathtt{com}},\ell'\cdot n_{\mathtt{bat}},\beta'_{\mathtt{x}},\mathsf{dcmp}_{\ell'}(q/2)\right). \end{split}$$
+
+- It is knowledge-sound with  $\kappa = ((\log(\varphi r m_{\mathtt{w}}/m_{\mathtt{rp}}))/q)^{n_{\mathtt{bat}}} + (\varphi r m_{\mathtt{w}}/m_{\mathtt{rp}})\kappa_{\mathtt{rp}},$  for
+
+$$\begin{split} &\mathcal{\Xi}^{\mathsf{sis}}[\mathsf{par}_{\mathtt{sis}}] \vee \mathcal{\Xi}^{\mathsf{lin}}_{\mathsf{COM}}\left[k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \mathsf{cmp}(\beta'_{\mathtt{y}, k_{\mathtt{lin}}}) / \alpha_{\mathtt{rp}}, \quad (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta'_{\mathtt{x}, i}, \beta'_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}}]}\right] \\ &\leftarrow \mathcal{\Xi}^{\mathsf{lin-rel}}_{\mathsf{COM}}\left[k_{\mathtt{lin}} + 2, k_{\mathtt{lr}}, n + n_{\mathtt{bat}}, m_{\mathtt{w}}, r, \beta'_{\mathtt{w}}, \quad (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta'_{\mathtt{x}, i}, \beta'_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}} + 2]}, \varrho'\right]. \end{split}$$
+
+where
+
+$$\mathsf{par}_{\mathtt{sis}} \supseteq \{(n_0, m_{\mathtt{w}}, 2\beta_{\mathtt{w}}' \varrho')\} \ \cup \ \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com}, k_{\mathtt{lin}}}, m_{\mathtt{y}, k_{\mathtt{lin}}}, \beta_{\mathtt{y}, k_{\mathtt{lin}}}', \beta_{\mathtt{x}, k_{\mathtt{lin}}}'] \\ \cup \ \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com}, k_{\mathtt{lin}}+1}, m_{\mathtt{y}, k_{\mathtt{lin}}+1}, \beta_{\mathtt{y}, k_{\mathtt{lin}}+1}', \beta_{\mathtt{x}, k_{\mathtt{lin}}+1}']$$
+
+- It has the following efficiency measures:
+  - Prover runtime:  $O(m_{\mathbf{w}}rn_{\mathbf{rp}}\varphi)$   $\mathbb{Z}$  operations,  $O(n_{\mathbf{bat}}m_{\mathbf{w}}r)$   $\mathcal{R}_q$  operations and the cost of computing  $\mathsf{com}_{k_{\mathsf{lin}}}$  and  $\mathsf{com}_{k_{\mathsf{lin}}+1}$ .
+  - Verifier runtime:  $O(n_{pmrp})$  samplings from  $\chi$ ,  $O(n_{bat} \log(\varphi r m_{w}/m_{pp}))$  samplings from  $\mathbb{Z}_q$  and  $O(n_{bat})$   $\mathcal{R}_q$  operations.
+  - Prover-to-verifier comm.:  $|\mathsf{com}_{k_{\mathsf{lin}}}| + |\mathsf{com}_{k_{\mathsf{lin}}+1}| + O(n_{\mathsf{bat}} \cdot \log |\mathcal{R}_q|)$ .
+
+<span id="page-21-0"></span>Lifting  $\overline{\mathbf{J}}$  to  $\mathsf{cf}_{\vee}(\mathbf{J})$  and using it is computationally more expensive than mere ring element addition and subtraction required to compute  $\mathbf{J}\mathbf{W}$  in  $\Pi^{\mathsf{proj-c}}$ .
+
+{22}------------------------------------------------
+
+```
+P(stmt, wit)
+                                                                                                                                                                                                                                                                                                                    V(stmt)
+                                                                                             \mathbf{parse} \; \mathsf{stmt} = ((\mathsf{com}_i, \mathbf{F}_i, \mathbf{H}_i)_{i \in [k_{\mathtt{lin}}]}, (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [k_{\mathtt{lr}}]}, \mathbf{A}, \mathbf{b})
+\mathbf{parse} \ \mathsf{wit} = (\mathbf{W}, (\mathbf{Y}_i, \mathbf{x}_i)_{i \in [k_{\mathtt{lin}}]})
+                                                                               /\!\!/ \quad (\mathsf{stmt}, \mathsf{wit}) \in \varXi_{\mathsf{COM}}^{\mathsf{lin}} \left[ k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta_{\mathtt{x}, i}, \beta_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}}]} \right] 
+\mathbf{V} \coloneqq (\mathbf{I}_{\varphi m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathsf{cf}_{\vee}^{-1} (\mathbf{J}^{\mathtt{T}})^{\mathtt{T}}) \cdot \mathbf{W} \in \mathcal{R}^{\varphi m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}} \times r}
+                                                                                                                                                                                                                                                                                                                   \mathbf{J} \leftarrow \chi^{n_{\mathtt{rp}} \times m_{\mathtt{rp}}}
+\mathbf{V}_{\mathtt{tr}} \coloneqq \mathsf{trace}(\mathbf{V}) \in \mathbb{Z}^{\varphi m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}} \times r}
+\mathbf{V}_{\mathtt{emb}} \coloneqq \mathsf{cf}^{-1}(\mathbf{V}_{\mathtt{tr}}) \in \mathcal{R}^{m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}} \times r}
+\mathbf{Y}_{k_{\mathtt{lin}}} \coloneqq \mathbf{G}_{\ell}^{-1}(\mathbf{V}_{\mathtt{emb}}) \in \mathcal{R}^{\ell m_{\mathtt{w}} \cdot \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}} \times r}
+                                                                                                                                                                                                                                                                                                                   \mathbf{Z}^{(0)} \leftarrow \mathbb{Z}_q^{n_{\mathtt{bat}} \times 2^{\otimes \log \varphi}}
+                                                                                                                                                                                                                                                                                                                    \mathbf{Z}^{(1)} \leftarrow \mathbb{Z}_a^{n_{\mathtt{bat}} \times 2^{\otimes \log(m_{\mathtt{W}}/m_{\mathtt{rp}})}}
+\mathbf{F}_k = \mathbf{0}, \; \mathbf{H}_k = \mathbf{0} \; \; /\!\!/ \; \text{ignored}
+                                                                                                                                                                                                                                                                                                                   \mathbf{Z} \coloneqq \mathbf{Z}^{(1)} \bullet \mathbf{Z}^{(0)}
+                                                                                                                                                                                                                                     \mathsf{com}_{k_{\mathtt{lin}}}
+(\mathsf{com}_{k_{\mathtt{lin}}}, \mathbf{x}_{k_{\mathtt{lin}}}) \coloneqq \mathsf{Com}_{\mathsf{par}_{\mathtt{com}}}(\mathsf{ck}, \mathsf{vec}(\mathbf{Y}_{k_{\mathtt{lin}}}))
+                                                                                                                                                                                                                                                                                                                   \mathbf{Z}^{(2)} \leftarrow \mathbb{S} \, \mathbb{Z}_a^{n_{\mathtt{bat}} \times 2^{\bigotimes 2}}
+                                                                                                                                                                                                                                      {\bf Z}, {\bf Z}^{(2)}
+\mathbf{V}_{\mathtt{bat}} \coloneqq \mathbf{Z} \cdot \mathbf{V} \bmod q \in \mathcal{R}_q^{n_{\mathtt{bat}} \times r}
+\mathbf{Y}_{k_{\mathtt{lin}}+1} \coloneqq \mathbf{G}_{\ell'}^{-1}(\mathbf{V}_{\mathtt{bat}}) \in \mathcal{R}^{\ell' \cdot n_{\mathtt{bat}} \times r}
+(\mathsf{com}_{k_{\mathtt{lin}}+1}, \mathbf{x}_{k_{\mathtt{lin}}+1}) \coloneqq \mathsf{Com}_{\mathsf{par}'_{\mathtt{com}}}(\mathsf{ck}, \mathsf{vec}(\mathbf{Y}_{k_{\mathtt{lin}}+1}))
+\mathbf{F}_{k_{\mathtt{lin}}+1} = \mathbf{Z}(\mathbf{I}_{\varphi m_{\mathtt{W}}/m_{\mathtt{rp}}} \otimes \mathsf{cf}_{\vee}^{-1}(\mathbf{J})), \ \mathbf{H}_{k_{\mathtt{lin}}+1} = \mathbf{G}_{\ell'}
+\hat{z}_i^{(0)} \coloneqq \mathsf{cf}_\vee^{-1}(\mathbf{z}_i^{(0)}) \in \mathcal{R} \ \forall i \in [n_{\mathsf{bat}}]
+                                                                                                                                                                                                                                                                                                                   \forall i \in [n_{\text{bat}}]:
+\mathbf{r} \coloneqq (\mathbf{V}_{\mathtt{bat}}\mathbf{z}_i^{(2)} - \mathbf{z}_1^{(1)\mathtt{T}}\hat{z}_i^{(0)}\mathbf{V}_{\mathtt{emb}}\mathbf{z}_i^{(2)})_{i \in [n_{\mathtt{bat}}]}
+                                                                                                                                                                                                                            \mathsf{com}_{k_{\mathtt{lin}}+1},\mathbf{r}
+                                                                                                                                                                                                                                                                                                                            trace(r_i) \stackrel{?}{=} 0
+\mathbf{A}' \coloneqq \mathsf{diag}(\mathbf{A}, (\mathbf{z}_i^{(2)} \otimes \mathbf{z}_i \otimes \mathbf{g} \| \mathbf{z}_i^{(2)} \otimes \mathbf{z}_i^{(1)} \otimes \hat{z}_i^{(0)} \otimes \mathbf{g})_{i \in [n_{\mathsf{bet}}]}^{\mathsf{T}})
+\mathbf{b}'\coloneqq [\mathbf{b}\|\mathbf{r}]
+(n_{k_{\mathtt{lin}}}, \mathsf{par}_{\mathtt{com}, k_{\mathtt{lin}}}, m_{\mathtt{y}, k_{\mathtt{lin}}}, \beta_{\mathtt{x}, k_{\mathtt{lin}}}, \beta_{\mathtt{y}, k_{\mathtt{lin}}}) \coloneqq \left(0, \mathsf{par}_{\mathtt{com}}, \ell m \frac{n_{\mathtt{rp}}}{m_{\mathtt{rp}}}, \beta_{\mathtt{x}}[\mathsf{par}_{\mathtt{com}}], \mathsf{dcmp}_{\ell}(\beta_{\mathtt{rp}} \cdot \beta_{\mathtt{w}})\right)
+ (n_{k_{\mathtt{lin}}+1}, \mathsf{par}_{\mathtt{com}, k_{\mathtt{lin}}+1}, m_{\mathtt{y}, k_{\mathtt{lin}}+1}, \beta_{\mathtt{x}, k_{\mathtt{lin}}+1}, \beta_{\mathtt{y}, k_{\mathtt{lin}}+1}) \coloneqq (n_{\mathtt{bat}}, \mathsf{par}'_{\mathtt{com}}, \ell' \cdot n_{\mathtt{bat}}, \beta_{\mathtt{x}}[\mathsf{par}'_{\mathtt{com}}], \mathsf{dcmp}_{\ell'}(q/2))
+\mathsf{wit}' \coloneqq (\mathbf{W}, (\mathbf{Y}_i, \mathbf{x}_i)_{i \in [k_{\mathtt{lin}} + 2]})
+                                                                                                \mathsf{stmt}' \coloneqq ((\mathsf{com}_i, \mathbf{F}_i, \mathbf{H}_i)_{i \in [k_{1:n}+2]}, (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [k_{1:n}]}, \mathbf{A}', \mathbf{b}')
+                                                      /\!\!/ \quad (\mathsf{stmt'}, \mathsf{wit'}) \in \varXi_\mathsf{COM}^\mathsf{lin} \left[ \frac{k_\mathsf{lin} + 2}{k_\mathsf{lr}}, \frac{n + n_\mathsf{bat}}{k_\mathsf{bat}}, m_\mathsf{w}, r, \beta_\mathsf{w}, (n_i, \mathsf{par}_{\mathsf{com},i}, m_{\mathsf{y},i}, \beta_{\mathsf{x},i}, \beta_{\mathsf{y},i})_{i \in [k_\mathsf{lin} + 2]} \right] 
+return (stmt', wit')
+                                                                                                                                                                                                                                                                                                                    return stmt
+```
+
+<span id="page-22-0"></span>**Fig. 3.**  $\Pi_{n_{\mathsf{bat}},\ell,\ell',\mathsf{par}_{\mathsf{com}},\mathsf{par}'_{\mathsf{com}}}^{\mathsf{proj-f}}$ : The commit-project self-RoK for  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$ .
+
+## Proof.
+
+#### Completeness:
+
+For an honest prover holding witness **W** with norm at most  $\beta_{\tt w}$ , by Lemma 6, except with probability at most  $(\varphi r m_{\tt w}/m_{\tt rp})\kappa_{\tt rp}$ , we have that  $\|{\bf V}_{\tt emb}\|_2 \leq \beta_{\tt rp} \cdot \beta_{\tt w}$ . Therefore, the norm of the committed witness  ${\bf Y}_{k_{\tt lin}}$  is at most  $\mathsf{dcmp}(\beta_{\tt rp} \cdot \beta_{\tt w})$ .
+
+For the batch constraints, we have  $V_{\text{bat}}$  with norm at most q. Therefore, the committed witness  $Y_{k_{\text{lin}}+1}$  has norm at most dcmp(q/2).
+
+To argue that the batch constraints are satisfied, we first note that:
+
+$$\mathsf{trace}(\mathsf{cf}_{\vee}^{-1}(\mathbf{J}^{\mathsf{T}})^{\mathsf{T}}\mathbf{w}_{i,j}) = \mathbf{J}\mathsf{cf}(\mathbf{w}_{i,j}) \quad \forall (i,j) \in [m_{\mathtt{w}}/m_{\mathtt{rp}}, r],$$
+
+{23}------------------------------------------------
+
+For each  $i \in [n_{bat}]$ , we observe that the following holds:
+
+$$\mathsf{trace}(\mathbf{z}_i^{(1)^{\mathtt{T}}} \otimes \mathbf{z}_i^{0\mathtt{T}} \mathsf{cf}_{\vee}^{-1} (\mathbf{J}^{\mathtt{T}})^{\mathtt{T}} \cdot \mathbf{W} \mathbf{z}_i^{(2)}) = \mathbf{z}_i^{(1)^{\mathtt{T}}} \otimes \mathbf{z}_i^{0\mathtt{T}} \mathbf{V}_{\mathtt{tr}} \mathbf{z}_i^{(2)},$$
+
+which is immediate since trace is  $\mathbb{Z}_q$  linear. Since  $\mathbf{z}_i^{0\mathsf{T}}\mathbf{V}_{\mathsf{tr}} = \mathsf{trace}(\hat{z}_i^{(0)}\mathbf{V}_{\mathsf{emb}})$ , it also holds that:
+
+$$\mathsf{trace}(\mathbf{z}_i^{(1)^{\mathsf{T}}} \otimes \mathbf{z}_i^{0\mathsf{T}} \mathsf{cf}_{\vee}^{-1} (\mathbf{J}^{\mathsf{T}})^{\mathsf{T}} \cdot \mathbf{W} \mathbf{z}_i^{(2)}) = \mathsf{trace}(\mathbf{z}_i^{(1)^{\mathsf{T}}} \otimes \hat{z}_i^{(0)} \mathbf{V}_{\mathtt{emb}} \mathbf{z}_i^{(2)}),$$
+
+which concludes that  $trace(r_i) = 0$  and also certifies the correctness of the new  $\mathbf{A}'$  constraints. Knowledge-soundness:
+
+The analysis of the extractor is conveniently split into two steps.
+
+accepting transcript.
+
+1. First, we consider the prover  $\mathcal{A}_{sz}$  for the sub-protocol that receives  $\mathbf{Z}$  and  $\mathbf{Z}^{(2)}$  from the verifier and sends  $\mathsf{com}_{k_{\text{lin}}+1}$  and  $\mathbf{r}$ . We construct an extractor  $\mathsf{Ext}_{sz}$  for the input intermediate relation,  $\mathcal{Z}^{\text{lin}}_{\mathsf{COM}}$  with an additional constraint that  $\mathbf{V}_{\mathsf{tr}} = \mathsf{trace}(\mathbf{I}_{\varphi m_{\mathsf{v}}/m_{\mathsf{rp}}} \otimes \mathsf{cf}^{-1}_{\mathsf{v}}(\mathbf{J}^{\mathsf{T}})^{\mathsf{T}} \cdot \mathbf{W})$ . First, the extractor executes  $\mathcal{A}_{sz}$  to obtain an accepting transcript. If the verifier rejects, the extractor aborts. If the verifier accepts, the extractor checks if the witness  $\mathbf{W}'$  from the witness  $(\mathbf{W}', \mathbf{s}')$  satisfies the input constraints and the additional trace constraint. If so, the extractor outputs the witness. If not, the extractor rewinds  $\mathcal{A}_{sz}$  and repeats the process to obtain a second
+
+Now, let  $(\mathbf{W}', \mathbf{s}')$  and  $(\mathbf{W}'', \mathbf{s}'')$  be the witnesses extracted from the two transcripts, respectively. If it holds that  $(\mathbf{W}', \mathbf{s}') \neq (\mathbf{W}'', \mathbf{s}'')$ , then the extractor outputs a non-zero column  $\mathbf{W}'\mathbf{s}'' - \mathbf{W}''\mathbf{s}'$  which satisfies  $\Xi^{\mathsf{sis}}[\mathsf{par}_{\mathsf{sis}}]$  branch for extraction, where  $\mathsf{par}_{\mathsf{sis}} \ni (n_0, m_{\mathsf{w}}, 2\beta_{\mathsf{w}}'\varrho')$ . If it holds that  $\mathbf{Y}'_{k_{\mathsf{lin}}+1} \neq \mathbf{Y}''_{k_{\mathsf{lin}}+1}$ , then the extractor outputs  $(\mathsf{vec}(\mathbf{Y}'_{k_{\mathsf{lin}}+1}), \mathbf{x}'_{k_{\mathsf{lin}}+1}), (\mathsf{vec}(\mathbf{Y}''_{k_{\mathsf{lin}}+1}), \mathbf{x}''_{k_{\mathsf{lin}}+1})$  which satisfies  $\Xi^{\mathsf{sis}}[\mathsf{par}_{\mathsf{sis}}]$  relation for the extraction, where
+
+$$\mathsf{par}_{\mathtt{sis}} \supseteq \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},k_{\mathtt{lin}}+1},m_{\mathtt{y},k_{\mathtt{lin}}+1},\beta'_{\mathtt{y},k_{\mathtt{lin}}+1},\beta'_{\mathtt{x},k_{\mathtt{lin}}+1}],$$
+
+which is a valid extraction due to Lemma 4. Similarly, if it holds that  $\mathbf{Y}'_{k_{\text{lin}}} \neq \mathbf{Y}''_{k_{\text{lin}}}$ , then the extractor outputs  $(\text{vec}(\mathbf{Y}'_{k_{\text{lin}}}), \mathbf{x}'_{k_{\text{lin}}}), (\text{vec}(\mathbf{Y}''_{k_{\text{lin}}}), \mathbf{x}''_{k_{\text{lin}}})$  which satisfies  $\Xi^{\text{sis}}[\text{par}_{\text{sis}}]$  relation for the extraction, where  $\text{par}_{\text{sis}} \supseteq \text{par}_{\text{break}}[\text{par}_{\text{com},k_{\text{lin}}}, m_{\text{y},k_{\text{lin}}}, \beta'_{\text{y},k_{\text{lin}}}, \beta'_{\text{x},k_{\text{lin}}}]$ , which is a valid extraction due to Lemma 4.
+
+Let us now assume that  $(\mathbf{W}', \mathbf{s}') = (\mathbf{W}'', \mathbf{s}'') = (\mathbf{W}^*, \mathbf{s}^*)$ . Let  $\mathbf{V}^*_{\mathtt{bat}} \coloneqq \mathbf{G} \mathbf{Y}^*_{k_{\mathtt{lin}}+1}, \mathbf{V}^*_{\mathtt{emb}} \coloneqq \mathbf{G} \mathbf{Y}^*_{k_{\mathtt{lin}}}, \mathbf{V}^*_{\mathtt{tr}} \coloneqq \mathsf{cf}(\mathbf{V}^*_{\mathtt{emb}})$ , and  $\mathbf{Z}^*, \mathbf{Z}^{*(2)}$  be the random matrices sampled in the second execution. Since,
+
+$$\mathbf{V}_{\mathtt{bat}}^* = \mathbf{Z}(\mathbf{I}_{\varphi m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathsf{cf}_{\vee}^{-1}(\mathbf{J}^{\mathtt{T}})^{\mathtt{T}}) \cdot \mathbf{W}^* \bmod q,$$
+
+then also by  $\mathbf{A}'$  constraints it holds that for each  $i \in [n_{\text{bat}}]$ :
+
+$$\mathsf{trace}(\mathbf{z}_i^{\mathsf{T}}(\mathbf{I}_{\varphi m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathsf{cf}_{\vee}^{-1}(\mathbf{J}^{\mathsf{T}})^{\mathtt{T}}) \cdot \mathbf{W}^* \cdot \mathbf{z}_i^{(2)}) = \mathsf{trace}(\mathbf{z}_i^{(1)} \otimes \hat{z}_i^{(0)} \mathbf{V}_{\mathtt{emb}}^* \mathbf{z}_i^{(2)}) \bmod q,$$
+
+which implies that  $\mathbf{V}^*_{\mathtt{emb}} = \mathsf{cf}^{-1}\mathbf{V}^*_{\mathtt{tr}}$  satisfies the constraint:
+
+$$\operatorname{trace}(\mathbf{z}_i^{\mathsf{T}}(\mathbf{I}_{\varphi m_{\mathsf{w}}/m_{\mathsf{rp}}} \otimes \operatorname{cf}_{\vee}^{-1}(\mathbf{J}^{\mathsf{T}})^{\mathsf{T}}) \cdot \mathbf{W}^* \cdot \mathbf{z}_i^{(2)}) = \mathbf{z}_i^{\mathsf{T}} \mathbf{V}_{\mathsf{tr}}^* \mathbf{z}_i^{(2)} \bmod q.$$
+
+Now, since  $\mathbf{Z}^*$ ,  $\mathbf{Z}^{*(2)}$  are uniformly random row-tensor matrices, by a standard Schwartz-Zippel argument (i.e. observing that batching with row-tensor vector  $(\mathbf{z}_i^{(2)})^{\mathsf{T}} \otimes \mathbf{z}_i^{\mathsf{T}}$  of dimension  $\varphi r m_{\mathsf{w}}/m_{\mathsf{rp}}$ 
+
+{24}------------------------------------------------
+
+is equivalent to evaluating a multilinear polynomial of total degree  $\log(\varphi r m_w/m_{rp})$ ), except with probability at most
+
+$$\kappa_{1,sz} := (\log(\varphi r m_{\mathtt{w}}/m_{\mathtt{rp}})/q)^{n_{\mathtt{bat}}},$$
+
+it holds that:
+
+$$\operatorname{trace}((\mathbf{I}_{\varphi m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \operatorname{cf}_{\vee}^{-1}(\mathbf{J})) \cdot \mathbf{W}^*) = \mathbf{V}_{\mathtt{tr}}^* \bmod q.$$
+
+2. Now, we consider the prover  $\mathcal{A}_{rp}$  for the sub-protocol that receives  $\mathbf{J}$  from the verifier and sends  $\mathsf{com}_{k_{1in}}, \, \mathbf{Z}, \, \mathbf{Z}^{(2)}$ . We construct an extractor  $\mathsf{Ext}_{rp}$  for the input relation,  $\Xi^{\mathsf{lin}}_{\mathsf{COM}}$ . Assume that the extractor has access to the (correct) output of the previous extractor  $\mathsf{Ext}_{sz}$ . The extractor runs  $\mathcal{A}_{rp}$  to obtain an accepting transcript. If the verifier rejects, the extractor aborts. If the verifier accepts, the extractor checks if the witness  $\mathbf{W}'$  from the witness  $(\mathbf{W}',s')$  satisfies the input constraints. If so, the extractor outputs the witness. If not, the extractor rewinds  $\mathcal{A}_{rp}$  and repeats the process to obtain a second accepting transcript. Now, let  $(\mathbf{W}',s')$  and  $(\mathbf{W}'',s'')$  be the witnesses extracted from the two transcripts, respectively. If it holds that  $(\mathbf{W}',s') \neq (\mathbf{W}'',s'')$ , then the extractor outputs a non-zero column  $\mathbf{W}'s'' - \mathbf{W}''s'$  which satisfies the  $\Xi^{\mathsf{sis}}[\mathsf{par}_{\mathsf{sis}}]$ , where  $\mathsf{par}_{\mathsf{sis}} \ni (n_0, m_{\mathsf{w}}, 2\beta'_{\mathsf{w}}\varrho')$ . If it holds that  $\mathbf{Y}'_{k_{1in}} \neq \mathbf{Y}''_{k_{1in}}$ , then the extractor outputs  $(\mathsf{vec}(\mathbf{Y}'_{k_{1in}}), \mathbf{x}'_{k_{1in}}), (\mathsf{vec}(\mathbf{Y}''_{k_{1in}}), \mathbf{x}'_{k_{1in}})$  which satisfies  $\Xi^{\mathsf{sis}}[\mathsf{par}_{\mathsf{sis}}]$  relation for extraction, where  $\mathsf{par}_{\mathsf{sis}} \supseteq \mathsf{par}_{\mathsf{break}}[\mathsf{par}_{\mathsf{com},k_{1in}}, m_{\mathsf{y},k_{1in}}, \beta'_{\mathsf{y},k_{1in}}]$ , which is a valid extraction due to Lemma 4. Let us now assume that  $(\mathbf{W}', \mathbf{s}') = (\mathbf{W}'', \mathbf{s}'') = :(\mathbf{W}^*, \mathbf{s}^*)$ . Let  $\mathbf{V}^*_{\mathsf{emb}} \coloneqq \mathbf{G}\mathbf{Y}^*_{k_{1in}}$ ,  $\mathbf{V}^*_{\mathsf{tr}} \coloneqq \mathsf{cf}(\mathbf{V}^*_{\mathsf{emb}})$ , and  $\mathbf{J}^*$  be the random matrix sampled in the second execution. Since,
+
+$$\operatorname{trace}((\mathbf{I}_{\varphi m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \operatorname{cf}^{-1}_{\vee}(\mathbf{J}^{*\mathtt{T}})^{\mathtt{T}}) \cdot \mathbf{W}^{*}) = \mathbf{V}_{\mathtt{tr}}^{*} \bmod q,$$
+
+we can now apply Lemma 6 to conclude that
+
+$$\|\mathbf{W}^*\|_2 \leq \|\mathbf{V}^*_{\texttt{emb}}\|_2/\alpha_{\texttt{rp}} \leq \mathsf{cmp}(\beta'_{\texttt{y},k_{\texttt{lin}}})/\alpha_{\texttt{rp}},$$
+
+unless with the failure probability  $\kappa_{1,rp} := (\varphi r m_{\mathtt{w}}/m_{\mathtt{rp}}) \cdot \kappa_{\mathtt{rp}}$  by Lemma 6, which concludes the extractability proof as the extractor outputs  $\mathbf{W}^*$  for relation  $\Xi_{\mathsf{COM}}^{\mathsf{lin-rel}}$ .
+
+In total, the failure probability is at most  $\kappa_1 := \kappa_{1,sz} + \kappa_{1,rp}$  by the union bound.
+
+## Extractor runtime:
+
+The extractor Ext runs the two extractors  $\mathsf{Ext}_{\mathtt{sz}}$  and  $\mathsf{Ext}_{\mathtt{rp}}$  sequentially. Each of these extractors runs in expected polynomial-time by a similar argument as in Lemma 7.
+
+#### Efficiency:
+
+The prover's cost is dominated by computing  $V_{tr}$  (no need to compute V explicitly), which costs  $O(m_{\tt w}rn_{\tt rp}\varphi)$   $\mathbb Z$  operations and by computing  $V_{\tt bat}$ , which costs  $O(n_{\tt bat}m_{\tt w}r)$   $\mathcal R_q$  operations. Further, the prover needs to compute two commitments – one for  $Y_{k_{\tt lin}}$  and one for  $Y_{k_{\tt lin}+1}$ .
+
+For the verifier, the cost is sampling **J**, which is  $O(m_{\mathtt{rp}}n_{\mathtt{rp}})$  samplings from  $\chi$ , sampling **Z** and  $\mathtt{Z}^{(2)}$ , which is  $O(n_{\mathtt{bat}}\log(\varphi r m_{\mathtt{w}}/m_{\mathtt{rp}}))$  samplings from  $\mathbb{Z}_q$  and  $O(n_{\mathtt{bat}})$  ring operations for computing each  $\mathtt{trace}(r_i)$ . The communication cost is dominated by sending the commitments  $\mathtt{com}_{k_{\mathtt{lin}}}$ ,  $\mathtt{com}_{k_{\mathtt{lin}}+1}$  and  $O(n_{\mathtt{bat}})$   $|\mathcal{R}_q|$  for sending **r**.
+
+<span id="page-24-0"></span>Committed Fine Random Projection with "Lift-and-Batch" The strategy in Fig. 3 can be further optimised asymptotically, though this barely matters for practical parameters. The technique, called "lift-and-batch", was introduced in [KLNO25] and exploits favourable ring structure to
+
+{25}------------------------------------------------
+
+gradually lift multiple (partial) trace-equalities to ring equalities by going through intermediate subrings. For suitable parameter choices and rings, this yields a protocol  $\Pi^{\text{proj-fl}}$  with prover communication  $|\text{com}_{k_{\text{lin}}}| + |\text{com}_{k_{\text{lin}}+1}| + O(\log |\mathcal{R}_q|)$ . The changes are very similar to [KLNO25], and we provide an informal protocol description and analysis in Section A.
+
+## <span id="page-25-0"></span>6 Committed Folding
+
+In this section, we present the committed folding RoK  $\Pi^{\mathsf{fold-split}}$  for  $\Xi^{\mathsf{lin}}_{\mathsf{COM}}$ . Starting from a committed-linear instance of width r, it folds the witness columns with a random challenge  $\mathbf{c} \in \mathcal{C}^r$  and then repacks the folded data into a new witness matrix of width r'. The output commitment is made to the derived output linear block (via  $\mathsf{vec}(\mathbf{Y})$ ), and all resulting claims are expressed as sumcheck constraints. Thus,  $\Pi^{\mathsf{fold-split}}$  reduces the witness size while preserving the committed-linear structure needed by the next round.
+
+On a technical level, the protocol consists of four main steps. First, the prover sends a commitment to  $\mathbf{T} = \mathbf{F}_{k_{1:n}} \mathbf{W}$ , i.e., the right-constraint block needed to encode all witness constraints as linear relations  $\mathbf{F}_i \mathbf{W} = \mathbf{H}_i \mathbf{Y}_i \mod q$ . Second, the verifier samples a folding challenge  $\mathbf{c}$ , and the prover computes the folded witness  $\mathbf{W}\mathbf{c}$ , its decomposition  $\widetilde{\mathbf{w}}$ , and the packed vector  $\widehat{\mathbf{w}}$ . Third, the prover reshapes  $\widehat{\mathbf{w}}$  to width r', derives the output linear block  $\mathbf{F}\mathbf{U} = \mathbf{G}_{\ell''}\mathbf{Y} \mod q$ , and commits to  $\mathbf{vec}(\mathbf{Y})$ . All folded consistency constraints are then expressed as a single sumcheck relation by linearity (e.g.,  $\mathbf{F}_i(\mathbf{W}\mathbf{c}) = (\mathbf{F}_i\mathbf{W})\mathbf{c}$ ). Fourth, the prover also computes the self-inner product  $v = \langle \widehat{\mathbf{w}}, \overline{\widehat{\mathbf{w}}} \rangle$  of the folded witness  $\widehat{\mathbf{w}}$ . This establishes a norm claim and bound (via  $\mathbf{trace}(v) = \|\widehat{\mathbf{w}}\|_{\sigma,2}$ ). Finally, all claims are turned into sumcheck-based constraints by standard machinery, here denoted as sumcheckify. We provide an explicit description of this step in Section 6.1. Crucially, commitment verification for all  $(\mathbf{com}_i)_{i \in [k_{1:n}]}$  is part of the constraints, so that validity of the resulting claim in  $\Xi_{\mathsf{COM}}^{\mathsf{sum}}$  implies knowledge of valid (short) openings.
+
+This treatment of folding is similar to the one in [BS23, KLNO24b, KLNO25] and the extraction based on coordinate-wise rewinding [FMN24] exploits the linearity of the folding operation.
+
+<span id="page-25-1"></span>**Lemma 9.** Let  $\ell, \ell', \ell'' \in \mathbb{N}$  be gadget decomposition parameters, let r, r' be powers-of-2 split widths (old and new, respectively), and let  $\mathsf{par}_{\mathsf{com}}$ ,  $\mathsf{par}'_{\mathsf{com}}$  be parameters for COM so that  $\beta_{\mathsf{x}} = \beta_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]$  and  $\beta'_{\mathsf{x}} = \beta_{\mathsf{x}}[\mathsf{par}'_{\mathsf{com}}]$ . Suppose that  $\tilde{\beta_{\mathsf{w}}}^2 \geq \mathsf{dcmp}_{\ell'}(r\gamma_{\mathcal{C}}\beta_{\mathsf{w}})^2 + \sum_{i \in [k_{\mathrm{lin}}+1]} \beta_{\mathsf{y},i}^2 + \beta_{\mathsf{x},i}^2$ . Let  $k_i$  be the number of linear constraints necessary to express COM. Verify( $\mathsf{ck}$ ,  $\mathsf{com}_i$ ,  $\mathsf{vec}(\mathbf{Y}_i)$ ,  $\mathbf{x}_i$ ) for each  $i \in [k_{\mathrm{lin}}+1]$  and let  $k_{\mathsf{sc}} = \sum_{i \in [k_{\mathrm{lin}}+1]} k_i + \sum_{i \in [k_{\mathrm{lin}}+1]} n_i + n + k_{\mathrm{lr}} + 1$ . The protocol  $\Pi^{\mathsf{fold-split}}_{r',\ell,\ell',\ell'',\mathsf{par}_{\mathsf{com}},\mathsf{par}'_{\mathsf{com}},\tilde{\beta_{\mathsf{w}}}}$  (Fig. 4) satisfies the following properties:
+
+- It is perfectly complete for
+
+$$\begin{split} &\mathcal{\Xi}_{\mathsf{COM}}^{\mathsf{lin}}[k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n_i, \mathsf{par}_{\mathsf{com},i}, m_{\mathtt{y},i}, \beta_{\mathtt{x},i}, \beta_{\mathtt{y},i})_{i \in [k_{\mathtt{lin}}]}] \\ &\to \mathcal{\Xi}_{\mathsf{COM}}^{\mathsf{sum}}[k_{\mathtt{sc}}, n, \tilde{m}_{\mathtt{w}}/r', r', \mathsf{par}'_{\mathsf{com}}, \ell'' n, \tilde{\beta}_{\mathtt{w}}, \beta_{\mathtt{x}}, \mathsf{dcmp}_{\ell''}(q/2), 2] \end{split}$$
+
+ $\begin{aligned} \textit{where } \tilde{m_{\mathtt{w}}} &= \mathsf{minpowtwo}(\ell' m_{\mathtt{w}} + \sum_{i \in [k_{\mathtt{lin}} + 1]} (m_{\mathtt{y},i} \cdot r + m_{\mathtt{x}}[\mathsf{par}_{\mathtt{com},i}])), \ \textit{where } \mathsf{par}_{\mathtt{com},k_{\mathtt{lin}}} = \mathsf{par}_{\mathtt{com}} \ \textit{and} \\ m_{\mathtt{y},k_{\mathtt{lin}}} &= \ell'' n. \end{aligned}$ 
+
+- It is  $\kappa$ -knowledge-sound, with  $\kappa = r/|\mathcal{C}|$ , for
+
+$$\begin{split} &\mathcal{\Xi}^{\mathsf{sis}}[\mathsf{par}_{\mathtt{sis}}] \vee \mathcal{\Xi}^{\mathsf{lin-rel}}_{\mathsf{COM}}\left[k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m, r, 2\mathsf{cmp}_{\ell'}(\tilde{\beta_{\mathtt{w}}}'), (n_i, \mathsf{par}_{\mathtt{com},i}, m_{\mathtt{y},i}, \tilde{\beta_{\mathtt{w}}}', \tilde{\beta_{\mathtt{w}}}')_{i \in [k_{\mathtt{lin}}]}, 2\gamma_{\mathcal{C}} \quad \right] \\ &\leftarrow \quad \mathcal{\Xi}^{\mathsf{sum}}_{\mathsf{COM}}[k_{\mathtt{sc}}, n, \tilde{m_{\mathtt{w}}}/r', r', \mathsf{par}'_{\mathtt{com}}, \ell'' n, \beta_{\mathtt{w}}', \beta_{\mathtt{x}}, \mathsf{dcmp}_{\ell''}(q/2), 2], \end{split}$$
+
+{26}------------------------------------------------
+
+```
+P(stmt, wit)
+                                                                                                                                                                                                                                                V(stmt)
+                                          \mathbf{parse} \; \mathsf{stmt} = ((\mathsf{com}_i, \mathbf{F}_i, \mathbf{H}_i)_{i \in [k_{\mathtt{lin}}]}, (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [k_{\mathtt{lr}}]}, \mathbf{A}, \mathbf{b})
+\mathbf{parse} \ \mathsf{wit} = (\mathbf{W}, (\mathbf{Y}_i, \mathbf{x}_i)_{i \in [k_{\mathtt{lin}}]})
+                               /\!\!/ \quad (\mathsf{stmt}, \mathsf{wit}) \in \varXi_{\mathsf{COM}}^{\mathsf{lin}}[k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n_i, \mathsf{par}_{\mathsf{com}, i}, m_{\mathtt{y}, i}, \beta_{\mathtt{x}, i}, \beta_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}}]}] 
+\mathbf{F}_{k_{\mathtt{lin}}} \coloneqq \mathsf{matrix}\text{-}\mathsf{from}\text{-}\mathsf{rows}((\mathbf{l}_j)_{j \in [k_{\mathtt{lr}}]}), \quad n_{k_{\mathtt{lin}}} := k_{\mathtt{lr}}
+\mathbf{T}\coloneqq \mathbf{F}_{k_{\mathtt{lin}}}\mathbf{W} \bmod q
+\mathbf{Y}_{k_{\mathtt{lin}}}\coloneqq \mathbf{G}_{\ell}^{-1}(\mathbf{T})\in \mathcal{R}^{\ell k_{\mathtt{lr}}r}
+        /\!\!/ \mathbf{F}_{k_{\min}} \mathbf{W} = \mathbf{G} \mathbf{Y}_{k_{\min}} \bmod q
+(\mathsf{com}_{k_{\mathtt{lin}}}, \mathbf{x}_{k_{\mathtt{lin}}}) \coloneqq \mathsf{Com}_{\mathsf{par}_{\mathtt{com}}}(\mathsf{ck}, \mathsf{vec}(\mathbf{Y}_{k_{\mathtt{lin}}}))
+                                                                                                                                                                      \mathsf{com}_{k_{\mathtt{lin}}}
+\widetilde{\mathbf{w}}\coloneqq \mathbf{G}_{\ell'}^{-1}(\mathbf{W}\mathbf{c})
+                                                                                                                                                                                 \mathbf{c}
+                                                                                                                                                                                                                                                \mathbf{c} \leftarrow \!\!\!\! \$ \, \mathcal{C}^r
+\widehat{\mathbf{w}} \coloneqq \mathsf{pack}(\widetilde{\mathbf{w}}, (\mathsf{vec}(\mathbf{Y}_i), \mathbf{x}_i) : i \in [k_{\mathtt{lin}} + 1])
+v \leftarrow \langle \widehat{\mathbf{w}}, \overline{\widehat{\mathbf{w}}} \rangle
+\mathbf{U}\coloneqq \mathsf{reshape}_{r'}(\widehat{\mathbf{w}}) \in \mathcal{R}^{\tilde{m_{\tt w}}/r' \times r'}
+\mathbf{F}\coloneqq \mathbf{A}_{n,\tilde{m_{\mathtt{w}}}/r'} /\!\!/ from ck
+\mathbf{Y} \coloneqq \mathbf{G}_{\ell''}^{-1}(\mathbf{FU} \bmod q) \in \mathcal{R}^{\ell''n \times r'}
+                                                                                                                                                                                                                                                \mathsf{trace}(v) \overset{?}{\leq} \hat{\mathfrak{f}} \cdot {\tilde{\beta_{\mathtt{w}}}}^2
+                                                                                                                                                                        \mathsf{com}, v
+(\mathsf{com}, \mathbf{x}) \leftarrow \mathsf{Com}_{\mathsf{par}'_{\mathsf{com}}}(\mathsf{ck}, \mathsf{vec}(\mathbf{Y}))
+                                                                                        \frac{(\widetilde{\mathbf{w}} \mid \mathbf{Y}_i, \mathbf{x}_i : i \in [k_{\text{lin}}] \mid \mathbf{Y}_{k_{\text{lin}}}, \mathbf{x}_{k_{\text{lin}}}) :}{\mathbf{F}_i \cdot \mathbf{G}_{\ell'} \cdot \widetilde{\mathbf{w}} = \mathbf{H}_i \cdot \mathbf{Y}_i \cdot \mathbf{c} \bmod q}
+                                                                                                                                                                                                                                                       \forall i \in [k_{\tt lin}]
+                                                                                       \mathbf{F}_{k_{\mathtt{lin}}} \cdot \mathbf{G}_{\ell'} \cdot \widetilde{\mathbf{w}} = \mathbf{G}_{\ell} \cdot \mathbf{Y}_{k_{\mathtt{lin}}} \cdot \mathbf{c} \bmod q
+           f_{\tt sc} \leftarrow \text{sumcheckify} \mid \text{COM.Verify}(\text{ck}, \text{com}_i, \text{vec}(\mathbf{Y}_i), \mathbf{x}_i) = 1 \quad \forall i \in [k_{\tt lin} + 1]
+                                                                                                      (\mathbf{G} \cdot \mathbf{Y}_{k_{\min}})[j,:] \cdot \mathbf{r}_{j} = t_{j} \mod q\mathbf{A} \cdot (\operatorname{vec}(\mathbf{Y}_{i}))_{i \in [k_{\min}]} = \mathbf{b} \mod q\langle \widehat{\mathbf{w}}, \overline{\widehat{\mathbf{w}}} \rangle = v \mod q
+                                                                                                                                                                                                                                                         \forall j \in [k_{\mathtt{lr}}]
+\mathsf{wit}' \coloneqq (\mathbf{U}, \mathbf{Y}, \mathbf{x})
+k_i := \# \mathsf{constraints}(\mathsf{par}_{\mathtt{com},i})
+k_{\textsf{sc}} := \sum_{i \in [k_{\textsf{lin}} + 1]} k_i + \sum_{i \in [k_{\textsf{lin}} + 1]} n_i + n + k_{\textsf{lr}} + 1
+                                                                                                      \mathsf{stmt}' \coloneqq (\mathsf{com}, \mathbf{F}, \mathbf{G}_{\ell''}, f_{\mathsf{sc}})
+                                    /\!\!/ \quad (\mathsf{stmt}', \mathsf{wit}') \in \varXi_{\mathsf{COM}}^{\mathsf{sum}} \left[ k_{\mathsf{sc}}, n, \tilde{m_{\mathtt{w}}} / r', r', \mathsf{par}'_{\mathsf{com}}, \ell'' n, \tilde{\beta_{\mathtt{w}}}, \beta_{\mathtt{x}}, \mathsf{dcmp}_{\ell''}(q/2), 2 \right] 
+\mathbf{return}\ (\mathsf{stmt}',\mathsf{wit}')
+                                                                                                                                                                                                                                                return stmt
+```
+
+<span id="page-26-0"></span>Fig. 4.  $\Pi_{r',\ell,\ell',\ell'',n,\mathsf{par}_{\mathsf{com}},\mathsf{par}'_{\mathsf{com}},\tilde{\beta_{\mathtt{w}}}}^{\mathsf{fold-split}}$ : The commit-fold RoK from  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  to  $\Xi_{\mathsf{COM}}^{\mathsf{sum}}$ .
+
+{27}------------------------------------------------
+
+where
+
+$$\mathsf{par}_{\mathtt{sis}} \supseteq \bigcup_{i \in [k_{\mathtt{lin}}+1]} \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},i}, m_{\mathtt{y},i}, \tilde{\beta_{\mathtt{w}}}', \tilde{\beta_{\mathtt{w}}}']$$
+
+ $\label{eq:where beta problem} \text{where } \tilde{\beta_{\mathtt{w}}'}^2 = \tilde{\beta_{\mathtt{w}}}^2 \cdot \hat{\mathfrak{f}} \cdot \mathsf{rad}(\mathfrak{f})/\mathfrak{f} \text{ if } r' \cdot \beta_{\mathtt{w}}'^2 \hat{\mathfrak{f}} < q/2.$ 
+
+- It has the following efficiency measures:
+  - Prover runtime:  $O(\ell m_{\mathbf{w}} r) \mathcal{R}_q$  operations and the com computation.
+  - Verifier runtime: O(1)  $\mathcal{R}_q$  operations and the cost of sampling r challenges from  $\mathcal{C}$ .
+  - Prover-to-verifier communication:  $|com_{k_{lin}}| + |com| + O(\log |\mathcal{R}_q|)$ .
+
+Proof.
+
+## Completeness:
+
+Let
+
+$$\mathsf{stmt} = ((\mathsf{com}_i, \mathbf{F}_i, \mathbf{H}_i)_{i \in [k_{\text{lin}}]}, (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [k_{\text{lr}}]}, \mathbf{A}, \mathbf{b}), \quad \mathsf{wit} = (\mathbf{W}, (\mathbf{Y}_i, \mathbf{x}_i)_{i \in [k_{\text{lin}}]})$$
+
+be such that  $(\mathsf{stmt}, \mathsf{wit}) \in \mathcal{Z}^{\mathsf{lin}}_{\mathsf{COM}}$ . The protocol outputs
+
+$$\mathsf{stmt}' = (\mathsf{com}, \mathbf{F}, \mathbf{G}_{\ell''}, f_{\mathsf{sc}}), \quad \mathsf{wit}' = (\mathbf{U}, \mathbf{Y}, \mathbf{x}),$$
+
+and we show
+
+$$(\mathsf{stmt}',\mathsf{wit}') \in \varXi^{\mathsf{sum}}_{\mathsf{COM}}[k_{\mathtt{sc}},n,\tilde{m}_{\mathtt{w}}/r',r',\mathsf{par}'_{\mathtt{com}},\ell''n,\tilde{\beta}_{\mathtt{w}},\beta_{\mathtt{x}},\mathsf{dcmp}_{\ell''}(q/2),2].$$
+
+First,  $\mathbf{F}_{k_{\text{lin}}}$  is defined from the left-constraint vectors (more precisely, by  $\mathbf{l}$  constraints from the bilinear constraints from the input relation  $\Xi_{\text{COM}}^{\text{lin}}$ ) and
+
+$$\mathbf{T} = \mathbf{F}_{k_{\text{lin}}} \mathbf{W} \mod q, \qquad \mathbf{Y}_{k_{\text{lin}}} = \mathbf{G}_{\ell}^{-1}(\mathbf{T}),$$
+
+hence  $\mathbf{F}_{k_{\text{lin}}}\mathbf{W} = \mathbf{G}_{\ell}\mathbf{Y}_{k_{\text{lin}}} \mod q$ . Let  $\widetilde{\mathbf{w}} = \mathbf{G}_{\ell'}^{-1}(\mathbf{W}\mathbf{c})$  and  $\widehat{\mathbf{w}} = \mathsf{pack}(\widetilde{\mathbf{w}}, (\mathsf{vec}(\mathbf{Y}_i), \mathbf{x}_i) : i \in [k_{\text{lin}} + 1])$ . By assumption on  $\widetilde{\beta}_{\mathbf{w}}$ ,
+
+$$\|\widehat{\mathbf{w}}\|_2^2 \leq \mathsf{dcmp}_{\ell'}(r\gamma_{\mathcal{C}}\beta_{\mathtt{w}})^2 + \sum_{i \in [k_{\mathrm{lin}}+1]} \beta_{\mathtt{y},i}^2 + \beta_{\mathtt{x},i}^2 \leq \widetilde{\beta_{\mathtt{w}}}^2.$$
+
+Next, the protocol computes the output linear block:
+
+$$\mathbf{U} = \mathsf{reshape}_{r'}(\widehat{\mathbf{w}}), \quad \mathbf{F} = \mathbf{A}_{n, \tilde{m}_{\mathbf{w}}/r'}, \quad \mathbf{Y} = \mathbf{G}_{\ell''}^{-1}(\mathbf{F}\mathbf{U} \bmod q),$$
+
+SO
+
+$$\mathbf{F}\mathbf{U} = \mathbf{G}_{\ell''}\mathbf{Y} \bmod q.$$
+
+By our matrix norm convention (maximum column norm), this also gives
+
+$$\|\mathbf{U}\|_{2} \leq \|\text{vec}(\mathbf{U})\|_{2} = \|\widehat{\mathbf{w}}\|_{2}.$$
+
+Further,  $(com, \mathbf{x})$  is computed by  $Com_{par'_{com}}$  on the output committed message, so the output commitment verification constraint holds by perfect correctness of COM.
+
+Let  $v = \langle \widehat{\mathbf{w}}, \overline{\widehat{\mathbf{w}}} \rangle$ . As in the standard cyclotomic trace identity,
+
+$$\operatorname{trace}(v) = \|\widehat{\mathbf{w}}\|_{\sigma,2}^2 \le \widehat{\mathfrak{f}} \, \widetilde{\beta_{\mathtt{w}}}^2,$$
+
+therefore the verifier norm check on v is satisfied.
+
+It remains to check  $f_{sc}$ . Every constraint used by sumcheckify is true by construction:
+
+{28}------------------------------------------------
+
+- $-\mathbf{F}_i\mathbf{G}_{\ell'}\widetilde{\mathbf{w}} = \mathbf{H}_i\mathbf{Y}_i\mathbf{c} \mod q$  for all  $i \in [k_{lin}]$ , from the input linear constraints and linearity of folding;
+- $-\mathbf{F}_{k_{\text{lin}}}\mathbf{G}_{\ell'}\widetilde{\mathbf{w}} = \mathbf{G}_{\ell}\mathbf{Y}_{k_{\text{lin}}}\mathbf{c} \bmod q, \text{ by definition of } \mathbf{Y}_{k_{\text{lin}}};$
+- COM.Verify(ck, com<sub>i</sub>, vec( $\mathbf{Y}_i$ ),  $\mathbf{x}_i$ ) = 1 for all  $i \in [k_{lin} + 1]$ , from input validity and construction of (com<sub> $k_{lin}$ </sub>,  $\mathbf{x}_{k_{lin}}$ );
+- $-(\mathbf{GY}_{k_{\text{lin}}})[j,:]\cdot\mathbf{r}_j=t_j \mod q \text{ for all } j\in[k_{\text{lr}}], \text{ from the right-constraints in the input relation;}$
+- $-\mathbf{A} \cdot (\text{vec}(\mathbf{Y}_i))_{i \in [k_{\text{lin}}]} = \mathbf{b} \mod q$ , from the global linear constraints in the input relation;
+- $-\langle \widehat{\mathbf{w}}, \overline{\widehat{\mathbf{w}}} \rangle = v \mod q$ , by definition of v.
+
+Hence all encoded sumcheck claims are valid, and  $\Pi^{\mathsf{fold-split}}$  is perfectly correct.
+
+## Knowledge-soundness:
+
+Let  $\mathcal{A}$  convince the verifier in  $\Pi^{\mathsf{fold-split}}$  with probability at least  $\epsilon$ . By the coordinate-wise rewinding extractor [FMN24, Lemma 7.1], we obtain r+1 accepting transcripts for challenges  $\mathbf{c}^{(0)}, \ldots, \mathbf{c}^{(r)}$ , where for every  $j \in [r]$ ,  $\mathbf{c}^{(j)}$  and  $\mathbf{c}^{(r)}$  differ only in coordinate j. Let
+
+$$\mathsf{wit}^{*(j)} = (\mathbf{U}^{*(j)}, \mathbf{Y}^{*(j)}, \mathbf{x}^{*(j)})$$
+
+be the extracted witness for transcript j. Since wit<sup>\*(j)</sup> is an accepting source witness with bound parameter  $\beta'_{\mathbf{w}}$ , we have
+
+$$\|\mathbf{U}^{*(j)}\|_2 \le \beta_{\mathbf{w}}'.$$
+
+Write
+
+$$\widehat{\mathbf{w}}^{*(j)} = \text{vec}(\mathbf{U}^{*(j)}).$$
+
+Then
+
+$$\|\widehat{\mathbf{w}}^{*(j)}\|_{2} \le \sqrt{r'} \|\mathbf{U}^{*(j)}\|_{2} \le \sqrt{r'} \beta_{\mathbf{w}}'.$$
+
+We then parse  $\widehat{\mathbf{w}}^{*(j)}$  according to the fixed packing layout into  $\widetilde{\mathbf{w}}^{*(j)}$  and  $(\mathbf{Y}_i^{*(j)}, \mathbf{x}_i^{*(j)})_{i \in [k_{\text{lin}}+1]}$ .
+
+1. Norm bound. For each j, the sumcheck constraints give
+
+$$\langle \widehat{\mathbf{w}}^{*(j)}, \overline{\widehat{\mathbf{w}}^{*(j)}} \rangle = v^{*(j)} \bmod q.$$
+
+Together with the verifier check on  $\operatorname{trace}(v^{*(j)})$  and the condition  $r' \cdot \beta_{\mathtt{w}}'^2 \hat{\mathfrak{f}} < q/2$ , this equality lifts to integers and yields
+
+$$\|\widehat{\mathbf{w}}^{*(j)}\|_{\sigma,2}^2 \leq \widehat{\mathfrak{f}} \, \widetilde{\beta_{\mathtt{w}}}^2 \quad \Longrightarrow \quad \|\widehat{\mathbf{w}}^{*(j)}\|_2^2 \leq \widetilde{\beta_{\mathtt{w}}}'^2 = \widetilde{\beta_{\mathtt{w}}}^2 \cdot \frac{\widehat{\mathfrak{f}} \operatorname{rad}(\mathfrak{f})}{\mathfrak{f}}.$$
+
+2. SIS from commitment breaks. If there exists  $i \in [k_{lin} + 1]$  and  $j \in [r]$  with  $\mathbf{Y}_i^{*(j)} \neq \mathbf{Y}_i^{*(r)}$ , then both openings verify for the same  $\mathsf{com}_i$  (by accepted transcripts), so we output
+
+$$(\text{vec}(\mathbf{Y}_{i}^{*(j)}), \mathbf{x}_{i}^{*(j)}), (\text{vec}(\mathbf{Y}_{i}^{*(r)}), \mathbf{x}_{i}^{*(r)})$$
+
+which satisfies  $\Xi^{sis}[par_{sis}]$  relation for extraction, where  $par_{sis} \supseteq par_{break}[par_{com,i}, m_{y,i}, \tilde{\beta_w}', \tilde{\beta_w}']$ , which is a valid extraction due to Lemma 4. Henceforth assume  $\mathbf{Y}_i^{*(j)} = \mathbf{Y}_i^{*(r)} =: \mathbf{Y}_i^*$  and  $\mathbf{x}_i^{*(j)} = \mathbf{x}_i^{*(r)} =: \mathbf{x}_i^*$  for all i, j.
+
+{29}------------------------------------------------
+
+3. Unfolding by coordinate differences. For each j, define
+
+$$\mathbf{v}^{*(j)} := \mathbf{G}_{\ell'} \widetilde{\mathbf{w}}^{*(j)}.$$
+
+From the sumcheck constraints, for all  $i \in [k_{lin} + 1]$ ,
+
+$$\mathbf{F}_i \mathbf{v}^{*(j)} = \mathbf{H}_i \mathbf{Y}_i^* \mathbf{c}^{(j)} \mod q, \qquad \mathbf{F}_i \mathbf{v}^{*(r)} = \mathbf{H}_i \mathbf{Y}_i^* \mathbf{c}^{(r)} \mod q.$$
+
+Subtracting and using  $s_j := c_j^{(j)} - c_j^{(r)} \neq 0$ , let
+
+$$\mathbf{u}^{(j)} := \frac{\mathbf{v}^{*(j)} - \mathbf{v}^{*(r)}}{s_j}.$$
+
+If  $\mathbf{y}_{i,j}^*$  denotes column j of  $\mathbf{H}_i \mathbf{Y}_i^*$ , then
+
+$$\mathbf{F}_i \mathbf{u}^{(j)} = \mathbf{y}_{i,j}^* \mod q \qquad \forall i \in [k_{\text{lin}} + 1], \ j \in [r].$$
+
+Therefore, with
+
+$$\mathbf{U} := (\mathbf{u}^{(j)})_{j \in [r]}, \qquad \mathbf{s} := (s_j)_{j \in [r]},$$
+
+we get
+
+$$\mathbf{F}_i \mathbf{U} = \mathbf{H}_i \mathbf{Y}_i^* \mod q \qquad \forall i \in [k_{\mathtt{lin}} + 1].$$
+
+Moreover,
+
+$$\|\mathbf{U}\mathsf{diag}(\mathbf{s})\|_2 \leq 2\,\mathsf{cmp}_{\ell'}(\tilde{\beta_{\mathtt{w}}}'), \qquad \|\mathsf{diag}(\mathbf{s})\|_{\mathtt{op},2} \leq 2\gamma_{\mathcal{C}}.$$
+
+<span id="page-29-0"></span>4. Remaining constraints. Let  $\mathbf{T}^* := \mathbf{G} \mathbf{Y}_{k_{\text{lin}}}^*$ . The sumcheck constraints give
+
+$$\mathbf{T}^*[j,:] \cdot \mathbf{r}_j = t_j \mod q \qquad \forall j \in [k_{1r}].$$
+
+Since  $\mathbf{F}_{k_{\text{lin}}}$  is built from rows  $(\mathbf{l}_j)$  and  $\mathbf{F}_{k_{\text{lin}}}\mathbf{U} = \mathbf{T}^*$ , we conclude
+
+$$\mathbf{l}_j^{\mathsf{T}}\mathbf{U}\mathbf{r}_j = t_j \bmod q \qquad \forall j \in [k_{\mathtt{lr}}].$$
+
+The constraints
+
+$$\mathbf{A} \cdot (\mathsf{vec}(\mathbf{Y}_i^*))_{i \in [k_{\text{lin}}]} = \mathbf{b} \bmod q$$
+
+and COM.Verify(ck, com<sub>i</sub>, vec( $\mathbf{Y}_i^*$ ),  $\mathbf{x}_i^*$ ) = 1 for  $i \in [k_{lin}]$  follow directly from accepted sumcheck claims.
+
+Hence the extractor outputs
+
+$$((\mathbf{U},\mathbf{s}),(\mathbf{Y}_i^*,\mathbf{x}_i^*)_{i\in[k_{\mathtt{lin}}]})$$
+
+satisfying the  $\Xi_{\text{COM}}^{\text{lin-rel}}$  branch with the parameters from the lemma statement, unless it already output a SIS witness via a commitment break. By [FMN24, Lemma 7.1], success probability is at least  $\epsilon - \frac{r}{|\mathcal{C}|}$ .
+
+#### Extractor runtime:
+
+Again by [FMN24, Lemma 7.1], the extractor uses O(r) prover invocations.
+
+## Efficiency:
+
+The dominant prover costs are computing  $\mathbf{T} = \mathbf{F}_{k_{\text{lin}}} \mathbf{W}$ , the decomposition/folding maps, and the two commitments  $\mathsf{com}_{k_{\text{lin}}}, \mathsf{com}$ . The verifier cost is dominated by sampling  $\mathbf{c} \in \mathcal{C}^r$  and checking  $\mathsf{trace}(v)$ . Communication is dominated by sending  $\mathsf{com}_{k_{\text{lin}}}, \mathsf{com}$ , and v.
+
+{30}------------------------------------------------
+
+```
+ \begin{split} & \frac{\text{sumcheckify}: \mathcal{R}^m \times \mathcal{R}^m \times (\mathcal{R}_q^{2m+3})^{k_{\text{sc}}} \to ((\mathcal{R}_q[\mathsf{y}_0, \dots, \mathsf{y}_{\mu-1}]^{\leq 2})[\mathsf{x}_0, \mathsf{x}_1]^{\leq 1})^{k_{\text{sc}}}}{\mathbf{parse input}:= (\mathbf{v}, \mathbf{w}, (a_{i,1}, b_{i,1}, \mathbf{a}_{i,0}, \mathbf{b}_{i,0}, c_i)_{i \in [k_{\text{sc}}]})}{\mathbf{for} \ i \in [k_{\text{sc}}]:} \\ & f_{\text{sc}}^{(i)}(\mathsf{x}_0, \mathsf{x}_1) := (a_{i,1} \cdot \mathsf{x}_0 + \mathsf{MLE}[\mathbf{a}_{i,0}]) \cdot (b_{i,1} \cdot \mathsf{x}_1 + \mathsf{MLE}[\mathbf{b}_{i,0}]) - \frac{c_i}{m} \\ & \mathbf{return} \ (f_{\text{sc}}^{(0)}, \dots, f_{\text{sc}}^{(k_{\text{sc}}-1)}) \end{split}
+```
+
+<span id="page-30-3"></span>Fig. 5. The sumcheckify algorithm. Here,  $m=2^{\mu}$  is the length of the vectors  ${\bf v}$  and  ${\bf w}$ .
+
+Remark 3. We note the protocol  $\Pi^{\mathsf{fold-split}}$  can be improved when  $\mathcal{R}$  is a power-of-two cyclotomic ring. In the modified variant, instead of inspecting  $\mathsf{trace}(v) \leq \hat{\mathfrak{f}} \cdot \tilde{\beta_{\mathtt{w}}}^2$ , the verifier checks that  $\mathsf{ct}(v) \leq \tilde{\beta_{\mathtt{w}}}^2$ , since the square of the 2-norm in the coefficient embedding is equal to the constant term of the inner product in that case. The knowledge-soundness proof follows similarly, with the extractor relying on the relaxed bound  $r' \cdot \beta_{\mathtt{w}}'^2 \leq q/2$ , instead of  $r' \cdot \beta_{\mathtt{w}}'^2 \hat{\mathfrak{f}} \leq q/2$ . The factor of  $\hat{\mathfrak{f}}$  is avoided together with the translations between the coefficient and canonical embeddings. Further, the  $\beta_{\mathtt{w}}'$  parameter in the extractability statement can be simplified to  $\tilde{\beta_{\mathtt{w}}}' = \tilde{\beta_{\mathtt{w}}}$ .
+
+#### <span id="page-30-0"></span>6.1 Inner Product Relations → Sumcheck Claims
+
+In this subsection we provide an efficient deterministic algorithm, called sumcheckify, which takes as input two vectors  $\mathbf{v}, \mathbf{w} \in \mathcal{R}^m$ , together with  $k \geq 1$  inner product relations, and outputs a list of k bilinear polynomials  $f_{\mathtt{sc}}^{(i)} \in (\mathcal{R}_q[\mathsf{y}_0,\ldots,\mathsf{y}_{\log m-1}]^{\leq 2})[\mathsf{x}_0,\mathsf{x}_1]^{\leq 1}$  for  $i \in [k_{\mathtt{sc}}]^{12}$ . Informally, the sumcheckify algorithm will translate inner product statements into sumcheck-type relations, for which we can use the sumcheck protocol to prove it.
+
+For simplicity, assume  $m = 2^{\mu}$  is a power-of-two – it will always be the case in our protocols, as both vectors  $\mathbf{v}$  and  $\mathbf{w}$  will be an output of the packing function (cf. Lemma 3). We represent the i-th inner product constraint, for  $i \in [k_{sc}]$ , with a tuple  $(a_{i,1}, b_{i,1}, \mathbf{a}_{i,0}, \mathbf{b}_{i,0}, c_i)$ , which corresponds to:
+
+<span id="page-30-2"></span>
+$$\langle a_{i,1} \cdot \mathbf{v} + \mathbf{a}_{i,0}, b_{i,1} \cdot \mathbf{w} + \mathbf{b}_{i,0} \rangle = c_i \bmod q \tag{4}$$
+
+where  $\mathbf{a}_{i,0}, \mathbf{b}_{i,0} \in \mathcal{R}_q^m, a_{i,1}, b_{i,1}, c_i \in \mathcal{R}_q$ . The most important property of the output polynomials  $f_{sc}^{(i)}$  is that vectors  $\mathbf{v}, \mathbf{w} \in \mathcal{R}^m$  satisfy the relation in (4) if and only if
+
+$$\sum_{\mathbf{z} \in \{0,1\}^{\mu}} F^{(i)}(\mathbf{z}) = 0 \bmod q, \quad \text{where} \quad F^{(i)} := f_{\mathtt{sc}}^{(i)}\left(\mathsf{MLE}[\mathbf{v}], \mathsf{MLE}[\mathbf{w}]\right).$$
+
+We provide a formal definition of sumcheckify in Figure 5 and show its correctness below.
+
+**Lemma 10.** Given input :=  $(\mathbf{v}, \mathbf{w}, (a_{i,1}, b_{i,1}, \mathbf{a}_{i,0}, \mathbf{b}_{i,0}, c_i)_{i \in [k_{sc}]}) \in \mathcal{R}^m \times \mathcal{R}^m \times (\mathcal{R}_q^{2m+3})^{k_{sc}}$ , the list of polynomials  $(f_{sc}^{(i)})_{i \in [k_{sc}]} \leftarrow \text{sumcheckify(input)}$  satisfies
+
+$$\sum_{\mathbf{z} \in \{0,1\}^{\mu}} (f_{\mathtt{sc}}^{(i)}(\mathsf{MLE}[\mathbf{v}], \mathsf{MLE}[\mathbf{w}]))(\mathbf{z}) = 0 \bmod q \iff \langle a_{i,1} \cdot \mathbf{v} + \mathbf{a}_{i,0}, b_{i,1} \cdot \mathbf{w} + \mathbf{b}_{i,0} \rangle = c_i \bmod q$$
+
+for all  $i \in [k_{sc}]$ .
+
+<span id="page-30-1"></span>In other words, coefficients of the bilinear polynomial  $f^{(i)}$  are multilinear polynomials in  $\mathcal{R}_q[\mathsf{y}_0,\ldots,\mathsf{y}_{\log m-1}]^{\leq 2}$ .
+
+{31}------------------------------------------------
+
+*Proof.* Fix  $i \in [k_{sc}]$  and consider the *i*-th constraint, as described in (4). Using the fact that for  $j \in [m]$ , the *j*-th coefficient of the vector  $\mathbf{v}$  is equal to  $\mathsf{MLE}[\mathbf{v}](\mathsf{bin}(j))$  (and similarly for  $\mathbf{w}, \mathbf{a}_{i,0}, \mathbf{b}_{i,0})$ , we note that the inner product is equivalent to:
+
+$$\sum_{\mathbf{z} \in \{0,1\}^{\mu}} (a_{i,1} \cdot \mathsf{MLE}[\mathbf{v}](\mathbf{z}) + \mathsf{MLE}[\mathbf{a}_{i,0}](\mathbf{z})) \cdot (b_{i,1} \cdot \mathsf{MLE}[\mathbf{w}](\mathbf{z}) + \mathsf{MLE}[\mathbf{b}_{i,0}](\mathbf{z})) = c_i \bmod q.$$
+
+Hence, by defining
+
+$$f_{\mathtt{sc}}^{(i)}(\mathsf{x}_0,\mathsf{x}_1) := (a_{i,1} \cdot \mathsf{x}_0 + \mathsf{MLE}[\mathbf{a}_{i,0}])(b_{i,1} \cdot \mathsf{x}_1 + \mathsf{MLE}[\mathbf{b}_{i,0}]) - \frac{c_i}{m},$$
+
+the equation above can be written equivalently as
+
+$$\sum_{\mathbf{z} \in \{0,1\}^{\mu}} (f_{\mathtt{sc}}^{(i)}\left(\mathsf{MLE}[\mathbf{v}], \mathsf{MLE}[\mathbf{w}]\right))(\mathbf{z}) = 0 \bmod q.$$
+
+Moreover, coefficients of  $f_{sc}^{(i)}$  indeed lie in  $\mathcal{R}_q[\mathsf{y}_0,\ldots,\mathsf{y}_{\mu-1}]^{\leq 1}$  by definition of a multilinear extension, which concludes the proof.
+
+Connection to committed folding RoK. Observe that all constraints passed to sumcheckify in Figure 4 take the form of inner product relations as in (4), instantiated with  $\mathbf{w} := \widehat{\mathbf{w}}$  and  $\mathbf{v} := \overline{\widehat{\mathbf{w}}}$  (and also  $a_{i,1} = 0$  for every constraint except the final one). Hence, we can make use of the fact that
+
+$$\mathsf{MLE}[\overline{\widehat{\mathbf{w}}}] = \overline{\mathsf{MLE}[\widehat{\mathbf{w}}]}$$
+
+so evaluating the multilinear extension of  $\mathbf{v}$  reduces to evaluating the multilinear extension of  $\mathbf{w}$ .
+
+Importantly, the sumcheckify procedure is oblivious to the cost of evaluating  $\mathsf{MLE}[\mathbf{a}_{i,0}]$  and  $\mathsf{MLE}[\mathbf{b}_{i,0}]$ , since it does not exploit any structural properties of the inner product vectors  $\mathbf{a}_{i,0}$ ,  $\mathbf{b}_{i,0}$ . In contrast, the constraints in Figure 4 are either sparse with small Hamming weight—because only specific components of  $\widehat{\mathbf{w}}$  participate in each inner product—or exhibit strong tensor structure (e.g., those derived from vSIS commitment matrices). In Section 8.2, we demonstrate how to leverage these properties to evaluate the sumcheckify constraints efficiently, thereby achieving succinct verification.
+
+# <span id="page-31-0"></span>7 Linearisation with Sumcheck
+
+Basic sumcheck. We recall the standard sumcheck protocol in Section B with a small modification: We include a linear map  $\Phi$  into the claim. In a nutshell, we show that sumcheck reduces a summation claim  $\Phi(\sum_{\mathbf{z}} g(\mathbf{z})) = y$  to an evaluation claim  $\Phi(g(\mathbf{c})) = v$ . We write such statements as  $(\Phi, g, v)$  and  $(\Phi, g, \mathbf{c}, v)$ , respectively. We define languages  $\Xi^{\mathsf{sc}}$  and  $\Xi^{\mathsf{polyeval}}$  for the above sumcheck and poly evaluation claims, parameterised by the (domain of) the linear map  $\Phi$ , variables, challenge, and summation domains. We concretely instantiate  $\Phi$  as a map with two steps First, it applies an isomorphism  $\theta_a \colon \mathcal{R}_q \to (\mathbb{F}_{q^a})^{\varphi/a}$ . Then, it applies a random  $\mathbb{F}_{q^a}$ -linear map  $\delta^{\mathsf{T}} \cdot \mathbb{F}_q$  to batch the  $(\mathbb{F}_{q^a})^{\varphi/a}$  slots together.
+
+To define  $\theta_a$ , we use the NTT isomorphism NTT:  $\mathcal{R}_q \to \mathbb{F}_{q^e}^{\varphi/e}$  defined in Section 3.1.For any  $a \mid e$ , we view the field  $\mathbb{F}_{q^e}$  as an  $\mathbb{F}_{q^a}$ -vector space of dimension e/a. This induces an isomorphism of  $\mathbb{F}_{q^a}$ -vector spaces  $\mathcal{R}_q \cong (\mathbb{F}_{q^a})^{\varphi/a}$ . i.e. an  $\mathbb{F}_{q^a}$ -linear map (that is *not* a ring isomorphism unless a = e). We denote this isomorphism by  $\theta_a \colon \mathcal{R}_q \to (\mathbb{F}_{q^a})^{\varphi/a}$ ; If a equals the residue degree of q
+
+{32}------------------------------------------------
+
+```
+P(stmt, wit)
+                                                                                                                                                                                                                                                                        V(stmt)
+                                                                                                 \mathbf{parse} \; \mathsf{stmt} = (\mathsf{com}, \mathbf{F}, \mathbf{H}, (f_{\mathtt{sc}}^{(i)})_{i \in [k_{\mathtt{sc}}]})
+                                                                                   /\!\!/ \quad (\mathsf{stmt}, \mathsf{wit}) \in \varXi_{\mathsf{COM}}^{\mathsf{sum}}[k_{\mathtt{sc}}, n, m_{\mathtt{w}}, r, \mathsf{par}_{\mathtt{com}}, m_{\mathtt{y}}, \beta_{\mathtt{w}}, \beta_{\mathtt{x}}, \beta_{\mathtt{y}}, \delta_{\mathtt{sc}}] 
+                                                                          // We assume m_{\mathtt{w}}=2^{\mu},\,r=2^{\rho},\,k_{\mathtt{sc}}=2^{\log(k_{\mathtt{sc}})} are powers-of-2.
+\mathbf{parse} \; \mathsf{wit} = (\mathbf{W}, \mathbf{Y}, \mathbf{x}) \in (\mathcal{R}_q^{m_\mathtt{W} \times r}, \mathcal{R}_q^{n \times r}, \mathcal{R}_q^{m_\mathtt{x}[\mathsf{par}_{\mathtt{com}}]})
+                                                                                                                                                                                                            \boldsymbol{\delta} \boldsymbol{\delta} \leftarrow \mathbb{F}_{q^a}^{\varphi/a}
+\mathbf{w} := \mathsf{vec}(\mathbf{W})
+                                                                           f_{\tt sc}(\mathsf{x}_0,\mathsf{x}_1)(\mathsf{z}) \coloneqq \sum_{i \in [k_{\tt sc}]} \mathsf{eq}(\mathsf{bin}(i), \boldsymbol{\gamma}) \cdot f_{\tt sc}^{(i)}(\mathsf{x}_0,\mathsf{x}_1)(\mathsf{z})
+                                                                                                                    g_{sc}(\mathbf{z}) \coloneqq f_{sc}(\mathsf{MLE}[\mathbf{w}], \mathsf{MLE}[\overline{\mathbf{w}}])(\mathbf{z})
+                                                                                    \varPhi(\,\cdot\,) := \boldsymbol{\delta}^{\mathtt{T}} \circ \theta_a \hspace{0.5cm} /\!\!/ \hspace{0.5cm} \varPhi \colon \mathcal{R}_q \to \mathbb{F}_{q^a} \text{ is random } \mathbb{F}_{q^a}\text{-linear map}
+                           Run \Pi^{\mathsf{basic\text{-}sc}} for sumcheck claim \Phi(\sum_{\mathbf{z}} g_{\mathsf{sc}}(\mathbf{z})) = 0, i.e. (\Phi, g_{\mathsf{sc}}, 0) \in \Xi_{\mathcal{R}_q, \mathbb{F}_{q^a}, \dim(\mathbf{z})}^{\mathsf{sc}}
+                                  to reduce to evaluation claim \Phi(g_{sc}(\mathbf{c})) = v, i.e. (\Phi, g_{sc}, \mathbf{c}, v) \in \Xi_{\mathcal{R}_q, \mathbb{F}_{q^a}, \dim(\mathbf{z})}^{\mathsf{polyeval}}
+(\mathbf{c}_0^{\mathtt{T}}, \mathbf{c}_1^{\mathtt{T}}) \in \mathbb{F}_{q^a}^{\rho} \times \mathbb{F}_{q^a}^{\mu} \subseteq \mathcal{R}_q^{\rho} \times \mathcal{R}_q^{\mu}
+z_0 := \mathsf{MLE}[\mathbf{w}](\mathbf{c}_0, \mathbf{c}_1) = \mathsf{tensor}(\mathbf{c}_1)^{\mathtt{T}} \cdot \mathbf{W} \cdot \mathsf{tensor}(\mathbf{c}_0) \in \mathcal{R}_q
+z_1 \coloneqq \mathsf{MLE}[\mathbf{w}](\overline{\mathbf{c}_0}, \overline{\mathbf{c}_1}) = \mathsf{tensor}(\overline{\mathbf{c}_1})^{\mathtt{T}} \cdot \mathbf{W} \cdot \mathsf{tensor}(\overline{\mathbf{c}_0}) \in \mathcal{R}_q
+\mathsf{wit}' \coloneqq (\mathbf{W}, (\mathbf{Y}, \mathbf{x}))
+                                                                                                                                                                                                                                                                    f_{\mathtt{sc}}(z_0,\overline{z_1})(\mathbf{c}) \stackrel{?}{=} v
+                                                                                                                                                                                                           z_0, z_1
+\mathbf{l}_0 = \mathsf{tensor}(\mathbf{c}_1), \mathbf{r}_0 = \mathsf{tensor}(\mathbf{c}_0), t_0 = z_0
+\mathbf{l}_1 = \mathsf{tensor}(\overline{\mathbf{c}_1}), \mathbf{r}_1 = \mathsf{tensor}(\overline{\mathbf{c}_0}), t_1 = z_1
+                                                                                             \mathsf{stmt}' \coloneqq ((\mathsf{com}, \mathbf{F}, \mathbf{H}), (\mathbf{l}_i, \mathbf{r}_i, t_i)_{i \in [2]}, \mathbf{0}, \mathbf{0})
+                                                                                /\!\!/ \quad (\mathsf{stmt}', \mathsf{wit}') \in \Xi_{\mathsf{COM}}^{\mathsf{lin}}[1, 2, 0, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n, \mathsf{par}_{\mathsf{com}}, m_{\mathtt{y}}, \beta_{\mathtt{x}}, \beta_{\mathtt{y}})]
+return (stmt', wit')
+                                                                                                                                                                                                                                                                        return stmt'
+```
+
+<span id="page-32-0"></span>**Fig. 6.**  $\Pi_{\theta_a}^{\text{lin}}$ : The linearisation RoK for  $\Xi_{\text{COM}}^{\text{sum}}$ .
+
+in  $\mathcal{R}$ , then  $\theta_a$  coincides with an NTT transformation. We combine this representation with batch verification in the  $\Pi^{\text{lin}}$  protocol below. That is,  $\Phi \colon \mathcal{R}_q = \mathbb{F}_{q^a}^{\varphi/a} \to \mathbb{F}_{q^a}$  batches claims  $(\mathbb{F}_{q^a})^{\varphi/a} \to \mathbb{F}_{q^a}$ , and  $\Phi$  is  $\mathbb{F}_{q^a}$ -linear. Thus, only a polynomial element over  $\mathbb{F}_{q^a}$  (instead of  $\mathcal{R}_q$ ) is sent per round, improving communication and computation. We use  $\mathbb{F}_{q^a} \subseteq \mathcal{R}_q$  as challenge space.
+
+Remark 4 (Sumcheck as reduction of knowledge). We treat sumcheck as a reduction of knowledge, although the witness for the statements is trivial. Moreover, we consider sumcheck a special type of "delayed-statement" reduction of knowledge. Namely, the verifier reduces a summation claim  $(\Phi, g, y)$  to an evaluation claim  $(\Phi, g, \mathbf{c}, v)$ , while it does not need to know anything about g (except degree and number of variables). This ensures that the honest verifier in our protocol can execute sumcheck (as g is not known to it). During knowledge extraction, the extractor will know g.
+
+Linearisation protocol. We describe the protocol  $\Pi^{\text{lin}}$  in Fig. 6. The protocol keeps the commitment block (com,  $\mathbf{F}$ ,  $\mathbf{H}$ ) from the input statement and linearises the sumcheck claims into a minimal committed-linear output statement. Concretely, all claims  $f_{\mathbf{sc}}^{(i)}$  are batched into one polynomial
+
+{33}------------------------------------------------
+
+ $f_{sc}$  using a random linear combination (via eq(bin(i),  $\gamma$ )), and a random  $\mathbb{F}_{q^a}$ -linear map  $\Phi \colon \mathcal{R}_q = \mathbb{F}_{q^a}^{\varphi/a} \to \mathbb{F}_{q^a}$  batches the slots. The protocol then runs basic sumcheck, obtains the evaluation claim  $\Phi(g_{sc}(\mathbf{c})) = v$ , and defers verification of this claim to two bilinear constraints over  $\mathbf{W}$  encoded in the output relation  $\Xi_{COM}^{lin}$ .
+
+<span id="page-33-0"></span>**Lemma 11.** Let  $\theta_a$  be the  $\mathbb{F}_{q^a}$ -linear isomorphism  $\mathcal{R}_q \to (\mathbb{F}_{q^a})^{\varphi/a}$  for some  $a \mid e$ . The protocol  $\Pi_{\theta_a}^{\text{lin}}$  (Fig. 6) satisfies the properties:
+
+- It is a perfectly complete reduction of knowledge
+
+$$\mathcal{Z}_{\mathsf{COM}}^{\mathsf{sum}}[k_{\mathtt{sc}}, n, m_{\mathtt{w}}, r, \mathsf{par}_{\mathtt{com}}, m_{\mathtt{y}}, \beta_{\mathtt{w}}, \beta_{\mathtt{x}}, \beta_{\mathtt{y}}, \delta_{\mathtt{sc}}] \to \mathcal{Z}_{\mathsf{COM}}^{\mathsf{lin}}[1, 2, 0, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (\mathsf{par}_{\mathtt{lin}, i})_{i \in [1]}]$$
+
+where  $par_{lin,0} := (n, par_{com}, m_{y}, \beta_{x}, \beta_{y}).$ 
+
+- It is  $\kappa$ -knowledge-sound, with  $\kappa = \frac{\log(k_{sc}) + \mu \delta_{sc} + 1}{q^a}$ , for
+
+$$\begin{split} & \boldsymbol{\Xi}_{\mathsf{COM}}^{\mathsf{sum}}[k_{\mathtt{sc}}, n_0, m_{\mathtt{w}}, r, \mathsf{par}_{\mathtt{com}, 0}, m_{\mathtt{y}, 0}, \beta_{\mathtt{w}}', \beta_{\mathtt{x}, 0}', \beta_{\mathtt{y}, 0}', \delta_{\mathtt{sc}}] \vee \; \boldsymbol{\Xi}^{\mathsf{sis}}[\mathsf{par}_{\mathtt{sis}}] \\ & \leftarrow \boldsymbol{\Xi}_{\mathsf{COM}}^{\mathsf{lin}}[1, 2, 0, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}', (n_0, \mathsf{par}_{\mathtt{com}, 0}, m_{\mathtt{y}, 0}, \beta_{\mathtt{x}, 0}', \beta_{\mathtt{y}, 0}')] \end{split}$$
+
+where
+
+$$\mathsf{par}_{\mathtt{sis}} \supseteq \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},0}, m_{\mathtt{y},0}, \beta_{\mathtt{v},0}', \beta_{\mathtt{x},0}'] \cup \{(n_0, m_{\mathtt{w}}, 2\beta_{\mathtt{w}}')\}$$
+
+- It has the following efficiency measures:
+  - Prover runtime: O(m)  $\mathcal{R}_q$  operations, cost of computing com, two MLE[vec( $\mathbf{W}$ )] evaluations, and batching of  $f_{\mathtt{sc}}^{(i)}$  plus the  $\mu$ -variate sumcheck for  $g_{\mathtt{sc}}$  of individual degree  $\leq \delta_{\mathtt{sc}}$ .
+  - Verifier runtime: Sampling  $O(\log(k_{\mathtt{sc}}) + \mu + \rho + \varphi/e)$  elements from  $\mathbb{F}_{q^e}$ , cost of running the  $\mu$ -variate sumcheck, evaluating  $f_{\mathtt{sc}}$  once, where  $\mu = \log(m_{\mathtt{w}})$  and  $\rho = \log(r)$ .
+  - Prover-to-verifier comm.:  $O(\log |\mathcal{R}_q|) + O(\delta_{sc}\mu \log(q^a))$ .
+
+Proof.
+
+### Completeness:
+
+Let
+
+$$\mathsf{stmt} = (\mathsf{com}, \mathbf{F}, \mathbf{H}, (f_{\mathtt{sc}}^{(i)})_{i \in [k_{\mathtt{sc}}]}), \qquad \mathsf{wit} = (\mathbf{W}, \mathbf{Y}, \mathbf{x}),$$
+
+and let  $(\mathsf{stmt'}, \mathsf{wit'})$  be the output of  $\Pi^{\mathsf{lin}}$  with
+
+$$\mathsf{stmt'} = ((\mathsf{com}, \mathbf{F}, \mathbf{H}), (\mathbf{l}_j, \mathbf{r}_j, t_j)_{j \in [2]}, \mathbf{0}, \mathbf{0}), \qquad \mathsf{wit'} = (\mathbf{W}, (\mathbf{Y}, \mathbf{x})).$$
+
+We show  $(\mathsf{stmt'}, \mathsf{wit'}) \in \Xi_{\mathsf{COM}}^{\mathsf{lin}}[1, 2, 0, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n, \mathsf{par}_{\mathsf{com}}, m_{\mathtt{y}}, \beta_{\mathtt{x}}, \beta_{\mathtt{y}})]$ . Since  $(\mathsf{stmt}, \mathsf{wit}) \in \Xi_{\mathsf{COM}}^{\mathsf{sum}}$ , we already have
+
+$$\mathbf{FW} = \mathbf{HY} \bmod q, \quad \mathsf{COM.Verify}(\mathsf{ck}, \mathsf{com}, \mathsf{vec}(\mathbf{Y}), \mathbf{x}) = 1, \quad \|\mathbf{W}\|_2 \leq \beta_{\mathtt{w}}, \ \|\mathsf{vec}(\mathbf{Y})\|_2 \leq \beta_{\mathtt{y}}, \ \|\mathbf{x}\|_2 \leq \beta_{\mathtt{x}}.$$
+
+These are exactly the committed-linear constraints for the single linear block. The global linear constraint is trivial because  $\mathbf{A} = \mathbf{0}$  and  $\mathbf{b} = \mathbf{0}$ .
+
+Let  $\mathbf{w} = \mathsf{vec}(\mathbf{W})$ . By definition of multilinear extension and of  $\mathbf{l}_j, \mathbf{r}_j, t_j$ , we have
+
+$$t_0 = z_0 = \mathsf{MLE}[\mathbf{w}](\mathbf{c}_0, \mathbf{c}_1) = \mathsf{tensor}(\mathbf{c}_1)^\mathsf{T}\mathbf{W}\mathsf{tensor}(\mathbf{c}_0) = \mathbf{l}_0^\mathsf{T}\mathbf{W}\mathbf{r}_0,$$
+
+and similarly
+
+$$t_1 = z_1 = \mathsf{MLE}[\mathbf{w}](\overline{\mathbf{c}_0}, \overline{\mathbf{c}_1}) = \mathbf{l}_1^\mathsf{T} \mathbf{W} \mathbf{r}_1.$$
+
+{34}------------------------------------------------
+
+Hence the linear constraints in  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  hold.
+
+Finally, because the input summation claims are true, the batched claim  $\Phi(\sum_{\mathbf{z}} g_{sc}(\mathbf{z})) = 0$  is true, and perfect completeness of  $\Pi^{\text{basic-sc}}$  gives  $f_{\text{sc}}(z_0, \overline{z}_1) = \Phi(g_{\text{sc}}(\mathbf{c})) = v$ , i.e. the verifier accepts. Therefore,  $\Pi^{\text{lin}}$  is perfectly correct.
+
+### Knowledge-soundness:
+
+Let  $\mathcal{A}$  be a prover convincing the verifier with probability at least  $\epsilon$ . We describe an extractor Ext. First, Ext runs  $\mathcal{A}$  once and obtains an accepting transcript with witness
+
+$$\mathsf{wit}' = (\mathbf{W}', (\mathbf{Y}', \mathbf{x}')) \in \varXi_{\mathsf{COM}}^{\mathsf{lin}}[1, 2, 0, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}', (n_0, \mathsf{par}_{\mathsf{com}, 0}, m_{\mathtt{y}, 0}, \beta_{\mathtt{x}, 0}', \beta_{\mathtt{y}, 0}')].$$
+
+If  $(\mathbf{W}', \mathbf{Y}', \mathbf{x}')$  satisfies all input summation claims, then Ext outputs this witness for
+
+$$\Xi_{\mathsf{COM}}^{\mathsf{sum}}[k_{\mathtt{sc}}, n_0, m_{\mathtt{w}}, r, \mathsf{par}_{\mathtt{com},0}, m_{\mathtt{y},0}, \beta_{\mathtt{w}}', \beta_{\mathtt{x},0}', \beta_{\mathtt{y},0}', \delta_{\mathtt{sc}}].$$
+
+Otherwise, define
+
+$$y_i^* \coloneqq \sum_{\mathbf{z} \in \{0,1\}^{\mu}} f_{\mathrm{sc}}^{(i)} \Big( \mathsf{MLE}[\mathsf{vec}(\mathbf{W}')], \mathsf{MLE}[\overline{\mathsf{vec}(\mathbf{W}')}] \Big) \left( \mathbf{z} \right) \in \mathcal{R}_q$$
+
+and note that some  $y_i^* \neq 0$ . The extractor rewinds  $\mathcal{A}$  with fixed prover randomness and obtains a second accepting transcript for fresh verifier challenges, with witness  $\mathsf{wit}'' = (\mathbf{W}'', (\mathbf{Y}'', \mathbf{x}''))$ .
+
+If  $Y'' \neq Y'$ , then both openings verify for the same commitment com, so Ext outputs
+
+$$(\mathsf{vec}(\mathbf{Y}'), \mathbf{x}'), (\mathsf{vec}(\mathbf{Y}''), \mathbf{x}'')$$
+
+which satisfies  $\Xi^{sis}[par_{sis}]$  relation for extraction, where  $par_{sis} \supseteq par_{break}[par_{com,0}, m_{y,0}, \beta'_{y,0}, \beta'_{x,0}]$ , which is a valid extraction due to Lemma 4.
+
+Assume now  $\mathbf{Y}'' = \mathbf{Y}'$ . Since both transcripts satisfy the linear block of  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  with the same  $(\mathbf{F}, \mathbf{H}),$ 
+
+$$\mathbf{F}(\mathbf{W''} - \mathbf{W'}) = \mathbf{0} \bmod q.$$
+
+If  $\mathbf{W}'' \neq \mathbf{W}'$ , pick a non-zero column  $\mathbf{u}$  of  $\mathbf{W}'' - \mathbf{W}'$ . Then  $\mathbf{A}_{n_0, m_{\mathbf{w}}} \mathbf{u} = \mathbf{0} \bmod q$  (for  $\mathbf{F} = \mathbf{A}_{n_0, m_{\mathbf{w}}}$ ), and
+
+$$\|\mathbf{u}\|_2 \le \|\mathbf{W}'' - \mathbf{W}'\|_2 \le 2\beta_{\mathbf{w}}',$$
+
+so Ext outputs a witness for  $\Xi^{sis}[par_{sis}]$  branch for extraction, where  $par_{sis} \ni (n_0, m_w, 2\beta_w')$ 
+
+Suppose that  $y_i^* = \sum_{\mathbf{z} \in \{0,1\}^{\mu}} f_{\mathsf{sc}}^{(i)}(\mathsf{MLE}[\mathbf{w}'], \mathsf{MLE}[\overline{\mathbf{w}'}])(\mathbf{z}) \in \mathcal{R}_q$  are the honest sums (derived from  $\mathbf{w}'$  obtained above). Note that some  $y_{i^*}^*$  is non-zero, or extraction would have succeeded. Relative to the fixed known witness  $\mathbf{W}'$ , the challenges satisfy that
+
+- except with probability  $\log(k_{\mathtt{sc}})/q^a$ :  $y^* = \sum_{i \in [k_{\mathtt{sc}}]} \mathsf{eq}(\mathsf{bin}(i), \boldsymbol{\gamma}'') \cdot y_i^* \neq 0$ ; except with probability  $1/q^a$ :  $\Phi(y^*) \neq 0$ , and  $(\Phi, g_{\mathtt{sc}}, 0) \notin \Xi_{\mathcal{R}_q, \mathbb{F}_{q^a}, \dim(\mathbf{z})}^{\mathtt{sc}}$ ;
+- except with probability  $\kappa_{sc} \leq \mu \delta_{sc}/q^a$ , sumcheck reduces to a false claim  $(\Phi, g_{sc}, \mathbf{c''}, v^*) \notin$  $\Xi_{\mathcal{R}_q,\mathbb{F}_{q^a},\dim(\mathbf{z})}^{\mathsf{polyeval}}$
+
+By the union bound, this bad case has probability at most
+
+$$\kappa = \frac{\log(k_{\rm sc}) + \mu \delta_{\rm sc} + 1}{q^a}.$$
+
+{35}------------------------------------------------
+
+Therefore, with probability at least  $\epsilon - \kappa$ , extractor Ext outputs a witness for one of the branches in the lemma statement.
+
+#### Extractor runtime:
+
+The extractor performs one accepting run and one forked rewind, so by standard rewinding analysis it runs in expected polynomial time.
+
+## Efficiency:
+
+The efficiency claims follow directly from the protocol description.
+
+Efficiency of  $\Pi^{\text{lin}}$ . The exact efficiency of  $\Pi^{\text{lin}}$  depends heavily on the sumcheck claims  $(f_{\text{sc}}^{(i)})_{i \in [k_{\text{sc}}]}$  in the input statement. Naively, the cost of computing the batched  $f_{\text{sc}}$  can be as high as  $O(m_{\text{w}} \cdot k_{\text{sc}})$ , which would be prohibitive for our goal of achieving succinct verification. However, in our application of  $\Pi^{\text{lin}}$  in the composition, the sumcheck claims are well-structured: they either correspond to structured linear constraints (e.g. evaluations of MLEs for tensor(·) or rows of the vSIS-based commitment) or are sparse, i.e. concern only small subsets of the witness (e.g. the evaluation of the MLE of the folding challenge). Section 8.2, as a part of the composition-specific analysis, summarises the efficiency of  $\Pi^{\text{lin}}$  when used in composition with the other RoKs defined in this work.
+
+# <span id="page-35-0"></span>8 Composition and Asymptotics
+
+As in prior works [KLNO24b, KLNO25, KLOT25], we can compose the RoKs  $\Pi^{\text{proj-c}}$ ,  $\Pi^{\text{proj-fl}}$ ,  $\Pi^{\text{fold-split}}$  and  $\Pi^{\text{lin}}$  presented in this work into a succinct argument. In contrast to these prior works, which focus on obtaining a succinct argument for (a less expressive variant of)  $\Xi_{\text{COM}}^{\text{lin}}$ , we have the flexibility to choose  $\Xi_{\text{COM}}^{\text{lin}}$  or  $\Xi_{\text{COM}}^{\text{sum}}$  as our "starting" relation. While (a succinct argument for)  $\Xi_{\text{COM}}^{\text{lin}}$  suffices for e.g. constructing polynomial commitment schemes (PCS),  $\Xi_{\text{COM}}^{\text{sum}}$  is more expressive and can capture complex relations such as Rank-1 Constraint Systems (R1CS). Another difference between the compositions of the aforementioned prior works and ours, to be presented below, is that ours is much simpler – it consists of a chain of RoKs alternating between the following two groups <sup>13</sup>:
+
+$$\Pi^{\mathsf{fold\text{-}split}} \circ \Pi^{\mathsf{proj}} : \Xi^{\mathsf{lin}}_{\mathsf{COM}} \to \Xi^{\mathsf{lin}}_{\mathsf{COM}} \to \Xi^{\mathsf{sum}}_{\mathsf{COM}} \qquad \text{and} \qquad \Pi^{\mathsf{lin}} : \Xi^{\mathsf{sum}}_{\mathsf{COM}} \to \Xi^{\mathsf{lin}}_{\mathsf{COM}}$$
+
+where  $\Pi^{\mathsf{proj}} \in \{\Pi^{\mathsf{proj-c}}, \Pi^{\mathsf{proj-fl}}\}$ . As usual, the goal of the composition is to gradually reduce the size of the witness until it becomes so small that it can be sent in plain.
+
+### <span id="page-35-2"></span>8.1 Simplifying Assumptions and Summary of RoKs
+
+As we focus only on asymptotics in this section, we make several simplifying assumptions that ease analysis without affecting the asymptotic behaviour of the composition.
+
+<span id="page-35-3"></span>vSIS parameters. To assess the hardness of vSIS, we model it as an SIS-type problem whose associated Euclidean kernel lattice has dimension  $N := \varphi \cdot n$ , where  $\varphi$  is the cyclotomic degree and n is the module rank. Under this identification, a random n-tuple over  $\mathcal{R}_q$  defines a random  $\mathbb{Z}_q$ -linear constraint, and solving vSIS amounts to finding a short nonzero kernel vector, as in SIS [MR09].
+
+<span id="page-35-1"></span> $<sup>\</sup>overline{\Pi' \circ \Pi}$  means apply  $\Pi$  first then  $\Pi'$ , as in function composition.
+
+{36}------------------------------------------------
+
+We use the standard heuristic that the best known attacks are generic lattice-reduction attacks (e.g., BKZ), whose cost is mainly governed by N and by the ratio between the target norm bound  $\beta$  and the natural volume scale, which for (module-)SIS behaves like  $q^{1/n}$  [CN11]. We assume  $q = \text{poly}(\lambda)$  and  $\beta = \text{poly}(\lambda)$ . Then  $\log q = \Theta(\log \lambda)$  and  $\log \beta = \Theta(\log \lambda)$ , so the dependence on  $q^{1/n}$  saturates once n exceeds a constant (more precisely, around  $n \approx \log q/\log \beta = \Theta(1)$ ). Beyond this point, increasing n yields little gain while it increases the dimension  $N = \varphi n$ . Consequently, we fix n = O(1) and scale security by  $\varphi$ , choosing  $\varphi = \Theta(\lambda)$  so that  $N = \Theta(\lambda)$ . Under these choices, we treat  $vSIS_{\mathcal{R},\varphi,n,m,q,\beta}$  as heuristically as hard as SIS in dimension N against generic lattice-reduction attacks. Similarly, for recursive commitments we will assume that all ranks are O(1).
+
+Commitment parameters. We assume that the recursive commitment  $COM = COM_{m_x,\beta_x}$  has depth 1. As such, we can assume that  $m_x = 0$  and  $\beta_x[par_{com}] = 0$  throughout and omit them from the parameters of relations and RoKs. We will also omit all aux = x which would otherwise have appeared. We assume that the commitment key of COM has module rank n, so  $\#constraints(par_{com}) = n \in O(1)$ . This choice of COM does not affect the asymptotics as we assume that the rank of the commitment is O(1), and the only effect of the commitment in the composition is to add O(1) linear constraints to the relations. With the choice of COM fixed, we will drop it from the subscripts of all relations.
+
+Random projection parameters. We assume that  $n_{rp} = O(\lambda)$  and  $m_{rp} = \rho \cdot n_{rp}$  for some  $\rho = \rho(\lambda)$  that we will specify later. This means  $n_{rp}/m_{rp} = \rho$  and  $n_{rp} \cdot m_{rp} = \lambda^2 \cdot \rho$ . We will also consider  $\mathbf{W} \in \mathcal{R}^{m_v \times \rho}$  with  $\rho$  columns throughout our composition.
+
+<span id="page-36-2"></span>Decomposition degree. We will also fix a large enough norm bound  $\beta \in \Theta(\sqrt{m_{\mathtt{w}}\lambda}\log q)$  throughout and assume that the decomposition degree  $\ell$  for gadget decomposition  $\mathbf{G}_{\ell}^{-1}$  is adaptively chosen so that the result has norm at most  $\beta$ . For an input vector  $\mathbf{x} \in \mathcal{R}^{m_{\mathtt{w}}}$  of norm at most  $\alpha \leq q/2$ , it suffices to take  $\ell \geq -2\ln\alpha/W_{-1}\left(-\frac{\varphi m_{\mathtt{w}}\ln\alpha}{2\beta^2}\right)$  where  $W_{-1}$  is the secondary branch of the Lambert W function. Note that for any u>0, we have  $-W_{-1}(-e^{-u-1})\geq 1+\sqrt{2u}+\frac{2u}{3}>\frac{2u}{3}$  due to [Cha13, Theorem 1]. Substituting  $u=\ln\frac{2\beta^2}{e\varphi m_{\mathtt{w}}\ln\alpha}^{14}$  and taking  $\beta\geq 2\sqrt{\varphi m_{\mathtt{w}}}\ln q>2\sqrt{\varphi m_{\mathtt{w}}}\ln\alpha$ , it suffices to set  $\ell\geq 3$ , which is constant. We will therefore assume throughout that  $\ell\leq O(1)$  and also omit it from all parameters.
+
+Batching parameters. For  $\Pi^{\mathsf{proj-f}}$ , we pick  $n_{\mathsf{bat}} = O(\lambda/\log \lambda)$ . For  $\Pi^{\mathsf{proj-fl}}$ , we assume that  $\mathcal{R}$  admits a 2-smooth tower structure, i.e.  $c = \log \varphi$ . We let  $n_{\mathsf{bat},c} = 1$ ,  $n_{\mathsf{bat},c-1} = O(1)$ ,  $n_{\mathsf{bat},i} = n_{\mathsf{bat},c-1}^{c-i}$  for all  $i \in [c]$ , so that  $\sum_{i \in [c]} n_{\mathsf{bat},i} \in O(\varphi) = O(\lambda)$ . We further assume that  $n_{\mathsf{bat},0} \in O(\lambda/\log \lambda)$ . For batching of sumchecks, we pick the parameter a for the map  $\theta$  in  $\Pi^{\mathsf{lin}}$  to be  $a = O(\lambda/\log \lambda)$ , so that the knowledge error for batching is negligible.
+
+Dropping parameters. With the above simplifications, and the observation that  $\Pi^{\text{proj-c}}$ ,  $\Pi^{\text{proj-f}}$ ,  $\Pi^{\text{lin}}$  almost 15 all produce  $\Xi^{\text{lin}}$  relations with  $m_{y,i} = O(n_i)$  and  $\beta_{y,i} = \beta$ , the parameters
+
+$$(k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n_i, m_{\mathtt{x},i}, m_{\mathtt{y},i}, \beta_{\mathtt{x},i}, \beta_{\mathtt{y},i})_{i \in [k_{\mathtt{lin}}]})$$
+
+of  $\Xi^{\text{lin}}$  can be simplified to
+
+$$(k_{lin}, k_{lr}, n, m_{w}, \beta_{w}, (n_i)_{i \in [k_{lin}]}).$$
+
+<span id="page-36-0"></span> $<sup>^{14}</sup>$  e here is Euler's number.
+
+<span id="page-36-1"></span>The only exception is that the parameters of an output relation of  $\Pi^{\text{proj-f}}$  contain a tuple  $(n_{k_{\text{lin}}}, m_{y,k_{\text{lin}}})$  where  $n_{k_{\text{lin}}} = 0$  but  $m_{y,k_{\text{lin}}} = O(m/\rho)$ .
+
+{37}------------------------------------------------
+
+<span id="page-37-0"></span>**Table 4.** Summary of all RoKs presented in this work with simplifications discussed in Section 8.1. We omit  $k_{\text{lin}}$ ,  $k_{\text{lr}}$  factors in  $O(\cdot)$  expressions since they stay constant in the compositions that we consider. The prover time and verifier time are measured in number of  $\mathcal{R}_q$  operations (or equivalent). The communication cost is measured in number of  $\mathcal{R}_q$  elements (or equivalent).
+
+|     |                                                        | Parameters                                                                                 | Prover                                      | Verifier                                                  | Comm                             |
+|-----|--------------------------------------------------------|--------------------------------------------------------------------------------------------|---------------------------------------------|-----------------------------------------------------------|----------------------------------|
+| 7   | $\varPi^{proj-c}: \varXi^{lin} \to \varXi^{lin}$       |                                                                                            | $O(m_{\mathtt{w}} \rho \lambda)$            | $O(\rho \lambda / \log \lambda)$                          | O(1)                             |
+|     |                                                        | $n_{k_{\texttt{lin}}} = m_{\texttt{w}}/\rho$                                               |                                             |                                                           |                                  |
+| 8   | $\varPi^{proj-f}: \varXi^{lin} \to \varXi^{lin}$       | $k_{\mathtt{lin}} \mapsto k_{\mathtt{lin}} + 2$                                            | $O(m_{\mathtt{w}} \rho \lambda)$            | $O((\rho\lambda + \log(m_{\mathtt{w}}\rho))/\log\lambda)$ | $O(\lambda/\log\lambda)$         |
+|     |                                                        | $n\mapsto n+n_{\texttt{bat}}$                                                              |                                             |                                                           |                                  |
+|     |                                                        | $n_{k_{\texttt{lin}}} = m_{\texttt{	w}}/\rho$                                              |                                             |                                                           |                                  |
+|     |                                                        | $n_{k_{\mathtt{lin}}+1} = n_{\mathtt{bat}}$                                                |                                             |                                                           |                                  |
+| 12  | $\varPi^{proj-fl}: \varXi^{lin} \to \varXi^{lin}$      | $k_{\mathtt{lin}} \mapsto k_{\mathtt{lin}} + 2$                                            | $O(m_{\mathtt{w}}\rho\lambda^2\log\lambda)$ | $O((\rho\lambda + \log(m_{\mathtt{w}}\rho))/\log\lambda)$ | $O(\log \lambda)$                |
+|     |                                                        | $n \mapsto n+1$                                                                            |                                             |                                                           |                                  |
+|     |                                                        | $n_{k_{\texttt{lin}}} = m_{\texttt{w}}/\rho$                                               |                                             |                                                           |                                  |
+|     |                                                        | $n_{k_{\text{lin}}+1} = 1$                                                                 |                                             |                                                           |                                  |
+| 9 1 | $T^{fold\text{-split}}: \varpi^{lin} \to \varpi^{sum}$ | $k_{\textsf{sc}} = O(n + \sum_{i \in [k_{\textsf{lin}}]} n_i)$                             | $O(m_{\tt w}\rho)$                          | $O(\rho/\log\lambda)$                                     | O(1)                             |
+|     |                                                        | $m_{\mathtt{w}} \mapsto O(m_{\mathtt{w}}/\rho + \sum_{i \in [k_{\mathrm{lin}}]} n_i \rho)$ |                                             |                                                           |                                  |
+|     |                                                        | $\beta_{\mathtt{w}} \mapsto O(\beta) \ n = 0$                                              |                                             |                                                           |                                  |
+|     |                                                        | $n_0 = O(1)$                                                                               |                                             |                                                           |                                  |
+|     |                                                        | $k_{\mathtt{lin}} = 1$                                                                     |                                             |                                                           |                                  |
+| 11  | $\varPi^{lin}: \varvarphi^{sum} \to \varphi^{lin}$     | $k_{\rm lr}=2$                                                                             | $O(m_{\mathtt{w}} \rho + \rho \lambda^2)$   | $O(\rho\lambda^2 + \log k_{\rm sc} + \log m_{\rm w})$     | $O(\log m_{\tt w}/\log \lambda)$ |
+
+Similarly, with the observation that  $\Pi^{\text{fold-split}}$  always output a  $\Xi^{\text{sum}}$  relation with  $\delta_{\text{sc}} = 2$ , the parameters  $(k_{\text{sc}}, m_{\text{w}}, m_{\text{x}}, \beta_{\text{w}}, \beta_{\text{x}}, \delta_{\text{sc}})$  for  $\Xi^{\text{sum}}$  can be simplified to  $(k_{\text{sc}}, m_{\text{w}}, \beta_{\text{w}})$ .
+
+RoKs Summary We summarise the effect of each RoK of interest in Table 4.<sup>16</sup> To reflect intuition that  $\lambda \ll m_{\tt w} \in \mathsf{poly}(\lambda)$ , when reporting asymptotics, we treat  $\log m_{\tt w}$  as being dominated by  $\lambda$ , e.g.  $O(\lambda + \log m_{\tt w}) = O(\lambda)$ , and  $\log \lambda$  as being dominated by  $\log m_{\tt w}$ , e.g.  $O(\log \lambda / \log m_{\tt w}) = O(1)$ . We are concerned about mainly two chains of RoKs:
+
+Coarse 
+$$\Pi^{\text{lin}} \circ \Pi^{\text{fold-split}} \circ \Pi^{\text{proj-c}} : \Xi^{\text{lin}} \to \Xi^{\text{lin}}$$
+ and Fine  $\Pi^{\text{lin}} \circ \Pi^{\text{fold-split}} \circ \Pi^{\text{proj-fl}} : \Xi^{\text{lin}} \to \Xi^{\text{lin}}$ .
+
+We analyse the costs of these chains assuming that the starting relation has  $k_{\text{lin}}, k_{\text{lr}}, n, n_i \in O(1)$  for all  $i \in [k_{\text{lin}}]$ . We also assume that we have  $m_{\text{w}} \geq \Omega(\lambda)$  for the coarse chain, since  $\Pi^{\text{proj-c}}$  does not work for  $m_{\text{w}}$  too small. We see that both chains have the following effect on the parameters:
+
+$$k_{\text{lin}} \mapsto 1,$$
+  $k_{\text{lr}} \mapsto 2,$   $n \mapsto 0,$   $m_{\text{W}} \mapsto O(m_{\text{W}}/\rho),$   $\beta_{\text{W}} \mapsto O(\beta),$   $(n_i)_{i \in [k_{\text{lin}}]} \mapsto (O(1)).$ 
+
+The coarse chain costs in total  $O(m_{\mathtt{w}}\rho\lambda)$  prover time,  $O(\rho\lambda^2 + \log m_{\mathtt{w}})$  verifier time and  $O(\log m_{\mathtt{w}}/\log \lambda)$  proof size. The fine chain costs in total  $O(m_{\mathtt{w}}\rho\lambda^2\log \lambda)$  prover time,  $O(\rho\lambda^2 + \log m_{\mathtt{w}})$  verifier time and  $O(\log \lambda + \log m_{\mathtt{w}}/\log \lambda)$  proof size. All of the above is measured in number of  $\mathcal{R}_q$  operations/elements (or equivalent).
+
+<span id="page-37-1"></span>The parameter  $n_{k_{\text{lin}}}$  in  $\Pi^{\text{proj-fl}}$  and  $\Pi^{\text{proj-fl}}$  is an overestimate. Accurately,  $n_{k_{\text{lin}}} = 0$  and  $m_{y,k_{\text{lin}}} = O(m_w/\rho)$ .
+
+{38}------------------------------------------------
+
+## <span id="page-38-0"></span>8.2 Efficiency of $\Pi^{\text{lin}}$
+
+The exact efficiency of  $\Pi^{\text{lin}}$  highly depends on the sumcheck claims  $(f_{sc}^{(i)})_{i \in [k_{sc}]}$  given in the input statement. The following Corollary 1 summarises the efficiency of  $\Pi^{\text{lin}}$  when used in the above composition.
+
+<span id="page-38-1"></span>Corollary 1. In the above RoK composition towards the PCS construction, each instance of  $\Pi^{\text{lin}}$  has the following performance guarantees:
+
+- Prover complexity:  $O(m_{\mathtt{w}} + n_{\mathtt{rp}} \cdot m_{\mathtt{rp}}) \ \mathcal{R}_q$  operations,
+- Verifier complexity:  $O(r + n_{\mathtt{rp}} \cdot m_{\mathtt{rp}} + \log k_{\mathtt{sc}}) \ \mathcal{R}_q$  operations and  $O(\mu) \ \mathbb{F}_{q^e}$  operations.
+- Prover-to-verifier communication:  $O(\log m_{\mathtt{w}}/\log \lambda) \ \mathcal{R}_q$  elements.
+
+*Proof.* In the RoK composition towards the PCS construction, we have  $n, k_{lin}, k_{lr}, \delta_{sc} = O(1)$ .
+
+Prover efficiency. As stated in Lemma 11, the prover complexity of  $\Pi^{\text{lin}}$  consists of  $O(m_{\mathtt{w}})$   $\mathcal{R}_q$  operations, the cost of computing com, two  $\mathsf{MLE}[\mathbf{w}]$  evaluations, batching of  $f_{\mathtt{sc}}^{(i)}$ , and the  $\mu$ -variate sumcheck for  $g_{\mathtt{sc}}$  of individual degree  $\leq \delta_{\mathtt{sc}}$ . Except for the batching of  $(f_{\mathtt{sc}}^{(i)})_{i \in [\mu]}$ , all other costs are bounded by  $O(m_{\mathtt{w}})$   $\mathcal{R}_q$  operations due to the efficiency of the MLE evaluation and the sumcheck protocol analysis in Lemma 13, assuming that  $f_{\mathtt{sc}} = \sum_{i \in [k_{\mathtt{sc}}]} \mathsf{eq}(\mathsf{bin}(i), \gamma) \cdot f_{\mathtt{sc}}^{(i)}$  is computed explicitly (as a list of coefficients) by the prover. The computation of com is upper bounded by  $O(m_{\mathtt{w}})$   $\mathcal{R}_q$  operations since the commitment key of COM has module rank n = O(1).
+
+We have  $k_{sc}$  polynomials to batch. Except for the projection constraints, the number of constraints is O(1), and thus the cost of batching these constraints is  $O(m_{\tt w})$   $\mathcal{R}_q$  operations.
+
+For the projection constraints, we inspect the constraints for "coarse" projections which are of the form
+
+$$(\mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathbf{J})\mathbf{G}_{\ell'}\widetilde{\mathbf{w}} = \mathbf{G}_{\ell}\mathbf{V}\mathbf{c} \bmod q$$
+
+with an implicit lift to  $\mathcal{R}_q$ .
+
+Assume, without loss of generality, that those constraints correspond to the first  $k'_{sc} \leq k_{sc}$  polynomials  $f_{sc}^{(i)}$  for  $i \in [k'_{sc}]$ . The cost of batching those  $(f_{sc}^{(i)})_{i \in [k'_{sc}]}$  is equivalent to the cost of computing coefficients of the following polynomial in  $\mathcal{R}_q[\mathbf{y}]$ :
+
+$$\mathsf{eq}(\mathbf{0}, \pmb{\gamma}_0) \begin{pmatrix} \mathsf{MLE}[\mathsf{tensor}(\pmb{\gamma}_1) \cdot (\mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathbf{J} \otimes \mathbf{g}_{\ell'}^{\mathtt{T}})] \cdot \mathsf{eq}(\mathbf{p}_w) \\ - \mathsf{MLE}[\mathbf{c} \otimes \mathsf{tensor}(\pmb{\gamma}_1) \otimes \mathbf{g}_\ell] \cdot \mathsf{eq}(\mathbf{p}_v) \end{pmatrix}$$
+
+where  $\gamma := (\gamma_0, \gamma_1)^T$  for  $\gamma_0 \in \mathcal{R}_q^{\log k_{sc} - \log k'_{sc}}$  and  $\gamma_1 \in \mathcal{R}_q^{\log k'_{sc}}$  and  $\mathbf{p}_w$  and  $\mathbf{p}_v$  are the selectors for the  $\widetilde{\mathbf{w}}$  and  $\mathbf{vec}(\mathbf{V})$  within  $\widehat{\mathbf{w}}$ . The cost of computing all eq terms is  $O(m_{\mathbf{w}})$   $\mathcal{R}_q$  operations. The cost of computing tensor( $\gamma_1$ )( $\mathbf{I}_{m_{\mathbf{w}}/m_{rp}} \otimes \mathbf{J} \otimes \mathbf{g}_{\ell'}^T$ ) is  $O(m_{\mathbf{w}} + n_{rp} \cdot m_{rp})$   $\mathcal{R}_q$  operations by the mixed-product property of the Kronecker product. The cost of computing  $\mathbf{c} \otimes \mathsf{tensor}(\gamma_1) \otimes \mathbf{g}_{\ell}$  is  $O(m_{\mathbf{w}})$   $\mathcal{R}_q$ .
+
+Analogously, the cost of batching constraints for "fine" projections is also  $O(m_w + n_{rp} \cdot m_{rp}/\varphi)$   $\mathcal{R}_q$  operations.
+
+Verifier efficiency. Engaging in the sumcheck protocol for the batched polynomial  $f_{sc}$  takes  $O(\mu)$   $\mathbb{F}_{q^e}$  operations. Additionally, observe that the verifier efficiency in  $\Pi^{\text{lin}}$  depends on the efficiency of verifying the sumcheck claims, i.e., that
+
+$$f_{\operatorname{sc}}(z_0,\overline{z_1})(\mathbf{s}) = \sum_{i \in [k_{\operatorname{sc}}]} \operatorname{eq}(\operatorname{bin}(i), \boldsymbol{\gamma}) \cdot f_{\operatorname{sc}}^{(i)}(z_0,\overline{z_1})(\mathbf{s}) \stackrel{?}{=} v \bmod q.$$
+
+{39}------------------------------------------------
+
+Each of the  $k_{sc}$  polynomials  $f_{sc}^{(i)}$  represents a linear constraint on the original witness **w** (and its conjugate) and the "public" vectors. The evaluation of the MLE for the witness (and its conjugate) at **s** is claimed by the prover as  $z_0$  and  $\overline{z_1}$  (and is verified in further rounds of the protocol). For the MLEs of public inputs, we draw the following conclusions:
+
+- (a) Commitment keys  $\mathbf{A}_{n,m} \in \mathcal{R}_q^{n \times \otimes^{\mu}}$  are row-tensors, perfectly aligning with the structure of the MLE; thus the evaluation of the MLE at  $\mathbf{s}$  is done in  $O(\mu)$   $\mathcal{R}_q$  time.
+- (b) For the rows obtained from the "left-right" constraints (i.e.,  $\mathbf{l}_i^T \cdot \mathbf{W} \cdot \mathbf{r}_i = t_i \mod q$  for  $i \in [k_{1r}]$ ), they are also row-tensors by construction, as they correspond to the evaluation of  $\mathbf{v}$  (the evaluation point) using a row-tensor basis of the polynomial ring. This alignment with the MLE structure means the evaluation at  $\mathbf{s}$  can be done in  $O(\mu)$   $\mathcal{R}_q$  time.
+- (c) The same argument applies for the constraints corresponding to the **A** matrix in the  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  relation, which is also a row-tensor; the evaluation of the MLE at **s** can be done in  $O(\mu)$   $\mathcal{R}_q$  time.
+- (d) For the challenge vector  $\mathbf{c}$ , the linear constraints, although unstructured, concern only a small part of the witness. In other words, the variables used in the linear constraints form only a small subset of the variables in the multilinear extension, allowing the evaluation of the MLE at  $\mathbf{c}$  to be done in O(r)  $\mathcal{R}_q$  time.
+- (e) Finally, the largest chunk of constraints arises from the projection constraints. For "coarse" projections, the constraints correspond to the expression:
+
+$$(\mathbf{I}_{m_{\mathbf{v}}/m_{rp}} \otimes \mathbf{J} \otimes \mathbf{g}_{\ell'}^{\mathsf{T}}) \cdot \widetilde{\mathbf{w}} = \mathbf{G}_{\ell} \mathbf{V} \mathbf{c} \mod q$$
+
+or equivalently, when vectorised,
+
+$$(\mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathbf{J} \otimes \mathbf{g}_{\ell'}^{\mathtt{T}}) \cdot \widetilde{\mathbf{w}} = (\mathbf{c} \otimes \mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathbf{g}_{\ell}) \cdot \mathsf{vec}(\mathbf{V}) \bmod q$$
+
+with implicit lift to  $\mathcal{R}_q$ . Let  $\mathbf{D} := (\mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathbf{J} \otimes \mathbf{g}_{\ell'}^{\mathtt{T}})$  and  $\mathbf{E} := (\mathbf{c} \otimes \mathbf{I}_{m_{\mathtt{w}}/m_{\mathtt{rp}}} \otimes \mathbf{g}_{\ell})$ . The evaluation claims for those constraints are given by:
+
+$$f_{\mathtt{sc}}^{(i)} = \mathsf{MLE}[\mathbf{d}_i] \cdot \mathsf{eq}(\mathbf{p}_w) \cdot \mathsf{MLE}[\mathbf{w}] - \mathsf{MLE}[\mathbf{e}_i] \cdot \mathsf{eq}(\mathbf{p}_v) \cdot \mathsf{MLE}[\mathbf{w}],$$
+
+where  $\mathbf{p}_w$  and  $\mathbf{p}_v$  are the (public) selectors (within  $\hat{\mathbf{w}}$ ) for  $\tilde{\mathbf{w}}$  and  $\operatorname{vec}(\mathbf{V})$  respectively, and  $\mathbf{d}_i$  and  $\mathbf{e}_i$  are the *i*-th rows of  $\mathbf{D}$  and  $\mathbf{E}$  respectively.
+
+We observe that  $k'_{sc}$  is a power of two, and we let  $\mu' = \log k'_{sc}$ . Assume, without loss of generality, that these  $k'_{sc}$  constraints are actually the first  $k'_{sc}$  constraints out of all  $k_{sc}$  constraints. Therefore, one splits  $\gamma = (\gamma_0, \gamma_1)^T$  where  $\gamma_0 \in \mathcal{R}_q^{\mu-\mu'}$  and  $\gamma_1 \in \mathcal{R}_q^{\mu'}$  and computes:
+
+$$v = \mathsf{eq}(\mathbf{0}, \boldsymbol{\gamma}_0) \cdot \begin{pmatrix} \mathsf{MLE}[\mathsf{tensor}(\boldsymbol{\gamma}_1)^\mathsf{T}\mathbf{D}] \cdot \mathsf{eq}(\mathbf{p}_w) \cdot z_0 \\ - \mathsf{MLE}[\mathsf{tensor}(\boldsymbol{\gamma}_1)^\mathsf{T}\mathbf{E}] \cdot \mathsf{eq}(\mathbf{p}_v) \cdot \overline{z_1} \end{pmatrix} (\mathbf{s}) \bmod q,$$
+
+which, by the mixed-product property of the tensor product, is equivalently computable in  $O(r + n_{rp} \cdot m_{rp} + \log k_{sc}) \mathcal{R}_q$  operations.
+
+For "fine" projections, the same idea applies, but due to the different structure of the projection constraints, the evaluation of the MLE at s can be done in  $O(r + n_{rp} \cdot m_{rp}/\varphi \cdot \log k_{sc}) \mathcal{R}_q$  operations.
+
+Communication. The communication cost of  $\Pi^{\text{lin}}$  is dominated by the cost of sending the evaluation points for the sumcheck claims, which is  $O(\mu)$   $\mathbb{F}_{q^a}$  elements. Equivalently, that is  $O(\log m_{\mathtt{w}}/\log \lambda)$   $\mathcal{R}_q$  elements.
+
+{40}------------------------------------------------
+
+<span id="page-40-0"></span>**Table 5.** Complexity measures of composed succinct argument for  $\Xi^{\text{lin}}$  in number of  $\mathcal{R}_q$  operations/elements (or equivalent) with different shrink factors. All measures are in  $O(\cdot)$  which is omitted.
+
+| Shrink factor                                                                              | Prover                        | Verifier                                       | Comm                                                                 |
+|--------------------------------------------------------------------------------------------|-------------------------------|------------------------------------------------|----------------------------------------------------------------------|
+| $\overline{\rho}$                                                                          | $\rho m_{\mathtt{w}} \lambda$ | $\rho \lambda^2 \log_\rho m_{\mathtt{w}}$      | $\log_{\rho}(m_{\mathtt{w}}) \cdot \log m_{\mathtt{w}}/\log \lambda$ |
+| 2                                                                                          | $m_{\mathtt{w}}\lambda$       | $\lambda^2 \log m_{\mathtt{w}}$                | $\log^2 m_{\tt w}/\log \lambda$                                      |
+| $\lambda$                                                                                  | $m_{\mathtt{w}}\lambda^2$     | $\lambda^3 \log m_{\mathtt{w}} / \log \lambda$ | $\log^2 m_{\mathtt{w}}/\log^2 \lambda$                               |
+| $\frac{1}{(m_{\mathtt{W}})^{\log m_{\mathtt{W}}/(\log \lambda \log \log m_{\mathtt{W}})}}$ | $o(m_{\mathtt{w}}^2\lambda)$  | $o(m_{\mathtt{w}}\lambda^2)$                   | $\log \log m_{\mathtt{w}}$                                           |
+
+## 8.3 Example: Polynomial Commitments
+
+We next investigate the asymptotic performance of a succinct argument obtained by composing our RoKs.
+
+ $\Xi^{\text{lin}}$  relation induced by polynomial commitment construction. For concreteness, we pick as an example polynomial commitment schemes (PCS) as our target application. Recall that a PCS allows the prover to commit to (the coefficients of) a polynomial and can later prove that the committed polynomial evaluates to some claimed value at a given point. We provide a sketch of how a PCS can be built from a succinct argument for  $\Xi^{\text{lin}}_{\text{COM}}$ . Let the PCS commitment key consist of a commitment key of COM and a random row-tensor matrix  $\mathbf{F} \in \mathcal{R}_q^{n \times \otimes_{i \in [\mu]d_i}}$  where  $m_{\mathbf{v}} = \prod_{i \in [\mu]} d_i$ , for some choice of  $n, m_{\mathbf{v}}$ . Suppose the (in general multivariate) polynomial p to be committed has coefficients (w.r.t. some tensor-structured basis of the polynomial ring) given by  $\operatorname{vec}(\mathbf{W}) \in \mathcal{R}^{m_{\mathbf{v}}\rho}$ . To commit to p, the prover recursively commits to  $\mathbf{W} \in \mathcal{R}^{m_{\mathbf{v}} \times \rho}$ . That is, they compute  $\mathbf{V} = \mathbf{F} \cdot \mathbf{W} \mod q$ ,  $\mathbf{Y} = \mathbf{G}_{\ell}^{-1}(\mathbf{V})$  and  $(\operatorname{com}, \operatorname{aux}) \leftarrow \operatorname{COM}.\operatorname{Commit}(\operatorname{ck}, \operatorname{vec}(\mathbf{Y}))$ . The value com is then released as a commitment of p. To prove a polynomial evaluation claim  $p(\mathbf{v}) = t \mod q$ , the prover expresses  $p(\mathbf{v}) = (\mathbf{r}^T \otimes \mathbf{l}^T) \cdot \operatorname{vec}(\mathbf{W})$  where  $\mathbf{l} \in \mathcal{R}^{m_{\mathbf{v}}/\rho}$  and  $\mathbf{r} \in \mathcal{R}^{\rho}$  consist of evaluations of some tensor-structured basis polynomials at  $\mathbf{v}$ . This gives a  $\Xi^{\text{lin}}$  relation:
+
+$$\begin{cases} &\mathsf{COM.Verify}(\mathsf{ck},\mathsf{com},\mathsf{vec}(\mathbf{Y})) = 1 \\ &\mathbf{F} \cdot \mathbf{W} = \mathbf{G}_{\ell} \cdot \mathbf{Y} \bmod q \\ &\mathbf{l}^{\mathsf{T}} \cdot \mathbf{W} \cdot \mathbf{r} = t \bmod q \\ &\|\mathbf{W}\| \leq \beta_{\mathtt{w}}, \ \|\mathbf{Y}\| \leq \beta \end{cases}$$
+
+with parameters  $(k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \beta_{\mathtt{w}}, (n_i)_{i \in [k_{\mathtt{lin}}]}) = (1, 1, 0, m_{\mathtt{w}}, \rho, \beta_{\mathtt{w}}, (O(1))).$ 
+
+Composition. To build a succinct argument for the above  $\Xi^{\text{lin}}$  relation, we sequentially compose the coarse chain  $\Pi^{\text{lin}} \circ \Pi^{\text{fold-split}} \circ \Pi^{\text{proj-c}}$  at most  $O(\log_{\rho} m_{\text{w}} - \log_{\rho} \lambda)$  times to shrink  $m_{\text{w}}$  down to  $m'_{\text{w}} = O(n_{\text{rp}}) = O(\lambda)$ . We then sequentially compose the fine chain  $\Pi^{\text{lin}} \circ \Pi^{\text{fold-split}} \circ \Pi^{\text{proj-fl}}$  at most  $O(\log_{\rho} \lambda)$  times to further shrink  $m'_{\text{w}}$  down to  $m''_{\text{w}} = O(1)$ . For prover runtime, we consider only the runtime of the first chain since it dominates the remaining runtime. For verifier runtime and communication, we consider the sum of the two chains since they are of the same order. This costs in total  $O(\rho m_{\text{w}} \lambda + \rho \lambda^2) = O(\rho m_{\text{w}} \lambda)$  prover time,  $O(\rho \lambda^2 \log_{\rho} m_{\text{w}})$  verifier time and  $O(\log_{\rho}(m_{\text{w}}) \cdot (\log \lambda + \log m_{\text{w}}/\log \lambda))$  communication in  $\mathcal{R}_q$  elements (or equivalent). Since we assume that  $m_{\text{w}} \gg \lambda$ , the communication cost is dominated by  $O(\log_{\rho}(m_{\text{w}}) \cdot \log m_{\text{w}}/\log \lambda)$ .
+
+In Table 5, we summarise the complexity measures of our composed succinct argument for  $\Xi^{\mathsf{lin}}$  when instantiated with different shrink factors  $\rho$  ranging from a constant, e.g. 2, to slightly
+
+{41}------------------------------------------------
+
+<span id="page-41-1"></span>Table 6. Asymptotic comparison between PCS from [KLOT25] and our protocol for different shrink factors  $\rho$ . All measures are in  $O(\cdot)$  which is omitted. Proof sizes are given in bits, whereas prover and verifier times are given in number of  $\mathcal{R}_q$  operations (or equivalent). We consider asymptotic expression for the proof size in bits, since the rings used in the two constructions are different, and thus the proof size in  $\mathcal{R}_q$  elements can be misleading. In particular, the ring used in [KLOT25] is a cyclotomic ring  $\mathcal{R}'_q$  of degree  $O(\lambda \log m/\log \lambda)$ , whereas the ring used in our construction is  $\mathcal{R}_q$  of degree  $O(\lambda)$ . Modulus q is assumed to be of  $O(\log m)$  bits for both constructions, which is sufficient for the inner product argument from  $\Pi^{\text{fold-split}}$  (and its analogue in [KLOT25]) to work. We use m as a shortcut for the number of coefficients of the committed polynomial, which corresponds to  $m_w \cdot \rho$  in our construction. For our work, we include the optimisation of skipping the first  $\Pi^{\text{proj-c}}$  when slack is allowed, as mentioned in Remark 5, and apply the same optimisation to [KLOT25] for a fair comparison.
+
+| [KLOT25]                                                                                                                                    | Ours                                                                                                    |
+|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| $\rho = 2 \text{ Prover: } m\lambda$ $\text{Verifier: } \lambda^2 \log m$ $\text{Comm: } \lambda \log^3 m / \log \lambda$                   | Prover: $m\lambda$<br>Verifier: $\lambda^2 \log m$<br>Comm: $\lambda \log^3 m / \log \lambda$           |
+| $\rho = \lambda \text{ Prover: } m$ $\text{Verifier: } \lambda^3 \log m / \log \lambda$ $\text{Comm: } \lambda^2 \log^3 m / \log^2 \lambda$ | Prover: $m$<br>Verifier: $\lambda^3 \log m / \log \lambda$<br>Comm: $\lambda \log^3 m / \log^2 \lambda$ |
+
+sublinear, e.g.  $(m_{\tt w}\lambda)^{1/\log\log m_{\tt w}}$ . The value of  $\rho=\lambda$  best reflects the performance of our concrete implementation.
+
+Finally, we note that while the above focuses on  $\Xi^{\text{lin}}$  as the starting relation, a very similar exercise can be done with  $\Xi^{\text{sum}}$  as the starting relation which we leave to the reader.
+
+<span id="page-41-0"></span>Remark 5. While the example composition discussed above allows extracting a witness for  $\Xi_{\text{COM}}^{\text{lin}}$  without slack, applications of PCS can typically tolerate slack in the polynomial evaluation claim, when the committed polynomial is not required to have small coefficients. For those applications, the very first instance of  $\Pi^{\text{proj-c}}$  can be skipped. In this case, if  $\rho = \Omega(\lambda)$ , the prover runtime can be improved to  $O(m_{\text{w}}\lambda)$ .
+
+### <span id="page-41-2"></span>8.4 Comparison with [KLOT25]
+
+Table 6 summarises the asymptotic comparison between our composed succinct argument for  $\Xi^{\text{lin}}$  and the PCS construction from [KLOT25] for different shrink factors  $\rho$ . We are particularly interested in the case of SALSAA instantiated with  $\rho=2$  and our PCS instantiation with  $\rho=\lambda$ . We limit our focus to viewing the two constructions as PCS and use m to denote the number of coefficients of the committed polynomial, which corresponds to  $m_{\mathtt{w}} \cdot \rho$  in our construction.
+
+In this case, our prover runtime is asymptotically faster by a factor of  $\lambda$ , our proof size is asymptotically smaller by a factor of  $\log \lambda$ , and our verifier runtime is asymptotically larger by a factor of  $\lambda/\log \lambda$ . We note that the increased verifier runtime is mainly due to upper bounding the cost of operating on random projection constraints without exploiting their structure. In practice, these constraints, especially when expressed as sumcheck constraints (i.e. turned into evaluation claims), are susceptible to optimizations that can significantly reduce the verifier runtime, as we demonstrate in practical evaluation. We leave as an open question whether the asymptotic analysis can be tightened to reflect the practical performance of the verifier.
+
+{42}------------------------------------------------
+
+# <span id="page-42-0"></span>9 Implementation and Experiments
+
+As a baseline for our experiment, we consider the experiments conducted in [NS24]. We restrict our focus to the instantiation of polynomial commitments scheme for norm-bounded coefficients from  $\mathbb{Z}_q$  that we embed into ring elements.
+
+For the most optimal performance, we choose to work with power-of-two cyclotomic rings  $\mathcal{R} = \mathbb{Z}[\zeta_{\mathfrak{f}}]$  where  $\mathfrak{f} = 2^k$  for some integer k. Power-of-two cyclotomic rings admit efficient arithmetic using the Number-Theoretic Transform (NTT). We assume that cyclotomic ring "almost splits" modulo q, i.e.  $\mathcal{R}_q \cong (\mathbb{F}_{q^2})^{\varphi/2}$ . Contrary to the asymptotic analysis, we do not use the "lift-and-batch" technique described in Section A to further reduce communication cost, as the overhead of the additional rounds of interaction and the more complex protocol flow outweighs the benefits for our concrete parameters. In other words, for projections we use solely  $\Pi^{\mathsf{proj-c}}$  and  $\Pi^{\mathsf{proj-f}}$ . Also, using "almost-splitting" cyclotomic rings allows us to use  $\mathbb{F}_q^e$  (with e=2) as a challenge set and conveniently batch across the  $\varphi/e$  NTT slots. We select modulus  $q \approx 2^{50}$  so that the operations' runtime is further improved using AVX-512-IFMA instructions available on modern Intel processors (details to follow below).
+
+We operate over the f-th cyclotomic ring for  $\mathfrak{f}=256$  (i.e.  $\varphi=128$ ), observing that the higher degree typically implies better performance, in exchange for larger proof sizes. All benchmark suites are designed to prove a  $\Xi_{\mathsf{COM}}^{\mathsf{lin}}$  relation with random tensor-structured  $\mathbf{l}$  and  $\mathbf{r}$ , essentially equivalent to opening a multi-linear polynomial at a random point. Witness  $\ell_{\infty}$  norm is set to  $2^{31}$  (in balanced representation) to match the parameters used in [NS24].
+
+## <span id="page-42-2"></span>9.1 Approximate challenge sampling
+
+We select a modulus q such that  $\mathcal{R}_q \cong (\mathbb{F}_{q^2})^{\varphi/2}$ , i.e. our cyclotomic ring splits into factors of degree 2. This is because:
+
+- The knowledge error of the RoKs we use (e.g.  $\Pi^{\mathsf{proj-c}}$ ,  $\Pi^{\mathsf{proj-f}}$ ,  $\Pi^{\mathsf{lin}}$ ) is at least  $1/q^e$ , where e is the residue degree of the ring modulo q. If e=1, as in the case of fully splitting power-of-two cyclotomic rings, the knowledge error becomes too large.
+- − For  $\Pi^{\text{fold-split}}$  we require the existence of a low-norm challenge set [LS18, ALS20, BC25b] so that the inverse of any two elements is invertible. We require that the set is large enough to ensure a sufficiently small knowledge error and the operator norm of the challenges is small. Such set cannot exist if the ring fully splits as the largest subfield of such ring is  $\mathbb{Z}_q$  itself, which itself is not large enough to provide a sufficiently small knowledge error. In other work, e.g. [BS23, NS24], the issue is avoided by using "almost-not-splitting" cyclotomic rings, i.e. rings that split into factors of large degree. Then, as shown in [LS18], low-norm challenges' differences are always invertible. However, such rings do not support NTT-based multiplication directly, leading to a significant computational overhead<sup>17</sup>. We take a different approach and sample challenges so that the coefficients are sampled uniformly from the ternary set {−1,0,1}. The set of challenges with ternary coefficients is not a strong sampling set by definition, but the probability that the difference of two sampled challenges is non-invertible is small. More precisely, the probability of sampling two elements so that their difference is non-invertible is bounded in Lemma 32
+
+<span id="page-42-1"></span>To circumvent this issue, in [BS23, NS24] the arithmetic is "lifted" to a higher modulus and then projected back to the original ring.
+
+{43}------------------------------------------------
+
+$$\epsilon = \max_{j \in [k]} \left( \frac{1}{q} + \frac{1}{q} \sum_{t=1}^{q-1} \prod_{i=0}^{k-1} \left| p + (1-p) \cos \left( \frac{2\pi t r_j^i}{q} \right) \right| \right)^e,$$
+
+where p is the "bias" of the ternary distribution (i.e. the probability of sampling 0, in our case p = 1/3),  $r_j$  are the roots of  $\xi^{\varphi} + 1$  in  $\mathbb{Z}_q$ ,  $k = \varphi/e$  is the number of irreducible factors of  $\xi^{\varphi} + 1$  in  $\mathbb{Z}_q[X]$ , and e is the residue degree. These results serve as a direct generalisation of Lemma 3.2 of [ALS20]. Following the heuristic from Table 1 of [ALS20], we expect that the  $e \approx \varphi/eq^e$ . Therefore, while selecting  $q \approx 2^{50}$  such that  $q = \varphi + 1 \mod \mathfrak{f}$  so that e = 2 and setting p = 1/3, we expect that the probability of sampling a non-invertible element is around  $e^{-94}$ . More detailed, rigorous analysis of the probability of sampling non-invertible elements with ternary coefficients, together with supporting empirical evidence, is available in [GLLO26].
+
+### 9.2 Implementation details
+
+<span id="page-43-1"></span>Ring arithmetic. Our implementation is done in Rust. The heart of our implementation is efficient cyclotomic ring arithmetic, which is crucial for the performance of our protocols. As mentioned above, we select parameters so that our ring is "almost-splitting", i.e. it splits into factors of degree 2, which allows us to leverage the incomplete NTT for efficient polynomial multiplication: each slot contains a degree-1 residue polynomial  $(a_i + b_i X)$  in  $\mathbb{Z}_q[X]/(X^2 - \psi_i)$ , and multiplication reduces to  $\varphi/2$  independent products of such pairs.
+
+We provide two variants of the ring arithmetic implementation:
+
+The first variant uses Intel HEXL [BKS<sup>+</sup>21] via a foreign-function interface. Multiplication of degree- $\varphi$  cyclotomic ring elements in incomplete-NTT form is decomposed into 7 separate HEXL calls using the schoolbook formula: 5 element-wise modular multiplications and 2 element-wise modular additions, all operating on vectors of length  $\varphi/2$ . This variant can be viewed as a Rust re-implementation of the ring arithmetic from [CCC<sup>+</sup>25], designed for proof-friendly CKKS-like FHE schemes (with the distinction that we do not support RNS decomposition). In our benchmarks, this approach matches the performance of the original C++ implementation in [CCC<sup>+</sup>25].
+
+The second variant is based on our own pure-Rust re-implementation of the relevant subset of HEXL, targeting NTT-based arithmetic for moduli  $q \approx 2^{50}$ . The performance improvement over the first variant is twofold. First, we *fuse* the entire multiplication into a single AVX-512 kernel: instead of 7 separate passes over the data, our kernel performs a single pass that loads all inputs and writes both outputs per index, significantly reducing memory traffic. Even using the same schoolbook formula (5 modular multiplications per slot), this fusion alone yields a  $1.35-1.60\times$  speedup. Second, within the fused kernel we apply the Karatsuba identity  $(a_id_i+b_ic_i)=(a_i+b_i)(c_i+d_i)-a_ic_i-b_id_i$ , reducing the number of modular multiplications from 5 to 4 per slot at the cost of one additional modular additions and two modular subtractions. This provides an additional 2–5% improvement, for a combined speedup of  $1.36-1.63\times$  over the first variant (and thus also over [CCC<sup>+</sup>25]) across degrees  $\varphi \in \{2^7, 2^8, \dots, 2^{14}\}$ . The individual modular multiplications use the same Dekker-based floating-point technique as Intel HEXL, so the per-element arithmetic is identical; the speedup comes entirely from the improved memory access pattern and the reduced multiplication count<sup>18</sup>.
+
+We remark that these observations, although presented in general terms, have been concretely verified in our benchmarks conducted on the same hardware as the rest of our experiments (see
+
+<span id="page-43-0"></span>Details of the comparison with [CCC<sup>+</sup>25] and the performance of the fused kernel are available at: https://github.com/lattice-arguments/rokoko/blob/main/benches/comparison\_ckks.md
+
+{44}------------------------------------------------
+
+below). That being said, our benchmarking machine features a mid-range mobile CPU. Nonconsumer workstations, servers, or cloud CPUs with different microarchitectures may exhibit different performance characteristics – for instance, larger L1 caches may reduce the relative benefit of our fused kernel, different AVX-512 implementations may shift absolute throughput, and less aggressive frequency downscaling under AVX-512 workloads could further improve performance. We leave a more detailed analysis across different microarchitectures for future work.
+
+We have open-sourced our ring arithmetic implementation as an independent library[19](#page-44-0). The library is thoroughly tested and benchmarked, and primarily consists of a re-implementation of the relevant subset of Intel HEXL, enhanced with our fused kernel and Karatsuba optimization. We chose to develop our own implementation rather than modify the original HEXL codebase to avoid the overhead of foreign-function calls between Rust and C++, and to have greater flexibility in applying optimizations. Our re-implementation (within the set of overlapping functionalities) achieves performance on par with the original HEXL.
+
+Projection arithmetic. For projections, both coarse and fine variant, we rely on highly-efficient intrinsics from the AVX-512 instruction set to implement the required matrix-vector multiplications, taking advantage of the structure of the projection matrices (for both prover and verifier side). In projections, we deliberately delay using modular reduction as much as possible, allowing us to perform multiple additions and multiplications before reducing the results modulo q, which leads to significant performance improvements.
+
+Platform and portability. Due to the level of optimizations, we limited our focus on Intel microarchitectures with AVX-512-IFMA support, which are widely available in modern Intel CPUs. HEXL does not support any other microarchitectures, except x86-64. Our independent implementation of the ring arithmetic, does not inherit this limitation and can be executed on any microarchitecture supported by Rust, albeit with a significant performance degradation.
+
+<span id="page-44-2"></span>Non-interactivity and testing. To obtain non-interactive arguments, we implement the Fiat-Shamir transform using the BLAKE3 hash function [\[OANWO20\]](#page-50-15). Our implementation is single-threaded to provide a fair comparison with prior work [\[NS24\]](#page-50-5) and is intensively tested using unit tests to ensure correctness.
+
+## <span id="page-44-1"></span>9.3 Parameters selection
+
+We select parameters to achieve λ = 128 security against known attacks listed in Lattice Estimator [\[APS15\]](#page-47-18). Our codebase is equipped with an "estimator" mode, which allows us to easily experiment with different parameters. Prover, while executed in the "estimator" mode, outputs the estimated security level, accounting for the norm growth during the extraction process. For statistical soundness, we set overall soundness error κ ≈ 2 <sup>−</sup><sup>80</sup> (mainly impacted by the size of NTT slots) following the industry standards. While heuristically ignoring the impact of the union bound (which is a common practice used e.g. in [\[BS23,](#page-48-3)[NS24\]](#page-50-5)), the soundness error is around 2−<sup>100</sup> .
+
+Our parameters are selected in semi-manual fashion, by preparing the configuration for all test suites. Then, we run the test suites in "estimator" mode and adjust the parameters accordingly.
+
+To reduce communication, we deviate slightly from the protocol description and allow the prover to perform even more aggressive norm decomposition on the "final level" of the recursive
+
+<span id="page-44-0"></span><sup>19</sup> Available at: <https://github.com/lattice-arguments/rokoko/tree/main/incomplete-rexl>
+
+{45}------------------------------------------------
+
+commitment. Then, a separate proof for the norm of the final level is provided (as an additional constraint in fsc). This allows us to reduce the rank of the final level significantly, leading to smaller proof sizes.
+
+## 9.4 Experiments
+
+Our experiments were performed on the following hardware and software configuration:
+
+<span id="page-45-1"></span>Table 7. Experimental setup
+
+| Component | Specification                                   |
+|-----------|-------------------------------------------------|
+| Processor | 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz  |
+| Cache     | 256KiB L1 cache, 10MiB L2 cache, 24MiB L3 cache |
+| Memory    | 64GiB System Memory                             |
+|           | Operating System Ubuntu 24.04.3 LTS x86 64      |
+| Machine   | Precision 7560                                  |
+| Compilers | Rust 1.95.0-nightly, g++ 13.3.0                 |
+| Execution | Single-threaded                                 |
+
+The results of our benchmarks are summarised in Table [1.](#page-5-0) We compare the performance of our implementation with the results from [\[NS24,](#page-50-5)[KLOT25\]](#page-49-9), which were obtained on the same hardware configuration. Values for the remaining SNARKs (where the concrete performance gaps are too significant to be attributed to architectural advantages) are taken from the original papers, and we refer the reader to those papers for details of their experimental setups.
+
+The codebase for our implementation, including the benchmarks, is available at: [https://github.](https://github.com/lattice-arguments/rokoko) [com/lattice-arguments/rokoko](https://github.com/lattice-arguments/rokoko).
+
+## 9.5 Towards a general-usage library
+
+We consider our work as an ongoing effort towards building a general-purpose library for lattice-based succinct arguments. We outline several directions for future work.
+
+- (a) For the sake of this work, we restricted our focus to the PCS-like relations. However, our sumcheck implementation is done in a highly-modular fashion, allowing us to easily plug in different relations as the first step of the reductions chain, which we view as a step towards building a general-purpose library for lattice-based succinct arguments.
+- (b) Our current API is restricted to calls to the functions within the same process. A natural extension is to support serialisation/deserialization of proofs, enabling network communication between prover and verifier.
+- (c) The parameters are hard-coded in the codebase and picked semi-manually. An important direction is to support dynamic parameter selection, allowing users to specify security levels and other parameters at runtime.
+- <span id="page-45-0"></span>(d) The proof size can be further optimised by applying a simpler protocol, i.e. [\[KLOT25\]](#page-49-9), [\[KLNO25\]](#page-49-8) or [\[BS23\]](#page-48-3), for the last rounds of the protocol execution, where the witness size is already significantly reduced.
+
+{46}------------------------------------------------
+
+<span id="page-46-0"></span>(e) Our ring arithmetic implementation is optimised for power-of-two cyclotomic rings, splitting into degree-2 factors. A natural direction is to extend the implementation to support more general rings, or more concretely, to extend support for splitting into degree-4 factors, which would allow us to further reduce the knowledge error. With the intention of still using the "native" (i.e. without defining an auxiliary, fully splitting, composite modulus and then projecting back to the original ring) approach, we expect that the performance degradation for the prover would be at most 1.4× (since around half time is spent on the element-wise multiplications, which would be slower by a factor of at most 1.8× following the numbers from [\[CCC](#page-48-19)+25]) and the verifier performance would negligibly degrade (since the verifier spends most of the time batching the "fine" projections with Z<sup>q</sup> challenges, which would be unaffected by the change of the ring).
+
+{47}------------------------------------------------
+
+# References
+
+- <span id="page-47-1"></span>AAB<sup>+</sup>24. Marius A. Aardal, Diego F. Aranha, Katharina Boudgoust, Sebastian Kolby, and Akira Takahashi. Aggregating falcon signatures with LaBRADOR. In Leonid Reyzin and Douglas Stebila, editors, CRYPTO 2024, Part I, volume 14920 of LNCS, pages 71–106. Springer, Cham, August 2024. [1](#page-0-0)
+- <span id="page-47-0"></span>ABPS24. Shahla Atapoor, Karim Baghery, Hilder V. L. Pereira, and Jannik Spiessens. Verifiable FHE via lattice-based SNARKs. CiC, 1(1):24, 2024. [1](#page-0-0)
+- <span id="page-47-9"></span>ACFY24. Gal Arnon, Alessandro Chiesa, Giacomo Fenzi, and Eylon Yogev. STIR: Reed-solomon proximity testing with fewer queries. In Leonid Reyzin and Douglas Stebila, editors, CRYPTO 2024, Part X, volume 14929 of LNCS, pages 380–413. Springer, Cham, August 2024. [1.1](#page-2-1)
+- <span id="page-47-10"></span>ACFY25. Gal Arnon, Alessandro Chiesa, Giacomo Fenzi, and Eylon Yogev. WHIR: Reed-solomon proximity testing with super-fast verification. In Serge Fehr and Pierre-Alain Fouque, editors, EUROCRYPT 2025, Part IV, volume 15604 of LNCS, pages 214–243. Springer, Cham, May 2025. [1.1,](#page-2-1) [1.3,](#page-4-0) [1](#page-5-0)
+- <span id="page-47-3"></span>ACK21. Thomas Attema, Ronald Cramer, and Lisa Kohl. A compressed Σ-protocol theory for lattices. In Tal Malkin and Chris Peikert, editors, CRYPTO 2021, Part II, volume 12826 of LNCS, pages 549–579, Virtual Event, August 2021. Springer, Cham. [1.1,](#page-1-0) [1.1](#page-1-2)
+- <span id="page-47-7"></span>AFLN24. Martin R. Albrecht, Giacomo Fenzi, Oleksandra Lapiha, and Ngoc Khanh Nguyen. SLAP: Succinct lattice-based polynomial commitments from standard assumptions. In Marc Joye and Gregor Leander, editors, EUROCRYPT 2024, Part VII, volume 14657 of LNCS, pages 90–119. Springer, Cham, May 2024. [1.1](#page-2-1)
+- <span id="page-47-13"></span>AHIV17. Scott Ames, Carmit Hazay, Yuval Ishai, and Muthuramakrishnan Venkitasubramaniam. Ligero: Lightweight sublinear arguments without a trusted setup. In Bhavani M. Thuraisingham, David Evans, Tal Malkin, and Dongyan Xu, editors, ACM CCS 2017, pages 2087–2104. ACM Press, October / November 2017. [1](#page-5-0)
+- <span id="page-47-11"></span>AHIV23. Scott Ames, Carmit Hazay, Yuval Ishai, and Muthuramakrishnan Venkitasubramaniam. Ligero: lightweight sublinear arguments without a trusted setup. DCC, 91(11):3379–3424, 2023. [1.3](#page-4-0)
+- <span id="page-47-5"></span>Ajt96. Mikl´os Ajtai. Generating hard instances of lattice problems (extended abstract). In 28th ACM STOC, pages 99–108. ACM Press, May 1996. [1.1](#page-2-2)
+- <span id="page-47-2"></span>AL21. Martin R. Albrecht and Russell W. F. Lai. Subtractive sets over cyclotomic rings - limits of Schnorr-like arguments over lattices. In Tal Malkin and Chris Peikert, editors, CRYPTO 2021, Part II, volume 12826 of LNCS, pages 519–548, Virtual Event, August 2021. Springer, Cham. [1.1,](#page-1-0) [1.1](#page-1-2)
+- <span id="page-47-14"></span>ALS20. Thomas Attema, Vadim Lyubashevsky, and Gregor Seiler. Practical product proofs for lattice commitments. In Daniele Micciancio and Thomas Ristenpart, editors, CRYPTO 2020, Part II, volume 12171 of LNCS, pages 470–499. Springer, Cham, August 2020. [1.3,](#page-5-1) [9.1](#page-42-2)
+- <span id="page-47-18"></span>APS15. Martin Albrecht, Rachel Player, and Sam Scott. On the concrete hardness of learning with errors. Journal of Mathematical Cryptology, 9:169–203, 10 2015. [https://github.com/malb/lattice-estimator/tree/](https://github.com/malb/lattice-estimator/tree/66771ec3d331e2021eccf17331a5ed1ff71f3ddb) [66771ec3d331e2021eccf17331a5ed1ff71f3ddb](https://github.com/malb/lattice-estimator/tree/66771ec3d331e2021eccf17331a5ed1ff71f3ddb). [9.3](#page-44-1)
+- <span id="page-47-8"></span>BBHR18. Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. Fast reed-solomon interactive oracle proofs of proximity. In Ioannis Chatzigiannakis, Christos Kaklamanis, D´aniel Marx, and Donald Sannella, editors, ICALP 2018, volume 107 of LIPIcs, pages 14:1–14:17. Schloss Dagstuhl, July 2018. [1.1,](#page-2-1) [1.3,](#page-4-0) [1](#page-5-0)
+- <span id="page-47-16"></span>BC25a. Dan Boneh and Binyi Chen. LatticeFold: A lattice-based folding scheme and its applications to succinct proof systems. In Goichiro Hanaoka and Bo-Yin Yang, editors, ASIACRYPT 2025, Part III, volume 16247 of LNCS, pages 330–362. Springer, Singapore, December 2025. [1.3](#page-5-2)
+- <span id="page-47-17"></span>BC25b. Dan Boneh and Binyi Chen. LatticeFold+: Faster, simpler, shorter lattice-based folding for succinct proof systems. In Yael Tauman Kalai and Seny F. Kamara, editors, CRYPTO 2025, Part VII, volume 16006 of LNCS, pages 327–361. Springer, Cham, August 2025. [1.3,](#page-5-2) [9.1](#page-42-2)
+- <span id="page-47-15"></span>BCFW25. Benedikt B¨unz, Alessandro Chiesa, Giacomo Fenzi, and William Wang. Linear-time accumulation schemes. Cryptology ePrint Archive, Report 2025/753, 2025. [1.3](#page-5-2)
+- <span id="page-47-12"></span>BCR<sup>+</sup>19. Eli Ben-Sasson, Alessandro Chiesa, Michael Riabzev, Nicholas Spooner, Madars Virza, and Nicholas P. Ward. Aurora: Transparent succinct arguments for R1CS. In Yuval Ishai and Vincent Rijmen, editors, EUROCRYPT 2019, Part I, volume 11476 of LNCS, pages 103–128. Springer, Cham, May 2019. [1.3](#page-4-0)
+- <span id="page-47-4"></span>BCS21. Jonathan Bootle, Alessandro Chiesa, and Katerina Sotiraki. Sumcheck arguments and their applications. In Tal Malkin and Chris Peikert, editors, CRYPTO 2021, Part I, volume 12825 of LNCS, pages 742–773, Virtual Event, August 2021. Springer, Cham. [1.1,](#page-1-0) [1.1](#page-1-2)
+- <span id="page-47-6"></span>BCS23. Jonathan Bootle, Alessandro Chiesa, and Katerina Sotiraki. Lattice-based succinct arguments for NP with polylogarithmic-time verification. In Helena Handschuh and Anna Lysyanskaya, editors, CRYPTO 2023, Part II, volume 14082 of LNCS, pages 227–251. Springer, Cham, August 2023. [1.1,](#page-2-1) [B.1](#page-52-1)
+
+{48}------------------------------------------------
+
+- <span id="page-48-7"></span>BFS20. Benedikt B¨unz, Ben Fisch, and Alan Szepieniec. Transparent SNARKs from DARK compilers. In Anne Canteaut and Yuval Ishai, editors, EUROCRYPT 2020, Part I, volume 12105 of LNCS, pages 677–706. Springer, Cham, May 2020. [1.3](#page-4-0)
+- <span id="page-48-1"></span>BK20. Dan Boneh and Sam Kim. One-time and interactive aggregate signatures from lattices. [https://crypto.](https://crypto.stanford.edu/~skim13/agg_ots.pdf) [stanford.edu/~skim13/agg\\_ots.pdf](https://crypto.stanford.edu/~skim13/agg_ots.pdf), 2020. [1](#page-0-0)
+- <span id="page-48-18"></span>BKS<sup>+</sup>21. Fabian Boemer, Sejun Kim, Gelila Seifu, Fillipe D. M. de Souza, and Vinodh Gopal. Intel HEXL: Accelerating homomorphic encryption with intel AVX512-IFMA52. Cryptology ePrint Archive, Report 2021/420, 2021. [9.2](#page-43-1)
+- <span id="page-48-4"></span>BL17. Carsten Baum and Vadim Lyubashevsky. Simple amortized proofs of shortness for linear relations over polynomial rings. Cryptology ePrint Archive, Report 2017/759, 2017. [1.1](#page-2-2)
+- <span id="page-48-17"></span>BL25. Katharina Boudgoust and Oleksandra Lapiha. Leftover hash lemma(s) over cyclotomic rings. Cryptology ePrint Archive, Report 2025/1080, 2025. [9.1](#page-42-2)
+- <span id="page-48-2"></span>BLNS20. Jonathan Bootle, Vadim Lyubashevsky, Ngoc Khanh Nguyen, and Gregor Seiler. A non-PCP approach to succinct quantum-safe zero-knowledge. In Daniele Micciancio and Thomas Ristenpart, editors, CRYPTO 2020, Part II, volume 12171 of LNCS, pages 441–469. Springer, Cham, August 2020. [1.1](#page-1-0)
+- <span id="page-48-9"></span>BLS19. Jonathan Bootle, Vadim Lyubashevsky, and Gregor Seiler. Algebraic techniques for short(er) exact latticebased zero-knowledge proofs. In Alexandra Boldyreva and Daniele Micciancio, editors, CRYPTO 2019, Part I, volume 11692 of LNCS, pages 176–202. Springer, Cham, August 2019. [1.3](#page-5-1)
+- <span id="page-48-11"></span>BMNW25a. Benedikt B¨unz, Pratyush Mishra, Wilson Nguyen, and William Wang. Accumulation without homomorphism. In Raghu Meka, editor, ITCS 2025, volume 325, pages 23:1–23:25. LIPIcs, January 2025. [1.3](#page-5-2)
+- <span id="page-48-12"></span>BMNW25b. Benedikt B¨unz, Pratyush Mishra, Wilson Nguyen, and William Wang. Arc: Accumulation for reedsolomon codes. In Yael Tauman Kalai and Seny F. Kamara, editors, CRYPTO 2025, Part VII, volume 16006 of LNCS, pages 128–160. Springer, Cham, August 2025. [1.3](#page-5-2)
+- <span id="page-48-3"></span>BS23. Ward Beullens and Gregor Seiler. LaBRADOR: Compact proofs for R1CS from module-SIS. In Helena Handschuh and Anna Lysyanskaya, editors, CRYPTO 2023, Part V, volume 14085 of LNCS, pages 518–548. Springer, Cham, August 2023. [1.1,](#page-2-2) [4,](#page-2-0) [1.1,](#page-3-0) [1.2,](#page-4-1) [2.1,](#page-6-2) [5.1,](#page-17-2) [5,](#page-17-1) [10,](#page-18-0) [6,](#page-25-0) [9.1,](#page-42-2) [17,](#page-42-1) [9.3,](#page-44-1) [\(d\)](#page-45-0)
+- <span id="page-48-19"></span>CCC<sup>+</sup>25. Ignacio Cascudo, Anamaria Costache, Daniele Cozzo, Dario Fiore, Antonio Guimar˜aes, and Eduardo Soria-Vazquez. Verifiable computation for approximate homomorphic encryption schemes. In Yael Tauman Kalai and Seny F. Kamara, editors, CRYPTO 2025, Part VII, volume 16006 of LNCS, pages 643–677. Springer, Cham, August 2025. [9.2,](#page-43-1) [18,](#page-43-0) [\(e\)](#page-46-0)
+- <span id="page-48-16"></span>Cha13. Ioannis Chatzigeorgiou. Bounds on the lambert function and their application to the outage analysis of user cooperation. IEEE Communications Letters, 17(8):1505–1508, 2013. [8.1](#page-36-2)
+- <span id="page-48-8"></span>CHM<sup>+</sup>20. Alessandro Chiesa, Yuncong Hu, Mary Maller, Pratyush Mishra, Psi Vesely, and Nicholas P. Ward. Marlin: Preprocessing zkSNARKs with universal and updatable SRS. In Anne Canteaut and Yuval Ishai, editors, EUROCRYPT 2020, Part I, volume 12105 of LNCS, pages 738–768. Springer, Cham, May 2020. [1.3](#page-4-0)
+- <span id="page-48-5"></span>CLM23. Valerio Cini, Russell W. F. Lai, and Giulio Malavolta. Lattice-based succinct arguments from vanishing polynomials - (extended abstract). In Helena Handschuh and Anna Lysyanskaya, editors, CRYPTO 2023, Part II, volume 14082 of LNCS, pages 72–105. Springer, Cham, August 2023. [1.1,](#page-2-1) [2.1,](#page-6-2) [1](#page-11-0)
+- <span id="page-48-6"></span>CMNW24. Valerio Cini, Giulio Malavolta, Ngoc Khanh Nguyen, and Hoeteck Wee. Polynomial commitments from lattices: Post-quantum security, fast verification and transparent setup. In Leonid Reyzin and Douglas Stebila, editors, CRYPTO 2024, Part X, volume 14929 of LNCS, pages 207–242. Springer, Cham, August 2024. [1.1,](#page-2-1) [1](#page-5-0)
+- <span id="page-48-15"></span>CN11. Yuanmi Chen and Phong Q. Nguyen. BKZ 2.0: Better lattice security estimates. In Dong Hoon Lee and Xiaoyun Wang, editors, ASIACRYPT 2011, volume 7073 of LNCS, pages 1–20. Springer, Berlin, Heidelberg, December 2011. [8.1](#page-35-3)
+- <span id="page-48-13"></span>CT10. Alessandro Chiesa and Eran Tromer. Proof-carrying data and hearsay arguments from signature cards. In Andrew Chi-Chih Yao, editor, ICS 2010, pages 310–331. Tsinghua University Press, January 2010. [1.3](#page-5-2)
+- <span id="page-48-10"></span>FKNP24. Giacomo Fenzi, Christian Knabenhans, Ngoc Khanh Nguyen, and Duc Tu Pham. Lova: Lattice-based folding scheme from unstructured lattices. In Kai-Min Chung and Yu Sasaki, editors, ASIACRYPT 2024, Part IV, volume 15487 of LNCS, pages 303–326. Springer, Singapore, December 2024. [1.3](#page-5-2)
+- <span id="page-48-14"></span>FMN24. Giacomo Fenzi, Hossein Moghaddas, and Ngoc Khanh Nguyen. Lattice-based polynomial commitments: Towards asymptotic and concrete efficiency. Journal of Cryptology, 37(3):31, July 2024. [6,](#page-25-0) [6,](#page-26-0) [6](#page-29-0)
+- <span id="page-48-0"></span>GBK<sup>+</sup>24. Mariana Gama, Emad Heydari Beni, Jiayi Kang, Jannik Spiessens, and Frederik Vercauteren. Blind zkSNARKs for private proof delegation and verifiable computation over encrypted data. Cryptology ePrint Archive, Report 2024/1684, 2024. [1](#page-0-0)
+
+{49}------------------------------------------------
+
+- <span id="page-49-13"></span>GGPR13. Rosario Gennaro, Craig Gentry, Bryan Parno, and Mariana Raykova. Quadratic span programs and succinct NIZKs without PCPs. In Thomas Johansson and Phong Q. Nguyen, editors, EUROCRYPT 2013, volume 7881 of LNCS, pages 626–645. Springer, Berlin, Heidelberg, May 2013. [1.3](#page-4-0)
+- <span id="page-49-6"></span>GHL22. Craig Gentry, Shai Halevi, and Vadim Lyubashevsky. Practical non-interactive publicly verifiable secret sharing with thousands of parties. In Orr Dunkelman and Stefan Dziembowski, editors, EU-ROCRYPT 2022, Part I, volume 13275 of LNCS, pages 458–487. Springer, Cham, May / June 2022. [1.1](#page-2-2)
+- <span id="page-49-19"></span>GLLO26. Albert Garreta, Helger Lipmaa, Urmas Luha¨a¨ar, and Micha l Osadnik. Cyclo: Lightweight lattice-based folding via partial range checks. Cryptology ePrint Archive, Paper 2026/359, 2026. To appear in Proceedings of EUROCRYPT 2026. [9.1](#page-42-2)
+- <span id="page-49-14"></span>GLS<sup>+</sup>23. Alexander Golovnev, Jonathan Lee, Srinath T. V. Setty, Justin Thaler, and Riad S. Wahby. Brakedown: Linear-time and field-agnostic SNARKs for R1CS. In Helena Handschuh and Anna Lysyanskaya, editors, CRYPTO 2023, Part II, volume 14082 of LNCS, pages 193–226. Springer, Cham, August 2023. [1.3,](#page-4-0) [1](#page-5-0)
+- <span id="page-49-11"></span>Gro16. Jens Groth. On the size of pairing-based non-interactive arguments. In Marc Fischlin and Jean-S´ebastien Coron, editors, EUROCRYPT 2016, Part II, volume 9666 of LNCS, pages 305–326. Springer, Berlin, Heidelberg, May 2016. [1.3](#page-4-0)
+- <span id="page-49-3"></span>GSW23. Riddhi Ghosal, Amit Sahai, and Brent Waters. Non-interactive publicly-verifiable delegation of committed programs. In Alexandra Boldyreva and Vladimir Kolesnikov, editors, PKC 2023, Part II, volume 13941 of LNCS, pages 575–605. Springer, Cham, May 2023. [1](#page-0-0)
+- <span id="page-49-12"></span>GWC19. Ariel Gabizon, Zachary J. Williamson, and Oana Ciobotaru. PLONK: Permutations over Lagrange-bases for oecumenical noninteractive arguments of knowledge. Cryptology ePrint Archive, Report 2019/953, 2019. [1.3](#page-4-0)
+- <span id="page-49-15"></span>HSS24. Intak Hwang, Jinyeong Seo, and Yongsoo Song. Concretely efficient lattice-based polynomial commitment from standard assumptions. In Leonid Reyzin and Douglas Stebila, editors, CRYPTO 2024, Part X, volume 14929 of LNCS, pages 414–448. Springer, Cham, August 2024. [1](#page-5-0)
+- <span id="page-49-0"></span>Kil92. Joe Kilian. A note on efficient zero-knowledge proofs and arguments (extended abstract). In 24th ACM STOC, pages 723–732. ACM Press, May 1992. [1](#page-0-0)
+- <span id="page-49-17"></span>KLNO24a. Michael Klooß, Russell W. F. Lai, Ngoc Khanh Nguyen, and Micha l Osadnik. RoK, paper, SISsors – toolkit for lattice-based succinct arguments. Cryptology ePrint Archive, Report 2024/1972, 2024. [2](#page-10-1)
+- <span id="page-49-7"></span>KLNO24b. Michael Klooß, Russell W. F. Lai, Ngoc Khanh Nguyen, and Michal Osadnik. RoK, paper, SISsors toolkit for lattice-based succinct arguments - (extended abstract). In Kai-Min Chung and Yu Sasaki, editors, ASIACRYPT 2024, Part V, volume 15488 of LNCS, pages 203–235. Springer, Singapore, December 2024. [1.1,](#page-2-1) [2.1,](#page-6-2) [3.4,](#page-12-2) [2,](#page-12-3) [6,](#page-25-0) [8](#page-35-0)
+- <span id="page-49-8"></span>KLNO25. Michael Klooß, Russell W. F. Lai, Ngoc Khanh Nguyen, and Michal Osadnik. RoK and roll - verifierefficient random projection for O˜(λ)-size lattice arguments - (extended abstract). In Goichiro Hanaoka and Bo-Yin Yang, editors, ASIACRYPT 2025, Part III, volume 16247 of LNCS, pages 297–329. Springer, Singapore, December 2025. [1.1,](#page-2-1) [1.2,](#page-4-1) [1,](#page-5-0) [2.1,](#page-6-2) [2.2,](#page-7-0) [1,](#page-10-2) [5,](#page-16-0) [5.3,](#page-24-0) [6,](#page-25-0) [8,](#page-35-0) [\(d\),](#page-45-0) [A](#page-51-0)
+- <span id="page-49-9"></span>KLOT25. Shuto Kuriyama, Russell W. F. Lai, Micha l Osadnik, and Lorenzo Tucci. SALSAA – sumcheck-aided lattice-based succinct arguments and applications. Cryptology ePrint Archive, Paper 2025/2124, 2025. [1.1,](#page-2-1) [1.2,](#page-4-1) [1,](#page-5-0) [2.1,](#page-6-2) [2.2,](#page-8-1) [2.3,](#page-8-2) [2.3,](#page-9-0) [8,](#page-35-0) [6,](#page-41-1) [8.4,](#page-41-2) [9.4,](#page-45-1) [\(d\)](#page-45-0)
+- <span id="page-49-1"></span>KP16. Yael Tauman Kalai and Omer Paneth. Delegating RAM computations. In Martin Hirt and Adam D. Smith, editors, TCC 2016-B, Part II, volume 9986 of LNCS, pages 91–118. Springer, Berlin, Heidelberg, October / November 2016. [1](#page-0-0)
+- <span id="page-49-18"></span>KP23. Abhiram Kothapalli and Bryan Parno. Algebraic reductions of knowledge. In Helena Handschuh and Anna Lysyanskaya, editors, CRYPTO 2023, Part IV, volume 14084 of LNCS, pages 669–701. Springer, Cham, August 2023. [3.4](#page-12-2)
+- <span id="page-49-16"></span>KST21. Abhiram Kothapalli, Srinath Setty, and Ioanna Tzialla. Nova: Recursive zero-knowledge arguments from folding schemes. Cryptology ePrint Archive, Report 2021/370, 2021. [1.3](#page-5-2)
+- <span id="page-49-2"></span>Lee21. Jonathan Lee. Dory: Efficient, transparent arguments for generalised inner products and polynomial commitments. In Kobbi Nissim and Brent Waters, editors, TCC 2021, Part II, volume 13043 of LNCS, pages 1–34. Springer, Cham, November 2021. [1](#page-0-0)
+- <span id="page-49-10"></span>LFKN92. Carsten Lund, Lance Fortnow, Howard Karloff, and Noam Nisan. Algebraic methods for interactive proof systems. J. ACM, 39(4):859–868, October 1992. [1.1](#page-2-1)
+- <span id="page-49-4"></span>LLZ<sup>+</sup>25. Fengrun Liu, Haofei Liang, Tianyu Zhang, Yuncong Hu, Xiang Xie, Haisheng Tan, and Yu Yu. HasteBoots: Proving FHE bootstrapping in seconds. Cryptology ePrint Archive, Report 2025/261, 2025. [1](#page-0-0)
+- <span id="page-49-5"></span>LM23. Russell W. F. Lai and Giulio Malavolta. Lattice-based timed cryptography. In Helena Handschuh and Anna Lysyanskaya, editors, CRYPTO 2023, Part V, volume 14085 of LNCS, pages 782–804. Springer, Cham, August 2023. [1](#page-0-0)
+
+{50}------------------------------------------------
+
+- <span id="page-50-4"></span>LNP22. Vadim Lyubashevsky, Ngoc Khanh Nguyen, and Maxime Plan¸con. Lattice-based zero-knowledge proofs and applications: Shorter, simpler, and more general. In Yevgeniy Dodis and Thomas Shrimpton, editors, CRYPTO 2022, Part II, volume 13508 of LNCS, pages 71–101. Springer, Cham, August 2022. [1.1,](#page-2-2) [1.3](#page-5-1)
+- <span id="page-50-3"></span>LNS21. Vadim Lyubashevsky, Ngoc Khanh Nguyen, and Gregor Seiler. Shorter lattice-based zero-knowledge proofs via one-time commitments. In Juan Garay, editor, PKC 2021, Part I, volume 12710 of LNCS, pages 215–241. Springer, Cham, May 2021. [1.1](#page-2-2)
+- <span id="page-50-10"></span>LNSW13. San Ling, Khoa Nguyen, Damien Stehl´e, and Huaxiong Wang. Improved zero-knowledge proofs of knowledge for the ISIS problem, and applications. In Kaoru Kurosawa and Goichiro Hanaoka, editors, PKC 2013, volume 7778 of LNCS, pages 107–124. Springer, Berlin, Heidelberg, February / March 2013. [1.3](#page-5-1)
+- <span id="page-50-14"></span>LS18. Vadim Lyubashevsky and Gregor Seiler. Short, invertible elements in partially splitting cyclotomic rings and applications to lattice-based zero-knowledge proofs. In Jesper Buus Nielsen and Vincent Rijmen, editors, EUROCRYPT 2018, Part I, volume 10820 of LNCS, pages 204–224. Springer, Cham, April / May 2018. [9.1](#page-42-2)
+- <span id="page-50-8"></span>MBKM19. Mary Maller, Sean Bowe, Markulf Kohlweiss, and Sarah Meiklejohn. Sonic: Zero-knowledge SNARKs from linear-size universal and updatable structured reference strings. In Lorenzo Cavallaro, Johannes Kinder, XiaoFeng Wang, and Jonathan Katz, editors, ACM CCS 2019, pages 2111–2128. ACM Press, November 2019. [1.3](#page-4-0)
+- <span id="page-50-0"></span>Mic94. Silvio Micali. CS proofs (extended abstracts). In 35th FOCS, pages 436–453. IEEE Computer Society Press, November 1994. [1](#page-0-0)
+- <span id="page-50-13"></span>MR09. Daniele Micciancio and Oded Regev. Lattice-based Cryptography, pages 147–191. Springer Berlin Heidelberg, Berlin, Heidelberg, 2009. [8.1](#page-35-3)
+- <span id="page-50-5"></span>NS24. Ngoc Khanh Nguyen and Gregor Seiler. Greyhound: Fast polynomial commitments from lattices. In Leonid Reyzin and Douglas Stebila, editors, CRYPTO 2024, Part X, volume 14929 of LNCS, pages 243–275. Springer, Cham, August 2024. [1.1,](#page-2-2) [1.1,](#page-3-0) [1.2,](#page-4-1) [1,](#page-5-0) [2.3,](#page-9-0) [9,](#page-42-0) [9.1,](#page-42-2) [17,](#page-42-1) [9.2,](#page-44-2) [9.3,](#page-44-1) [9.4](#page-45-1)
+- <span id="page-50-11"></span>NS25. Wilson Nguyen and Srinath Setty. Neo: Lattice-based folding scheme for CCS over small fields and pay-per-bit commitments. Cryptology ePrint Archive, Report 2025/294, 2025. [1.3](#page-5-2)
+- <span id="page-50-15"></span>OANWO20. Jack O'Connor, Jean-Philippe Aumasson, Samuel Neves, and Zooko Wilcox-O'Hearn. Blake3: the high-speed cryptographic hash, 2020. [9.2](#page-44-2)
+- <span id="page-50-2"></span>OKC<sup>+</sup>25. Michal Osadnik, Darya Kaviani, Valerio Cini, Russell W. F. Lai, and Giulio Malavolta. Papercraft: Lattice-based verifiable delay function implemented. In Marina Blanton, William Enck, and Cristina Nita-Rotaru, editors, 2025 IEEE Symposium on Security and Privacy, pages 1603–1621. IEEE Computer Society Press, May 2025. [1,](#page-0-0) [1](#page-5-0)
+- <span id="page-50-6"></span>PHGR13. Bryan Parno, Jon Howell, Craig Gentry, and Mariana Raykova. Pinocchio: Nearly practical verifiable computation. In 2013 IEEE Symposium on Security and Privacy, pages 238–252. IEEE Computer Society Press, May 2013. [1.3](#page-4-0)
+- <span id="page-50-12"></span>Val08. Paul Valiant. Incrementally verifiable computation or proofs of knowledge imply time/space efficiency. In Ran Canetti, editor, TCC 2008, volume 4948 of LNCS, pages 1–18. Springer, Berlin, Heidelberg, March 2008. [1.3](#page-5-2)
+- <span id="page-50-7"></span>WTs<sup>+</sup>18. Riad S. Wahby, Ioanna Tzialla, abhi shelat, Justin Thaler, and Michael Walfish. Doubly-efficient zkSNARKs without trusted setup. In 2018 IEEE Symposium on Security and Privacy, pages 926–943. IEEE Computer Society Press, May 2018. [1.3](#page-4-0)
+- <span id="page-50-9"></span>XZZ<sup>+</sup>19. Tiancheng Xie, Jiaheng Zhang, Yupeng Zhang, Charalampos Papamanthou, and Dawn Song. Libra: Succinct zero-knowledge proofs with optimal prover computation. In Alexandra Boldyreva and Daniele Micciancio, editors, CRYPTO 2019, Part III, volume 11694 of LNCS, pages 733–764. Springer, Cham, August 2019. [1.3](#page-4-0)
+- <span id="page-50-1"></span>ZLW<sup>+</sup>25. Zhelei Zhou, Yun Li, Yuchen Wang, Zhaomin Yang, Bingsheng Zhang, Cheng Hong, Tao Wei, and Wenguang Chen. ZHE: Efficient zero-knowledge proofs for HE evaluations. In Marina Blanton, William Enck, and Cristina Nita-Rotaru, editors, 2025 IEEE Symposium on Security and Privacy, pages 3328–3346. IEEE Computer Society Press, May 2025. [1](#page-0-0)
+
+{51}------------------------------------------------
+
+# <span id="page-51-0"></span>A Committed Fine Random Projection with "Lift-and-Batch"
+
+As discussed in Section 5.3, the RoK  $\Pi^{\text{proj-f}}$  presented in Fig. 3 ultimately results in a communication cost of  $\widetilde{\Omega}(\lambda^2)$   $\mathcal{R}_q$  elements when composed. To reduce communication cost to  $\widetilde{O}(\lambda)$   $\mathcal{R}_q$  elements, an idea borrowed from the unstructured projection protocol of [KLNO25] is to assume and exploit a d-smooth tower structure of  $\mathcal{R}$ , i.e. assume that
+
+$$\mathcal{R} = \mathcal{R}_c \supset \mathcal{R}_{c-1} \supset \cdots \supset \mathcal{R}_1 \supset \mathcal{R}_0 = \mathbb{Z}$$
+. and  $[\mathcal{R}_{i+1} : \mathcal{R}_i] \leq d$ .
+
+The trick is to gradually lift the trace value from  $\mathcal{R}_i$  to  $\mathcal{R}_{i+1}$ , while simultaneously applying batch verification to reduce the elements in  $\mathcal{R}_i$  to fewer elements in  $\mathcal{R}_{i+1}$ , and so on.
+
+More concretely, consider the prover computing  $\mathbf{r}_0 = \mathbf{r} \in \mathcal{R}^{n_{\text{bat},0}}$  as in Fig. 3. Instead of sending  $\mathbf{r}_0$  in plain, which would be expensive, they send its trace relative to  $\mathcal{R}_0 = \mathbb{Z}$  and receives from the verifier a random challenge  $\mathbf{Z}_0 \in \mathcal{R}_0^{n_{\text{bat},1} \times n_{\text{bat},0}}$ . Using the challenge, prover batches  $\mathbf{r}_0 \in \mathcal{R}^{n_{\text{bat},0}}$  into  $\mathbf{r}_1 \in \mathcal{R}^{n_{\text{bat},1}}$  and sends its trace relative to  $\mathcal{R}_1$ . Continuing in this way, the prover eventually arrives at  $\mathbf{r}_c \in \mathcal{R}_c^{n_{\text{bat},c}}$  where  $\mathcal{R}_c = \mathcal{R}$ , which is small enough to be sent in plain. For suitable choices of parameters, the sketched protocol has O(1) communication complexity measured in  $\mathcal{R}_q$  elements.
+
+To ensure soundness of batching, we further require that each intermediate extension  $\mathcal{R}_i$  admits a "relatively large" subfield modulo q. Concretely, we write  $\mathcal{Q}_i = \mathcal{R}_i/(q\mathcal{R}_i) \cong (\mathbb{F}_{q^{e_i}})^{\varphi_i/e_i}$ . Given  $n_{\mathsf{bat},i+1}$  rows in  $\mathbf{Z}_i$ , we can manage to lose a knowledge error proportional to  $1/q^{e_i n_{\mathsf{bat},i+1}}$  for each i. For favourable rings, e.g. if some intermediate  $\mathcal{Q}_i$  is a field of size  $2^{-\lambda}$ , we observe that communication for the batching phase is bounded by  $c|\mathcal{R}_q|$ , where c is the tower height.
+
+Due to complexity of the notation and the fundamental similarity to the unstructured projections in [KLNO25], we omit the full protocol description and analysis here. The envisioned protocol follows the same structure as Fig. 3, with more stages of batching and lifting interleaved as described in [KLNO25].
+
+We will refer to this protocol as  $\Pi^{\mathsf{proj-fl}}$  in the asymptotic analysis. We do not use that protocol in our concrete instantiations (or rather, we view  $\Pi^{\mathsf{proj-fl}}$  as a special case of  $\Pi^{\mathsf{proj-fl}}$  with tower height c=1).
+
+<span id="page-51-1"></span>**Lemma 12.** Let  $\mathcal{R} = \mathcal{R}_c \supset \ldots \supset \mathcal{R}_0 = \mathbb{Z}$  be a tower of rings and  $\mathbf{n}_{\mathsf{bat}} = (n_{\mathsf{bat},0},\ldots,n_{\mathsf{bat},c}) \in \mathbb{N}^{c+1}$  be batching parameters. Let  $\mathbf{e} \in \mathbb{N}^{c+1}$  be the vector of extension degrees, i.e.  $\mathbf{e}^{\mathsf{T}} = (e_0,\ldots,e_c)$  where  $e_i$  is the residue degree of q in  $\mathcal{R}_i$ . Let  $\ell,\ell' \in \mathbb{N}$  be gadget decomposition parameters and  $\mathsf{par}_{\mathsf{com}}$ ,  $\mathsf{par}'_{\mathsf{com}}$  be parameters for COM so that  $\beta_{\mathsf{x}} = \beta_{\mathsf{x}}[\mathsf{par}_{\mathsf{com}}]$  and  $\beta'_{\mathsf{x}} = \beta_{\mathsf{x}}[\mathsf{par}'_{\mathsf{com}}]$ . Let  $m_{\mathsf{rp}}|\varphi m_{\mathsf{w}}$ . The  $\mathsf{RoK}\ \Pi^{\mathsf{proj-fl}}_{n_{\mathsf{bat}},\ell,\ell',\mathsf{par}_{\mathsf{com}},\mathsf{par}'_{\mathsf{com}}}$  satisfies the following properties:
+
+- It is  $\epsilon$ -complete, with  $\epsilon = (\varphi m_{\mathtt{w}}/m_{\mathtt{rp}})\kappa_{\mathtt{rp}}$ , for  $\Xi_{\mathsf{COM}}^{\mathsf{lin}} \to \Xi_{\mathsf{COM}}^{\mathsf{lin}}$  with parameter changes
+
+$$k_{\text{lin}} \mapsto k_{\text{lin}} + 2,$$
+  $n \mapsto n + n_{\text{bat},c}$ 
+
+where  $(n_i, \mathsf{par}_{\mathsf{com},i}, m_{\mathsf{y},i}, \beta_{\mathsf{x},i}, \beta_{\mathsf{y},i})$  for  $i \in \{k_{\mathsf{lin}}, k_{\mathsf{lin}} + 1\}$  is given by
+
+$$\begin{cases} \left(0, \mathsf{par}_{\mathsf{com}}, \ell m \frac{n_{\mathsf{rp}}}{m_{\mathsf{rp}}}, \beta_{\mathsf{x}}, \mathsf{dcmp}_{\ell}(\beta_{\mathsf{rp}} \cdot \beta_{\mathsf{w}})\right) & i = k_{\mathsf{lin}}, \\ (n_{\mathsf{bat},c}, \mathsf{par}'_{\mathsf{com}}, \ell' n_{\mathsf{bat},c}, \beta'_{\mathsf{x}}, \mathsf{dcmp}_{\ell'}(q/2)) & i = k_{\mathsf{lin}} + 1. \end{cases}$$
+
+- It is  $\kappa$ -knowledge-sound, with
+
+$$\kappa = \sum_{i \in [c]} (n_{\mathtt{bat},i}/q^{e_i})^{n_{\mathtt{bat},i+1}} + (\varphi r m_{\mathtt{W}}/m_{\mathtt{rp}}) \kappa_{\mathtt{rp}},$$
+
+{52}------------------------------------------------
+
+for
+
+$$\begin{split} &\mathcal{\Xi}^{\mathsf{sis}}[\mathsf{par}_{\mathtt{sis}}] \vee \mathcal{\Xi}^{\mathsf{lin}}_{\mathsf{COM}} \begin{bmatrix} k_{\mathtt{lin}}, k_{\mathtt{lr}}, n, m_{\mathtt{w}}, r, \mathsf{cmp}(\beta'_{\mathtt{y}, k_{\mathtt{lin}}}) / \alpha_{\mathtt{rp}}, \\ (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta'_{\mathtt{x}, i}, \beta'_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}}]} \end{bmatrix} \\ \leftarrow \mathcal{\Xi}^{\mathsf{lin-rel}}_{\mathsf{COM}} \begin{bmatrix} k_{\mathtt{lin}} + 2, k_{\mathtt{lr}}, n + n_{\mathtt{bat}, c}, m_{\mathtt{w}}, r, \beta'_{\mathtt{w}}, \\ (n_i, \mathsf{par}_{\mathtt{com}, i}, m_{\mathtt{y}, i}, \beta'_{\mathtt{x}, i}, \beta'_{\mathtt{y}, i})_{i \in [k_{\mathtt{lin}} + 2]}, \varrho'. \end{bmatrix} \end{split}$$
+
+where
+
+$$\mathsf{par}_{\mathtt{sis}} \supseteq \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},k_{\mathtt{lin}}}, m_{\mathtt{y},k_{\mathtt{lin}}}, \beta'_{\mathtt{y},k_{\mathtt{lin}}}, \beta'_{\mathtt{x},k_{\mathtt{lin}}}] \\ \cup \mathsf{par}_{\mathtt{break}}[\mathsf{par}_{\mathtt{com},k_{\mathtt{lin}}+1}, m_{\mathtt{y},k_{\mathtt{lin}}+1}, \beta'_{\mathtt{y},k_{\mathtt{lin}}+1}, \beta'_{\mathtt{x},k_{\mathtt{lin}}+1}] \cup \{(n_0, m_{\mathtt{w}}, \gamma_{\mathcal{C}} \cdot \beta'_{\mathtt{w}} \varrho')\}$$
+
+- It has the following efficiency measures:
+  - Prover runtime:  $O(m_{\mathbf{w}}rn_{\mathbf{rp}}\varphi)$   $\mathbb{Z}$  operations,  $O\left(\sum_{i\in[c]}n_{\mathsf{bat},i}mr\right)$   $\mathcal{R}_q$  operations and the cost of computing  $\mathsf{com}_{k_{\mathsf{lin}}}$  and  $\mathsf{com}_{k_{\mathsf{lin}}+1}$ .
+  - Verifier runtime:  $O(n_{pmrp})$  samplings from  $\chi$ ,  $O(n_{bat,0} \log(\varphi r m_w/m_{pp}))$  samplings from  $\mathbb{Z}_q$ ,  $O(n_{bat,i+1})$  samplings from  $\mathcal{R}_{i+1,q}$  for  $i \in [c-1]$ , and  $O(n_{bat,c})$   $\mathcal{R}_q$  operations.
+  - Prover-to-verifier communication:  $|com_{k_{lin}}| + |com_{k_{lin}+1}| + \sum_{i \in [c]} O(n_{bat,i} \cdot \log |\mathcal{R}_{c,q}|)$ .
+
+# <span id="page-52-0"></span>B Generic sumcheck
+
+We recall sumchecks and expand on their use with NTT-based batching over  $\mathbb{F}_{q^e}$ , as applied in Section 7.
+
+## <span id="page-52-1"></span>B.1 Basic sumcheck
+
+We follow the sumcheck notion for modules from [BCS23], which we briefly recall. Let M be a (commutative) R-module. Let  $g \in M[\mathsf{x}_0, \ldots, \mathsf{x}_{\ell-1}] = M[\mathsf{x}]$  be a polynomial with coefficients in M. Let  $\mathcal{C} \subseteq R$  be a set with invertible differences in R, a.k.a. strong sampling set. Let  $H \subseteq R$ , usually  $H = \{0, 1\}$ 
+
+The usual sumcheck language consists of tuples
+
+$$\mathsf{stmt} = (g,y) \in M[\mathsf{x}_0, \dots, \mathsf{x}_{\ell-1}] \times M \quad \text{with} \quad \sum_{\mathbf{x} \in H^\ell} g(\mathbf{x}) = y$$
+
+However, we generalise it slightly, by introducing a " $\mathcal{C}$ -linear" map<sup>20</sup>  $\Phi: N \to M$ , i.e.  $\Phi(a \cdot c) = \Phi(a) \cdot c$  for all  $a \in N$  and  $c \in \mathcal{C}$ . Hence, our sumcheck language  $\Xi_{R,N,M,\mathcal{C},\ell}^{\mathsf{sc}}$  consists of tuples  $\mathsf{stmt} = (\Phi,g,y)$  such that
+
+- $-\Phi: N \to M$  is a C-linear map;
+- $-g \in N[\mathsf{x}_0,\ldots,\mathsf{x}_{\ell-1}] = N[\mathsf{x}]$  is a polynomial with coefficients in N;
+- $-y = \Phi(\sum_{\mathbf{x} \in H^{\ell}} g(\mathbf{x}))$  is the summation claim.
+
+If unspecified, we assume M=N,  $\Phi=\operatorname{id}$  and  $H=\{0,1\}$ . The sumcheck protocol is a reduction (of knowledge) from  $\Xi_{R,N,M,\mathcal{C},H,\ell}^{\operatorname{sc}}$  to a polynomial evaluation claim  $\Xi_{R,N,M,\mathcal{C},H,\ell}^{\operatorname{polyeval}}$ , where  $\Xi_{R,N,M,\mathcal{C},H,\ell}^{\operatorname{polyeval}}$  consists of statements  $\operatorname{stmt}=(\Phi,g,\mathbf{c},v)$  such that
+
+<span id="page-52-2"></span>More mathematically, C-linear for the subring  $C \subseteq R$  generated by  $\mathcal{C}$ .
+
+{53}------------------------------------------------
+
+$$\begin{array}{ll} \displaystyle \frac{\mathsf{P}(\mathsf{par},\mathsf{stmt})}{\mathsf{parse}} & \displaystyle \frac{\mathsf{V}(\mathsf{par},\mathsf{stmt})}{\mathsf{parse}} \\ & \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad \qquad$$
+
+<span id="page-53-0"></span>Fig. 7. The basic sumcheck protocol (supporting a C-linear map Φ).
+
+- Φ: N → M is a C-linear map;
+- g ∈ N[x0, . . . , xℓ−1] = N[x] is a polynomial with coefficients in N;
+- c ∈ C<sup>ℓ</sup> is a vector of (random) challenges;
+- v = Φ(g(c)) is the evaluation claim.
+
+In the following, we usually leave the languages Ξsc and Ξpolyeval implicit, as they will always be clear from the context (namely from f and the stated sum over f). Moreover, if N = R, M = C = F ⊆ R, H = {0, 1} we use the shorthand notation
+
+$$\varXi_{R,\mathbb{F},\ell}^{\mathsf{sc}} \coloneqq \varXi_{R,N,M,\mathcal{C},\ell}^{\mathsf{sc}} \quad \text{and} \quad \varXi_{R,\mathbb{F},\ell}^{\mathsf{polyeval}} \coloneqq \varXi_{R,N,M,\mathcal{C},H,\ell}^{\mathsf{polyeval}}.$$
+
+<span id="page-53-1"></span>We give formal statements for the sumcheck protocol next.
+
+Definition 4 (Basic sumcheck with linear map). Let R be a non-trivial ring, N, M be Rmodules, C ⊆ R be a subset with invertible difference (a.k.a. strong sampling set) and H = {0, 1}. Let g ∈ N[x1, . . . , x<sup>ℓ</sup> ] and y ′ ∈ M. Let Φ: N → M be an "C-linear" map (i.e. Φ(a · c) = Φ(a) · c for all a ∈ N, c ∈ C). The sumcheck protocol in Fig. [7](#page-53-0) with C-linear map Φ is a public-coin reduction of knowledge from a summation claim
+
+$$\mathsf{stmt} = (\varPhi, g, y) \quad \textit{where} \quad \varPhi\left(\sum_{(x_0, \dots, x_{\ell-1}) \in H^\ell} g(x_0, \dots, x_{\ell-1})\right) = y$$
+
+to an evaluation claim Φ(g(c)) = v, i.e.
+
+$$\mathsf{stmt} = (\varPhi, g, \mathbf{c}, v) \in \varXi_{R,N,M,\mathcal{C},\ell}^{\mathsf{polyeval}}$$
+
+where c = (c0, . . . , cℓ−1) ∈ C<sup>ℓ</sup> are the verifier's challenges.
+
+Remark 6. The basic sumcheck verifier does not need access to g; one-time evaluation access c 7→ Φ(g(c)) suffices to run the verification. More abstractly, it suffices to convince the verifier that Φ(g(c)) = v via a polynomial evaluation proof.
+
+{54}------------------------------------------------
+
+We include the linear map  $\Phi$  in the sumcheck protocol to capture batch-verification techniques, in particular to make batch verification with the NTT isomorphism  $\mathcal{R}_q \cong \mathbb{F}_{q^e}^{\varphi/e}$  more explicit.
+
+Remark 7 (Eliminating the linear map  $\Phi$ ). For any  $\Phi: N \to M$ , we can define  $\Phi(g) \in M[\mathbf{x}]$ , which is obtained from  $g \in M[\mathbf{x}]$  by coefficient-wise application of  $\Phi$ . For  $\mathcal{C}$ -linear  $\Phi$ , it is easy to see that  $\Phi(g(\mathbf{c})) = \Phi(g)(\mathbf{c})$ . A brief inspection then shows that the sumcheck protocol for  $(\Phi, g, y)$  (that reduces to  $(\Phi, g, \mathbf{c}, y_0)$ ) is equivalent to a standard sumcheck for  $(\mathsf{id}, \Phi(g), \mathbf{c}, y_0)$ ).
+
+<span id="page-54-0"></span>**Lemma 13.** The sumcheck protocol with linear map  $\Phi$  is a perfectly correct reduction of knowledge. For an instance  $\Phi: N \to M$ ,  $g \in N[\mathsf{x}_0, \ldots, \mathsf{x}_{\ell-1}]$ ,  $y \in M$  as in Definition 4, the (knowledge) soundness error  $\kappa$  is bounded by  $\kappa \leq \frac{\sum_{i \in [\ell]} \deg_{\mathsf{x}_i}(g)}{|\mathcal{C}|} \leq \frac{\ell \deg(g)}{|\mathcal{C}|}$ , where  $\deg(g)$  denotes the maximal individual degree.
+
+The communication consists of  $\sum_{i \in [\ell]} (\deg_{\mathsf{x}_i}(g) + 1)$  elements in M from the prover,  $\ell$  challenges in  $\mathcal{C}$  from the verifier. Assuming the prover has access to the evaluation table of g on  $H^\ell$ , the prover performs  $O\left(\frac{d}{|H|-1} \cdot |H|^\ell\right)$  operations in N and  $\sum_{i \in [\ell]} (\deg_{\mathsf{x}_i}(g) + 1)$  applications of  $\Phi$ , where  $d = \max_i \deg_{\mathsf{x}_i}(g)$ . The computation of the verifier is dominated by evaluating  $\ell$  polynomials of degrees  $\deg_{\mathsf{x}_i}(g)$ , respectively, at |H| points.
+
+*Proof.* Perfect correctness follows by the direct inspection of the protocol: if  $\Phi(\sum_{\mathbf{x}\in H^{\ell}} g(\mathbf{x})) = y$  holds, then each partial sum  $q_i$  is correctly computed and all verifier checks pass. For soundness, we observe that since  $\Phi$  is  $\mathcal{C}$ -linear, the round polynomials  $q_i(\mathbf{x}) \in M[\mathbf{x}]$  have the same individual degree bounds as in the standard (i.e.  $\Phi = \mathrm{id}$ ) sumcheck, so the Schwartz–Zippel argument applies directly to the  $q_i$ 's.
+
+In every round, the verifier gets the partially evaluated sum  $q_i(x)$ , asserts that  $\sum_{x \in H} q_i(x) = y_{i-1}$ , and randomly assigns  $x_i$  with  $c_i$ . If a (partial) summation claim is false, say  $y_{i-1}^* \neq y_{i-1}$ , then  $\sum_{x \in H} q_i(x) = y_{i-1}$  only holds if the prover's message  $q_i^*(x)$  differs from the honestly computed  $q_i(x)$  of the current round. Then  $q_i(c_i) = y_i \neq q_i^*(c_i)$  except with probability at most  $\frac{\deg_{x_i}(g)}{|\mathcal{C}|}$  by the Schwartz-Zippel lemma. (To apply Schwartz-Zippel, we need the invertible difference property of  $\mathcal{C}$ , which ensures unique interpolation even if R is not a field.)
+
+For the prover's runtime, we use the standard bookkeeping technique. Before round i, the prover maintains a table  $T_i: H^{\ell-i} \to N$  of size  $|H|^{\ell-i}$ , defined by
+
+$$T_i(x_i,\ldots,x_{\ell-1})=q(c_0,\ldots,c_{i-1},x_i,\ldots,x_{\ell-1}).$$
+
+The initial table  $T_0$  is the evaluation of g on  $H^{\ell}$ , which is given by assumption. In round i, the prover must determine the univariate polynomial
+
+$$q_i^{\circ}(\mathsf{x}) \coloneqq \sum_{(x_{i+1},\dots,x_{\ell-1})\in H^{\ell-i-1}} g(c_0,\dots,c_{i-1},\mathsf{x},x_{i+1},\dots,x_{\ell-1}) \in N[\mathsf{x}]$$
+
+of degree  $d_i = \deg_{\mathsf{x}_i}(g)$ , and then set  $q_i = \Phi \circ q_i^{\circ}$ . Since  $q_i^{\circ}$  has degree  $d_i$ , it is determined by its values at any  $d_i + 1$  points. For each  $\alpha \in H$ , the value  $q_i^{\circ}(\alpha)$  is obtained by summing the  $|H|^{\ell-i-1}$  table entries  $T_i(\alpha, x_{i+1}, \ldots, x_{\ell-1})$ . For each of the remaining  $d_i + 1 - |H|$  evaluation points  $\alpha \notin H$ , the value  $g(c_0, \ldots, c_{i-1}, \alpha, x_{i+1}, \ldots, x_{\ell-1})$  is obtained for every  $(x_{i+1}, \ldots, x_{\ell-1})$  by interpolating the |H| stored values in the variable  $\mathsf{x}_i$ , at cost  $O(d_i)$  per tuple. Hence, computing  $q_i^{\circ}$  costs  $O(d_i \cdot |H|^{\ell-i-1})$ 
+
+{55}------------------------------------------------
+
+operations in N. After receiving  $c_i$ , the prover updates the table to  $T_{i+1}$  by evaluating the univariates at  $c_i$ , at the same asymptotic cost. Summing over all rounds with  $d = \max_i d_i$ ,
+
+$$\sum_{i=0}^{\ell-1} O(d \cdot |H|^{\ell-i-1}) = O\left(d \cdot \sum_{j=0}^{\ell-1} |H|^j\right) = O\left(\frac{d}{|H|-1} \cdot |H|^\ell\right),$$
+
+where the geometric series is dominated by its largest term, showing that the total cost is at most a factor  $\frac{|H|}{|H|-1}$  over the first round alone. Additionally,  $\Phi$  is applied  $\sum_i (d_i + 1)$  times in total to produce the messages  $q_i = \Phi \circ q_i^{\circ}$ .
+
+### B.2 Exploiting ring structure and NTT
+
+By the Chinese Remainder Theorem, the splitting of the cyclotomic polynomial  $\Phi_{\mathfrak{f}}$  modulo q into  $\varphi/e$  irreducible factors of degree e induces a ring isomorphism NTT:  $\mathcal{R}_q \to \mathbb{F}_{q^e}^{\varphi/e}$ .
+
+Let  $M = \mathcal{R}_q$  and let  $\mathcal{R} \cong \mathbb{F}_{q^e}^{\varphi/e}$  be the NTT decomposition. Write  $\mathbb{F} = \mathbb{F}_{q^e}$  as a shorthand. Observe that all operations in sumcheck are algebraic. Hence, by applying NTT:  $\mathcal{R} \to \mathbb{F}^{\varphi/e}$ , we can run sumcheck over  $\mathbb{F}^{\varphi/e}$  (with component-wise operations). If we need the resulting claim over  $\mathcal{R}$ , it can be recovered via NTT<sup>-1</sup>.
+
+Switching to the NTT domain increases our implementation efficiency. In fact, we can further optimise the sumcheck by running it over  $\mathbb{F}$  instead of  $\mathbb{F}^{\varphi/e}$ . For this, we assume that  $\mathcal{C} \subseteq \mathbb{F}$ . Then, we can view  $M = \mathcal{R} = \mathbb{F}^{\varphi/e}$  as a  $\mathbb{F}$ -vector space of dimension  $\varphi/e$ . By choosing a suitable random  $\mathbb{F}$ -linear map  $\Phi \colon \mathbb{F}^{\varphi/e} \to \mathbb{F}$ , we can replace the sumcheck claim
+
+$$\sum_{\mathbf{x}\in H^n} g(\mathbf{x}) = y \in \mathbb{F}^{\varphi/e}$$
+
+with the batched version
+
+$$\Phi\left(\sum_{\mathbf{x}\in H^n}g(\mathbf{x})\right)=\Phi(y)$$
+
+This is a reduction of knowledge with soundness error depending on the choice of  $\Phi$ .
+
+- For  $\Phi$  defined as  $\Phi : \boldsymbol{\delta}^{\mathtt{T}} \circ \mathsf{NTT}$  for uniformly random  $\boldsymbol{\delta} \leftarrow \mathbb{F}^{\varphi/e}$ , the knowledge error is  $\frac{1}{|\mathbb{F}|} = q^{-e}$ .
+- For random tensor product, i.e.  $\Phi_i = \operatorname{eq}(\operatorname{bin}(i), \mathbf{r})$  where  $\mathbf{r} \leftarrow \mathbb{F}^{\lceil \log(\varphi/e) \rceil}$ , the knowledge error is  $\frac{\lceil \log(\varphi/e) \rceil}{|\mathbb{F}|} = q^{-e} \cdot \lceil \log(\varphi/e) \rceil$ .
+
+Both claims are consequences of the Schwartz-Zippel lemma.
+
+The sumcheck reduction with random  $\Phi$  reduces the summation claim (over  $\mathcal{R}_q \cong \mathbb{F}_{q^e}^{\varphi/e}$ ) to an evaluation claim  $\Phi(g(\mathbf{c})) = v$ , where  $v \in \mathbb{F}$  and  $\mathbf{c} \in \mathbb{F}$  are the verifier's random challenges. As our expressions are of the form  $g(\mathbf{c}) = f(\mathsf{MLE}[\mathbf{w}], \mathsf{MLE}[\overline{\mathbf{w}}])(\mathbf{c})$  for  $f \in (R[\mathbf{z}])[\mathsf{x}_0, \mathsf{x}_1]$ , we find:
+
+$$\varPhi(f(\mathsf{MLE}[\mathbf{w}],\mathsf{MLE}[\overline{\mathbf{w}}]))(\mathbf{c}) = \varPhi(f(\mathsf{MLE}[\mathbf{w}],\mathsf{MLE}[\overline{\mathbf{w}}])(\mathbf{c})) = \varPhi(g(\mathbf{c})) = v.$$
+
+In particular, for any  $\mathbf{c} \in \mathbb{F}_{q^e}^{\mathsf{len}(\mathbf{z})} \subseteq \mathcal{R}_q^{\mathsf{len}(\mathbf{z})}$ , this expression can be verified as  $\Phi(f(z_0, z_1)(\mathbf{c}))$  given  $z_0 = \mathsf{MLE}[\mathbf{w}](\mathbf{c})$  and  $z_1 = \mathsf{MLE}[\overline{\mathbf{w}}](\mathbf{c})$ , where the claimed equalities for  $z_0, z_1$  may be delegated to the prover again, while exploiting the identity
+
+$$z_1 = \mathsf{MLE}[\overline{\mathbf{w}}](\mathbf{c}) \iff \overline{z_1} = \mathsf{MLE}[\mathbf{w}](\overline{\mathbf{c}}).$$

--- a/data/markdown/eprint/2026_575/2026_575_meta.json
+++ b/data/markdown/eprint/2026_575/2026_575_meta.json
@@ -1,0 +1,44 @@
+{
+  "eprint": {
+    "title": "RoKoko: Lattice-based Succinct Arguments, a Committed Refinement",
+    "authors": [
+      {
+        "name": "Michael Klooss",
+        "email": "klooss@kit",
+        "affiliation": ""
+      },
+      {
+        "name": "Russell W. F. Lai",
+        "email": "lai@aalto",
+        "affiliation": ""
+      },
+      {
+        "name": "Ngoc Khanh Nguyen",
+        "email": "nguyen@kcl",
+        "affiliation": ""
+      },
+      {
+        "name": "Michał Osadnik",
+        "email": "osadnik@aalto",
+        "affiliation": ""
+      },
+      {
+        "name": "Lorenzo Tucci",
+        "email": "tucci@aalto",
+        "affiliation": ""
+      }
+    ],
+    "abstract": "We present RoKoko, a new lattice-based succinct argument system that achieves a linear-time prover alongside polylogarithmic communication and verifier complexity. Asymptotically, our construction improves upon RoK and Roll (ASIACRYPT 2025), the first post-quantum SNARK with $\\tilde{O}(\\lambda)$ proof size, by a multiplicative factor of $\\Theta(\\log \\lambda)$. Practically, our system yields proofs of roughly $200$KB, while outperforming the state-of-the-art polynomial commitment scheme Greyhound (CRYPTO 2024) with a $100\\times$ faster verification time, similar prover time, and competitive proof size. Our framework natively supports (tensor-)structured relations, such as polynomial evaluation and sumcheck relations.\r\n\r\nAt a high level, our construction follows the recursive split-and-fold paradigm: the prover first splits the witness into $\\rho$ sub-witnesses, sends the corresponding cross-terms, and then folds them into a single witness that is shorter by a factor of $\\rho$ using verifier challenges. Prior works typically restrict $\\rho = O(1)$ to preserve succinct verification and maintain the optimal $\\tilde{O}(\\lambda)$ proof size. We overcome this “constant barrier”, which enables larger $\\rho$ and thereby reduces the proof size. To achieve this, we introduce the following technical contributions.\r\n\r\n(i) Committed folding. Instead of sending $O(\\rho)$ cross-terms in the clear, the prover commits to the messages and later proves that the committed vector satisfies the verification relations. This enables the use of a larger shrinking factor, thereby reducing the number of recursion rounds. While this strategy has been successfully used in LaBRADOR (CRYPTO 2023), additional care is required here to preserve succinct verification.\r\n(ii) Recursive commitments. We generalise the double-commitment technique from LaBRADOR into a framework for recursive commitments, yielding further compression in commitment size. This results in concrete improvements in communication within each recursion round.\r\n(iii) Sumcheck-driven structured recursion. We extend the sumcheck framework from SALSAA (ePrint 2025/2124) to prove substantially more complex constraints arising in our construction (and open for future extensions), including correctness of random projections, inner-product claims and well-formedness of recursive commitments. While expressing these constraints as sumcheck relations requires considerable technical effort, the resulting protocols compose seamlessly with the structured recursion, yielding both linear-time proving and succinct verification.",
+    "keywords": [
+      "lattice",
+      "SNARK",
+      "avx-512",
+      "PCS"
+    ],
+    "category": "Cryptographic protocols",
+    "publication_info": "Preprint.",
+    "last_updated": "2026-04-23",
+    "license": "CC BY",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2026_575/conversion_info.json
+++ b/data/markdown/eprint/2026_575/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "modal-marker",
+  "converted_at": "2026-04-25T14:37:46.320321+00:00",
+  "elapsed_seconds": 382.44,
+  "pdf_sha256": "a4411e08baa503817bf6074cd27c38428770be3083f42d353dde575130fa5752",
+  "source_pdf": "2026_575.pdf",
+  "output_path": "2026_575/2026_575.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "modal",
+    "os": "Linux",
+    "os_version": "4.4.0",
+    "arch": "x86_64",
+    "python_version": "3.12.10",
+    "cpu_count": 17,
+    "provider": "modal",
+    "gpu_count": 1,
+    "gpu_name": "NVIDIA A100-SXM4-40GB",
+    "gpu_vram_mb": 40441,
+    "cuda_version": "12.8"
+  },
+  "estimated_cost_usd": 0.117027
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2026/575

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit a16329b)
Website: https://papyrus.badaas.eu