### PR TITLE
Add markdown for 2026/480

### DIFF
--- a/data/markdown/eprint/2026_480/2026_480.md
+++ b/data/markdown/eprint/2026_480/2026_480.md
@@ -1,0 +1,1186 @@
+
+
+{0}------------------------------------------------
+
+## Chopin: Optimal Pairing-Based Multilinear Polynomial Commitments from Bivariate KZG
+
+Juraj Belohorec1,<sup>2</sup> [,](https://orcid.org/0009-0004-3677-0530) Pavel Hubáček1,<sup>2</sup> [,](https://orcid.org/0000-0002-6850-6222) Aleksi Kalsta3,<sup>4</sup> [,](https://orcid.org/0009-0000-6295-2574) and Kristýna Mašková1,[2](https://orcid.org/0009-0003-7982-0190)
+
+- 1 Institute of Mathematics, Czech Academy of Sciences, Prague, Czech Republic {belohorec,hubacek,maskova}@math.cas.cz
+- <sup>2</sup> Charles University, Faculty of Mathematics and Physics, Prague, Czech Republic <sup>3</sup> VTT Technical Research Centre of Finland
+
+aleksi.kalsta@vtt.fi <sup>4</sup> Aalto University, Finland
+
+Abstract. We present Chopin, a pairing-based multilinear polynomial commitment scheme (PCS) achieving constant proof size and a linear time prover, constructed modularly from a bivariate PCS. Chopin generalizes the recent compilers from univariate to multilinear PCS Mercury (Eagen and Gabizon, ePrint 2025/385) and Samaritan (Ganesh, Patranabis, and Singh, ASIACRYPT 2025). Due to its modular design, we obtain a direct proof of knowledge soundness via a reduction to the knowledge soundness of the underlying bivariate PCS in the standard model. In particular, our analysis avoids idealized models such as the Algebraic Group Model.
+
+When instantiated with the bivariate KZG scheme (Papamanthou, Shi, and Tamassia, TCC 2013), Chopin achieves similar proof size to Mercury and Samaritan while offering a two-fold speedup in prover time, which arises because Chopin requires only a single large MSM proportional to the size of the committed multilinear polynomial, in contrast to the two large MSMs required by the prior works, at the cost of one additional pairing for the verifier.
+
+Keywords: Polynomial Commitment Schemes · KZG · Multilinear · Proof Batching.
+
+## 1 Introduction
+
+Polynomial Commitment Schemes (PCSs) are a core building block of modern practical SNARKs, enabling the compilation of information-theoretic Polynomial Interactive Oracle Proofs (PIOPs) into succinct arguments. For sumcheck-based systems like Spartan [\[Set20\]](#page-31-0) and HyperPlonk [\[CBBZ23\]](#page-30-0), the efficiency of the PCS is paramount: it dictates the proof size, verification cost, and the prover's computational overhead. Specifically, the move towards linear-time SNARKs relies entirely on the existence of a multilinear PCS that supports fast commitments and openings. Consequently, improvements in multilinear PCS translate directly into end-to-end gains for these practical proof systems.
+
+The quest for linear-time commitments. There are two principal directions for constructing a multilinear PCS in the literature. The first, exemplified by the multivariate KZG analogue [\[PST13\]](#page-31-1), commits directly in the multivariate setting. This yields a fast prover but suffers from proof sizes that grow linearly with the number of variables. The second, used by Gemini [\[BCHO22\]](#page-30-1) and Zeromorph [\[KT24\]](#page-31-2), compiles multilinear claims into univariate ones. This achieves succinct proofs but typically incurs quasi-linear prover overhead due to complex basis changes.
+
+The state of the art and the quotient bottleneck. Recently, Mercury [\[EG25\]](#page-31-3) and Samaritan [\[GPS25\]](#page-31-4) achieved a significant breakthrough: they constructed the first pairing-based schemes with both constant-size proofs and linear-time provers. To achieve this, they verify evaluations via a "folding" approach on the univariate representation. However, the reliance on a univariate representation of the multilinear polynomial hits a structural barrier. To verify the folding (effectively a polynomial division), the prover must commit to a high-degree quotient polynomial. This necessitates an additional Multi-Scalar Multiplication (MSM) of size 
+
+{1}------------------------------------------------
+
+roughly  $N = 2^n$ , effectively doubling the prover's work compared to the theoretical lower bound (computing a single univariate evaluation proof). Furthermore, the security of these schemes was established only in the Algebraic Group Model (AGM) [FKL18], leaving open the question of whether such efficiency is achievable under standard falsifiable assumptions.
+
+#### 1.1 Our Contributions
+
+In this work, we present Chopin, a pairing-based multilinear PCS that matches the asymptotic efficiency of prior work while eliminating the structural overhead of folding verification via polynomial division. This allows us to reach the theoretical lower bound on the prover's complexity while proving security in the standard model.
+
+A general framework via bivariate embeddings. Chopin is a modular framework for constructing multilinear PCS by bootstrapping from a bivariate PCS. Generalizing the "univariate twin" paradigm, we represent the multilinear polynomial as a bivariate polynomial. This shift allows us to view the multilinear evaluation claim as an evaluation of a bilinear form given by the coefficients of the multilinear polynomial. This leads to a structural simplification allowing us to avoid univariate division in the verification logic, and, in particular, to avoid producing a high-degree quotient byproduct that requires committing.
+
+Reaching the theoretical lower bound. Because our consistency check involves a bivariate cross-evaluation rather than univariate division, the prover in Chopin performs only a single MSM of size N. This achieves a concrete two-fold speedup in the dominant cost factor compared to Mercury and Samaritan, effectively hitting the theoretical floor for commitment scheme performance. We describe an optimized instantiation of Chopin using the bivariate KZG scheme [PST13], which is compared with the state of the art in Table 1: With the same proof size, Chopin halves the prover's main overhead at the cost of a single additional pairing for the verifier.
+
+Security analysis in the standard model. Our security proof cleanly separates the multilinear-to-bivariate compiler from the assumptions needed for the underlying primitives. In contrast to prior works that analyze security in the AGM, we give a modular proof in the standard model. This is not merely a matter of generality: a recent result of Chmel, Hubáček, and Stejskal [CHS26] shows that the AGM formalizations of extractability and knowledge soundness for polynomial commitments are already implied by standard-model evaluation binding. Consequently, for our setting, one cannot avoid analyzing the relevant extractability guarantees directly in the standard model.
+
+A key technical contribution of our analysis is the first proof of knowledge soundness in the standard model for 1) a Lagrange Inner Product Argument adapted from Mercury [EG25] and 2) the batched univariate proof for evaluations of multiple polynomials at *multiple* points [BDFG20]. This fills a gap in the existing literature, since Eagen and Gabizon analysed their Lagrange IPA only in the AGM and the previous analysis of univariate batch evaluation proofs in the standard model due to Lipmaa, Parisella, and Siim [LPS25] was limited to batching evaluations of many polynomials at a *single* point.
+
+#### 1.2 Other Related Work
+
+While Chopin focuses on the pairing-based setting to minimize proof size, a rich body of literature explores alternative constructions achieving other properties.
+
+Discrete-logarithm and group-based schemes. Several transparent PCS constructions remove the trusted setup needed in pairing-based schemes by relying on the discrete logarithm problem or groups of unknown order. Prominent examples include Bulletproofs [BBB+18] and Dory [Lee21], which leverage the discrete logarithm assumption to achieve logarithmic proof sizes. Works such as DARK [BHR+21] and Dew [AGL+22] explore polynomial commitments over groups of unknown order to achieve succinctness. While transparent, these schemes typically incur higher verification costs or larger proof sizes compared to pairing-based alternatives.
+
+{2}------------------------------------------------
+
+<span id="page-2-0"></span>**Table 1.** Comparison of pairing-based n-variate multilinear PCSs. We denote  $\mathbb{G}$  the number of group elements,  $\mathbb{F}$  the number of field elements, and  $N=2^n$  (resp.  $\sqrt{N}$ ) the number of multi-scalar-multiplications (MSMs) of size N (resp.  $\sqrt{N}$ ). Costs are separated into (a+b) where b is the batching overhead. Chopin reduces the dominant MSM cost from 2N to 1N with a proof of security in the standard model.
+
+| Scheme            | Proof Size                      | Prover MSMs                   | Pairings | Security |
+|-------------------|---------------------------------|-------------------------------|----------|----------|
+| Mercury [EG25]    | $(6+2)\mathbb{G} + 6\mathbb{F}$ | $2N + (4+2)\sqrt{N}$          | 2 + 2    | AGM      |
+| Samaritan [GPS25] | $7\mathbb{G} + 1\mathbb{F}$     | $2N + 4\sqrt{N}$              | 4        | AGM      |
+| Снорім            | $(5+2)\mathbb{G} + 7\mathbb{F}$ | $\mathbf{1N} + (4+2)\sqrt{N}$ | 3 + 2    | Standard |
+
+Hashing and code-based schemes. Another major category avoids group operations entirely, relying instead on error-correcting codes and cryptographic hashing to achieve transparency and post-quantum security. FRI [BBHR18] is the foundational work in this category, enabling Reed–Solomon proximity testing. To address the prover overhead of FRI, recent linear-time constructions such as Brakedown [GLS+23], Orion [XZS22], and Basefold [ZCF24] have been introduced, alongside earlier systems like Aurora [BCR+19] and Ligero [AHIV23]. While these schemes offer excellent prover performance, they typically produce proofs ranging from several kilobytes to megabytes, in contrast to the compact, constant-sized proofs of pairing-based schemes.
+
+Distributed and sparse proving. Recent works have also addressed specific deployment scenarios for a multilinear PCS. Hyperpianist [LZL<sup>+</sup>25] introduces techniques to parallelize prover workloads for a multilinear PCS. Cirrus [WSVZ24] focuses on distributed SNARK proving, introducing accountability mechanisms to detect dishonest distributed provers. Finally, Setty [Set20] constructs a PCS specifically optimized for sparse multilinear polynomials, which is complementary to our work, where we implicitly consider dense polynomials.
+
+## 2 Technical Overview
+
+Our construction follows a modular "compile-and-prove" structure. The core of our approach is a structural observation that transforms the evaluation of a multilinear polynomial into operations on its bivariate twin. This observation yields a general template for constructing a multilinear PCS by bootstrapping from any bivariate PCS. When carefully instantiated with the bivariate KZG scheme [PST13], our template halves the dominant prover complexity bottleneck compared to recent proposals such as Mercury [EG25] and Samaritan [GPS25] that are based on univariate KZG.
+
+From multilinear to bivariate. Let F be a multilinear polynomial in n = 2m variables. Instead of viewing F as a vector of size  $N = 2^n$ , we treat its coefficients as a square matrix  $\mathbf{F}$  of dimension  $M \times M$ , where  $M = 2^m$ . The multilinear evaluation claim can then be equivalently expressed as the evaluation of a bilinear form defined by  $\mathbf{F}$ :
+
+<span id="page-2-1"></span>
+$$\eta = F(\bar{z}) = \mathbf{\Psi}_{\bar{z}_L}^T \mathbf{F} \ \mathbf{\Psi}_{\bar{z}_R},\tag{1}$$
+
+where  $\Psi_{\bar{z}_L}$  and  $\Psi_{\bar{z}_R}$  denote the vectors of Lagrange basis evaluations for the left and right halves of  $\bar{z} = (\bar{z}_L, \bar{z}_R)$ . Specifically,  $\Psi_{\bar{z}_L} = (\tilde{e}q(0^m; \bar{z}_L), \dots, \tilde{e}q(1^m; \bar{z}_L))$ , where  $\tilde{e}q(u; X_1, \dots, X_m)$  is the multilinear Lagrange basis polynomial corresponding to  $u \in \{0, 1\}^m$ .
+
+Interactive proof for multilinear evaluation. Based on this matrix representation, we design a constant-round interactive proof that significantly reduces the verification complexity of the evaluation claim. This interactive proof then naturally serves as the template for our multilinear PCS. The protocol proceeds in two steps:
+
+{3}------------------------------------------------
+
+- 1. Column Restriction: P partially evaluates the bilinear form from Equation (1) by computing the vector  $\mathbf{F}_{\bar{z}_R} = \mathbf{F} \cdot \mathbf{\Psi}_{\bar{z}_R}$ , which is then sent to V. At this point, V can check the multilinear evaluation claim via an inner product check of size M, verifying that  $\eta = \mathbf{\Psi}_{\bar{z}_L}^T \mathbf{F}_{\bar{z}_R}$ . However, V also needs to verify the consistency of  $\mathbf{F}_{\bar{z}_R}$  with  $\mathbf{F}$ . To this end, V samples a random challenge  $\alpha \leftarrow \mathbb{F}$  and sends it to P.
+- 2. Row Folding and Check: For  $\alpha^T = (1, \alpha, ..., \alpha^{M-1})$ , P computes and sends to V the vector  $\mathbf{F}_{\alpha} = \alpha^T \mathbf{F}$ . Observe that  $\mathbf{F}_{\alpha}$  is a random folding of the rows of  $\mathbf{F}$  defined by powers of the verifier's challenge  $\alpha$ . At this point, V checks the consistency of  $\mathbf{F}_{\alpha}$  with  $\mathbf{F}$ , and the consistency of  $\mathbf{F}_{\bar{z}_R}$  with  $\mathbf{F}_{\alpha}$ . This is achieved by sampling a uniform  $\beta \leftarrow \mathbb{F}$  and verifying that
+
+$$\boldsymbol{\alpha}^T \mathbf{F}_{\bar{z}_R} = \mathbf{F}_{\alpha}^T \boldsymbol{\Psi}_{\bar{z}_R} \quad \text{and} \quad \mathbf{F}_{\alpha}^T \; \boldsymbol{\beta} = \boldsymbol{\alpha}^T \mathbf{F} \; \boldsymbol{\beta},$$
+
+where 
+$$\beta = (1, \beta, ..., \beta^{M-1})^T$$
+.
+
+Algebraically, the inner product of a vector  $\mathbf{G}$  with  $\boldsymbol{\alpha}$  corresponds to the evaluation of the univariate polynomial  $g(X) = \sum_{i=1}^{M} \mathbf{G}_{i} X^{i-1}$  at  $\alpha$ . Similarly, the evaluation of the bilinear form  $\boldsymbol{\alpha}^{T} \mathbf{F} \boldsymbol{\beta}$  corresponds to the evaluation of the bivariate polynomial  $f(X,Y) = \sum_{i,j=1}^{M} \mathbf{F}_{i,j} X^{i-1} Y^{j-1}$  at  $(\alpha,\beta)$ . Under this polynomial interpretation, we successfully reduce the original evaluation claim  $F(\bar{z}) = \eta$  to checking the following three identities:
+
+<span id="page-3-0"></span>
+$$\eta = \langle \mathbf{F}_{\bar{z}_R}, \mathbf{\Psi}_{\bar{z}_L} \rangle, \quad f_{\bar{z}_R}(\alpha) = \langle \mathbf{F}_{\alpha}, \mathbf{\Psi}_{\bar{z}_R} \rangle, \quad \text{and} \quad f_{\alpha}(\beta) = f(\alpha, \beta).$$
+(2)
+
+Here, f(X,Y) is the bivariate twin representation of the original multilinear polynomial F. The polynomials  $f_{\bar{z}_R}$  and  $f_{\alpha}$  are univariate twin representations of intermediate multilinear functions defined over half the original number of variables. By a standard Schwartz-Zippel argument, the soundness error of this protocol is at most  $2(M-1)/|\mathbb{F}|$ . Detailed notation, the derivation of protocol correctness, and the formal proof of soundness are provided in Section 4.1.
+
+CHOPIN: The corresponding multilinear PCS. The interactive proof described above serves as a blueprint for compiling any bivariate PCS into a multilinear PCS. To commit to the multilinear polynomial F, the prover simply commits to its bivariate representation f using the underlying bivariate PCS. During the evaluation phase, the prover commits to the univariate polynomials  $f_{\bar{z}_R}$  and  $f_{\alpha}$ . The prover then provides evaluation proofs for  $f_{\bar{z}_R}(\alpha)$ ,  $f_{\alpha}(\beta)$ , and  $f(\alpha,\beta)$ , enabling the verifier to check the identities in Equation (2). Additionally, the PCS must support what we call a Lagrange Inner Product Argument (Lagrange IPA). This type of argument allows proving inner product claims about the coefficient vectors of the committed univariate polynomials (i.e.,  $f_{\bar{z}_R}$  and  $f_{\alpha}$ ) and the Lagrange evaluation vectors (i.e.,  $\Psi_{\bar{z}_L}$  and  $\Psi_{\bar{z}_R}$ ). Because we run the Lagrange IPA on polynomials of degree less than  $M = \sqrt{N}$ , it does not strictly require a linear-time prover. Consequently, we can simply instantiate this component using the state-of-the-art Lagrange IPA from Mercury [EG25]. Overall, because our bivariate twin representation is defined directly over the Lagrange basis, the prover operates essentially in linear time (O(N) field operations). Crucially, this approach completely avoids the need for expensive basis conversions via Fast Fourier Transforms (FFTs).
+
+Due to our modular approach, we can establish a direct proof of knowledge soundness for Chopin by reducing it to the knowledge soundness of the underlying bivariate PCS equipped with a Lagrange IPA. To cleanly formalize the extraction process, we introduce the notion of knowledge soundness for a "Lagrange IPA supporting" bivariate PCS. This notion captures the extractor's ability to recover a bivariate polynomial from an evaluation proof and a Lagrange IPA proof such that the polynomial satisfies both the evaluation claim and the Lagrange inner product claim. Armed with this stronger definition of knowledge soundness, we can seamlessly reduce the security of the compiled multilinear PCS to the statistical soundness of our interactive proof. The formal description of Chopin and the rigorous proof of its knowledge soundness are presented in Section 4.3.
+
+ $Matryoshka\ PCS:\ Security\ of\ all\ commitments\ under\ a\ single\ bivariate\ key.$  A naive implementation of the checks in Equation (2) would invoke two separate schemes: a bivariate PCS and a univariate PCS. However, deploying two disjoint schemes is unnecessarily wasteful. A bivariate PCS supporting polynomials of degree less than M in each variable can naturally be used to prove evaluations of univariate polynomials of degree
+
+{4}------------------------------------------------
+
+less than M. While this observation neatly minimizes the size of the commitment key, it introduces subtle complications in the proof of knowledge soundness. Specifically, extracting from a univariate commitment using a bivariate key only guarantees the recovery of a bivariate polynomial consistent with the claimed univariate evaluations. To rigorously resolve this technicality, we introduce the concept of a "matryoshka" PCS. This abstraction formalizes the ability to safely operate a bivariate PCS in both a bivariate and a univariate mode, supported by corresponding native bivariate and univariate extractors. Beyond being conceptually elegant, this property is readily satisfied by practical constructions such as the bivariate KZG scheme. The primary condition to verify is that the univariate extractor retains its success probability even when the adversary in the univariate knowledge soundness experiment is given access to a full bivariate commitment key. For the bivariate KZG scheme, this condition is easily proven via a basic simulation argument, thanks to the clean separation between the univariate slice and the remaining group elements in the bivariate key. We provide an extended discussion of this property, recall the bivariate KZG scheme, and formally argue that it constitutes a matryoshka PCS in Section [4.2.](#page-12-0)
+
+Lagrange IPA in the standard model. To verify the aforementioned consistency checks, we employ a Lagrange IPA adapted from Mercury [\[EG25\]](#page-31-3). We carefully adapt this protocol to support statements about univariate polynomials committed under a bivariate KZG key. Crucially, while the authors of Mercury analyzed the security of their Lagrange IPA exclusively in the Algebraic Group Model, we provide a proof of knowledge soundness for our adapted Lagrange IPA in the standard model. At a high level, the Mercury protocol translates a Lagrange inner product claim into a polynomial identity by leveraging the cross-correlation properties captured within the coefficients of a specific Laurent polynomial. Consequently, verifying the inner product claim reduces to testing this polynomial identity through standard evaluation claims on corresponding univariate polynomials. Relying on our matryoshka PCS property, the extraction process for the Lagrange IPA first recovers the polynomials from the underlying evaluation proofs. It then demonstrates their consistency with the claimed Lagrange inner product by structurally relying on the Laurent polynomial identity. Applying this technique, we successfully prove the standard-model knowledge soundness of the batched Lagrange IPA introduced by Mercury. In Section [5,](#page-17-0) we recall the algebraic identity that relates inner product statements to symmetric decompositions of Laurent polynomials. We then detail the batched Lagrange IPA for univariate polynomials committed under a bivariate key and formally reduce its knowledge soundness to the security of the underlying bivariate matryoshka PCS. In particular, this reduction establishes that we have a Lagrange IPA supporting bivariate PCS.
+
+<span id="page-4-0"></span>Optimized instantiation from bivariate KZG. We instantiate our generic Chopin template using the bivariate KZG commitment scheme [\[PST13\]](#page-31-1). First, the prover commits to the bivariate representation f of the multilinear polynomial F using bivariate KZG. During the interactive evaluation proof, the prover commits to the univariate polynomials fz¯<sup>R</sup> and f<sup>α</sup> utilizing the exact same bivariate commitment key. The intermediate Lagrange inner product claims are subsequently batched and reduced to six univariate evaluation claims involving fz¯<sup>R</sup> (X), fα(X), and an auxiliary polynomial S(X) that witnesses the inner product relations. The prover then commits to this witness polynomial S(X). Upon receiving the challenges α and β, the prover computes and transmits two distinct proofs to the verifier. The first is a bivariate KZG evaluation proof for the opening of f at the point (α, β). The second is a univariate batch proof that simultaneously resolves all remaining univariate evaluation claims. The verifier accepts if and only if both the bivariate proof and the univariate batch proof are accepting and the corresponding evaluations satisfy the constraints imposed by the interactive proof and the batched Lagrange IPA. This concrete variant of Chopin based on bivariate KZG is presented in full detail in Section [6.](#page-20-0)
+
+We intentionally avoid batching the bivariate and univariate evaluations together. Currently, there are no known batching techniques for multivariate KZG that offer competitive concrete efficiency. Furthermore, even if one were to conceptually extend existing univariate batching techniques to the bivariate setting, the resulting batched protocol would likely become computationally heavier for the prover. In our optimized instantiation, the batch proof is computed exclusively over univariate polynomials of degree strictly less than M = √ N. Consequently, the Multi-Scalar Multiplications (MSMs) induced by this univariate batch evaluation proof are of size M, which is insignificant compared to the instance size N. The primary bottleneck 
+
+{5}------------------------------------------------
+
+in generating the standalone bivariate KZG proof for  $f(\alpha, \beta)$  lies in computing a commitment to the quotient polynomial  $q_1(X,Y) = (f(X,Y) - f(\alpha,Y))/(X-\alpha)$ . Because  $q_1(X,Y)$  contains exactly N monomials, this step necessitates a single dominant MSM of size N. Note that the second quotient polynomial  $q_2(X,Y) = (f(\alpha,Y) - f(\alpha,\beta))/(Y-\beta)$  contains only M monomials and is thus computationally cheap to commit to. Consider the cost of a hypothetical bivariate batch proof encompassing all evaluation claims. Standard univariate batching techniques require the prover to compute and transmit at least one auxiliary polynomial commitment (or evaluation proof) whose size is proportional to the degree of the batched polynomials. Extending this paradigm to the bivariate setting would introduce a second MSM of size N just to facilitate the batching logic. This additional overhead would effectively double the prover's execution time, erasing the structural performance gains of our design.
+
+Comparison to Mercury and Samaritan. Mercury [EG25] and Samaritan [GPS25] employ a broadly similar template, but they reduce multilinear evaluation to a purely univariate PCS. Starting from the univariate twin f(X) of the multilinear polynomial F, they verify the structural correctness of the folded univariate polynomial  $f_{\alpha}(X)$  by testing the polynomial identity
+
+$$f(X) = q_{\alpha}(X)(X^{M} - \alpha) + f_{\alpha}(X).$$
+
+However, this algebraic relation strictly necessitates committing to the quotient polynomial  $q_{\alpha}(X)$ . Because  $q_{\alpha}(X)$  possesses a large degree of  $N - \sqrt{N}$ , committing to it inevitably induces an additional MSM of order roughly N. By avoiding this high-degree polynomial division entirely, Chopin bypasses this secondary MSM and achieves optimal prover performance. We detail the information-theoretic protocol underlying Mercury and Samaritan in order to compare it to our own interactive proof in Appendix A.
+
+Our presentation of Chopin is closer to the structure of Mercury. The authors of Samaritan present an optimized variant of their PCS, where all the consistency checks are reduced to a single pairing identity and a degree check. Because of this, they report a better proof size compared to Mercury (see Table 1). We believe similar techniques would also work for Mercury and Chopin if one needs to optimize the proof size.
+
+Univariate batch evaluation in the standard model. The execution of the interactive proof and the IPAs generates multiple evaluation claims for different univariate polynomials at different points. Specifically, for CHOPIN, we require batching the evaluations of multiple polynomials (namely  $f_{\bar{z}_R}$ ,  $f_{\alpha}$ , and S) at multiple points  $(\alpha, \beta, \alpha, \beta)$  and  $\beta^{-1}$ . To minimize proof size and verification costs, we aggregate all these claims into a single batched univariate KZG proof. We provide a rigorous security analysis for this batching: specifically, we prove the knowledge soundness of a modified multi-polynomial, multi-point batch evaluation protocol in the standard model (again, relative to a bivariate commitment key). This fills a gap in the literature, as the previous analysis of multi-point batching (Boneh et al. [BDFG20]) relied predominantly on the AGM. Furthermore, recent standard-model analysis from Lipmaa et al. [LPS24] was limited to evaluations of multiple polynomials at a single point and does not directly extend to our setting. At a high level, we show that a specially structured set of accepting transcripts for the batch proof can be used to extract polynomials consistent with any batch evaluation proof. Additionally, we formally argue that, when batching a constant number of polynomials, it is possible to extract such a structured set of accepting transcripts in expected polynomial time from any prover that has a non-negligible success probability.
+
+Extensions to an odd number of variables and zero-knowledge. While we primarily motivate and present CHOPIN in terms of square matrices representing multilinear polynomials in an even number of variables n=2m, the framework seamlessly extends to an odd number of variables n=2m+1 without requiring artificial padding. Instead of padding the multilinear polynomial to 2m+2 variables, which would wastefully double the domain size and the dominant prover MSM cost, we evaluate the polynomial using a rectangular matrix representation. We partition the n variables asymmetrically into a left part  $\bar{X}_L$  of size  $m_1=m+1$  and a right part  $\bar{X}_R$  of size  $m_2=m$ . Consequently, the coefficients of F form a rectangular matrix F of dimension  $M_1 \times M_2$ , where  $M_1 = 2^{m_1}$  and  $M_2 = 2^{m_2}$ . Importantly, the total number of matrix entries remains exactly  $M_1 \times M_2 = 2^{2m+1} = N$ , precisely matching the native size of the non-padded multilinear polynomial. The
+
+{6}------------------------------------------------
+
+evaluation of the bilinear form from Equation (1) remains structurally identical, except that the Lagrange evaluation vectors  $\Psi_{\bar{z}_L}$  and  $\Psi_{\bar{z}_R}$  now have asymmetric lengths  $M_1$  and  $M_2$ , respectively. The interactive protocol adapts naturally to these asymmetric dimensions: the column restriction vector  $\mathbf{F}_{\bar{z}_R}$  becomes a vector of length  $M_1$ , while the row folding vector  $\mathbf{F}_{\alpha}$  is derived using a challenge vector  $\boldsymbol{\alpha}$  of length  $M_1$  and results in a vector of length  $M_2$ . Under the polynomial interpretation, the bivariate twin f(X,Y) is defined with asymmetric degree bounds: strictly less than  $M_1$  in X, and strictly less than  $M_2$  in Y. The soundness error of the interactive proof naturally adjusts to  $(M_1 + M_2 - 2)/|\mathbf{F}|$ . When operating the corresponding multilinear PCS, the univariate twin  $f_{\bar{z}_R}$  has a degree bounded by  $M_1 - 1$ , and  $f_{\alpha}$  has a degree bounded by  $M_2 - 1$ . The underlying bivariate KZG scheme effortlessly supports these asymmetric degree bounds simply by generating the commitment key with maximal degrees  $d_X = M_1 - 1$  and  $d_Y = M_2 - 1$ . Because the protocol operates strictly within the  $M_1 \times M_2$  bounds, the largest quotient polynomial during the bivariate KZG opening still contains exactly N monomials, strictly preserving the optimal prover complexity of a single MSM of size N.
+
+While our presentation focuses on the core multilinear polynomial commitment scheme, achieving zero-knowledge is often required for deploying a multilinear PCS in practice. By relying on a hiding version of the univariate KZG commitment scheme to mask evaluations as in Zeromorph [KT24], one can construct a zero-knowledge variant of Chopin in a rather straightforward manner. This approach preserves the core advantage of Chopin, as it avoids the prover overhead of committing to a high-degree random masking polynomial. However, extracting the blinding randomness from perfectly hiding commitments typically leads to an analysis in the Algebraic Group Model or under knowledge-assumptions. Therefore, proving the knowledge soundness of the zero-knowledge variant in the standard model might require additional techniques, which we leave for future work.
+
+#### 3 Preliminaries
+
+For  $a, b \in \mathbb{N}$ , a < b we denote by [a, b] the set  $[a, b] = \{a, a + 1, \ldots, b\}$  and we denote [a] = [1, a]. For a distribution D, we denote by  $x \leftarrow D$  sampling x from D. A finite set S in the place of D implies the uniform distribution on S. By  $\lambda$  we denote the security parameter. For an algorithm A,  $y \leftarrow A(x)$  denotes that given input x, A outputs y. We say that a function  $\varepsilon \colon \mathbb{N} \to \mathbb{R}^+$  is negligible if it approaches zero faster than any inverse polynomial. In that case, we write  $\varepsilon(\lambda) \in \mathsf{negl}(\lambda)$ . We say that a function  $g \colon \mathbb{N} \to \mathbb{N}$  is O(f), if there exists constants c > 0 and  $n_0 \in \mathbb{N}$ , such that  $|g(n)| \le c|f(n)|$  for all  $n > n_0$ .
+
+Polynomials. Throughout the paper, we use the following notation. We write  $N = 2^n$  and  $M = 2^m$ , where in our setting m = n/2. Multilinear polynomials in several variables are denoted by uppercase letters such as P, F, G, while lowercase letters are reserved for univariate or bivariate polynomials (e.g., p, f, g). The arity of a lowercase polynomial will always be clear from the context.
+
+We define the standard polynomial  $\tilde{eq}(Y_1, \ldots, Y_n; X_1, \ldots, X_n) = \prod_{j=1}^n (Y_j X_j + (1-Y_j)(1-X_j))$ . Observe that the X and Y variables play symmetric roles, since each factor  $Y_j X_j + (1-Y_j)(1-X_j)$  is invariant under exchanging  $X_j$  and  $Y_j$ , and therefore  $\tilde{eq}(Y;X) = \tilde{eq}(X;Y)$ . For any fixed  $\bar{b} = (b_1, \ldots, b_n) \in \{0,1\}^n$ , plugging  $\bar{b}$  into the Y-variables defines the multilinear Lagrange basis polynomial corresponding to  $\bar{b}$  is  $\tilde{eq}(\bar{b}; X_1, \ldots, X_n) = \prod_{j=1}^n (b_j X_j + (1-b_j)(1-X_j))$ .
+
+Let  $B^n$  denote the Boolean hypercube of size n. For  $\bar{b} \in B^n$  we denote by  $\langle \bar{b} \rangle$  the integer corresponding to its binary expansion, namely  $\langle \bar{b} \rangle = \sum_{i=1}^n b_i \, 2^{i-1}$ .
+
+We define the inner product of two vectors  $\mathbf{g} = (g_0, \dots, g_{n-1})$  and  $\mathbf{h} = (h_0, \dots, h_{n-1})$  as  $\langle \mathbf{g}, \mathbf{h} \rangle = \sum_{i=0}^{n-1} g_i h_i$ .
+
+Bilinear Groups and Pairings Consider two additive groups  $(\mathbb{G}_1, +_1)$  and  $(\mathbb{G}_2, +_2)$  and a multiplicative group  $(\mathbb{G}_T, \otimes)$ , all of prime order p. A pairing  $e : \mathbb{G}_1 \times \mathbb{G}_2 \to \mathbb{G}_T$  satisfies:
+
+**Bilinearity:** For all  $P_1 \in \mathbb{G}_1$ ,  $P_2 \in \mathbb{G}_2$ , and  $a, b \in \mathbb{F}_p$ , it holds that  $e(aP_1, bP_2) = e(P_1, P_2)^{ab}$ . **Non-degeneracy:** For all  $P_1 \neq 0_{\mathbb{G}_1}$  and  $P_2 \neq 0_{\mathbb{G}_2}$ , it holds that  $e(P_1, P_2) \neq 1_{\mathbb{G}_T}$ , 
+
+{7}------------------------------------------------
+
+where  $0_{\mathbb{G}_1}$  (resp.  $0_{\mathbb{G}_2}$  and  $1_{\mathbb{G}_T}$ ) is the neutral element of  $\mathbb{G}_1$  (resp.  $\mathbb{G}_2$  and  $\mathbb{G}_T$ ).
+
+To simplify notation and make algebraic manipulations clearer, we use the bracket notation for group elements, where we write  $[a]_1 = a[1]_1$ , where  $[1]_1$  is the generator of  $\mathbb{G}_1$  (and similarly for the other two groups). We use the symbol  $\bullet$  as a binary operator that represents an application of the pairing, i.e.,  $[a]_1 \bullet [b]_2 = e([a]_1, [b]_2)$ . Then the bilinearity property, for example, gives us
+
+$$[a]_1 \bullet [b]_2 = ([1]_1 \bullet [1]_2)^{ab} = [ab]_1 \bullet [1]_2 = ([a]_1 \bullet [1]_2)^b.$$
+
+We assume that there is some bilinear group generator PGen that samples the groups  $\mathbb{G}_1, \mathbb{G}_2$ , and  $\mathbb{G}_T$ , and outputs the corresponding group parameters  $\mathsf{gp} = (p, [1]_1, +_1, [1]_2, +_2, [1]_T, \otimes, \bullet)$  that specify the order of the groups, and allow to compute the respective group operations and pairing efficiently. In the rest of the paper, we simply write  $\mathsf{gp} = (p, [1]_1, [1]_2, \bullet)$  for brevity.
+
+Polynomial Commitment Schemes A Polynomial Commitment Scheme (PCS) is a cryptographic primitive that allows a prover to commit to a polynomial and later reveal its evaluations at specific points, along with a proof of correctness.
+
+**Definition 1 (Multivariate Polynomial Commitment Scheme).** A Non-Interactive Multivariate Polynomial Commitment Scheme is a tuple of algorithms (KGen, Com, Open, Ver) such that:
+
+KGen( $1^{\lambda}$ ,  $\mathbf{d}$ , aux): Given a security parameter  $1^{\lambda}$ , a vector of degree bounds  $\mathbf{d} = (d_1, \ldots, d_n) \in \mathbb{N}^n$ , and an auxiliary input aux, returns a commitment key ck.
+
+Com(ck, f): Given a commitment key ck and a polynomial  $f \in \mathbb{F}[X_1, \ldots, X_n]^{\leq \mathbf{d}}$ , returns a commitment C. Open(ck, C, f,  $\bar{z}$ ,  $\eta$ ): Given a commitment key ck, a commitment C, a polynomial  $f \in \mathbb{F}[X_1, \ldots, X_n]^{\leq \mathbf{d}}$ , an evaluation point  $\bar{z} = (z_1, \ldots, z_n) \in \mathbb{F}^n$ , and a claimed evaluation  $\eta$ , returns an evaluation proof  $\pi$ .
+
+Ver(ck,  $C, \bar{z}, \eta, \pi$ ): Given a commitment key ck, a commitment C, an evaluation point  $\bar{z} = (z_1, \dots z_n) \in \mathbb{F}^n$ , a proposed evaluation  $\eta \in \mathbb{F}$ , and an evaluation proof  $\pi$ , returns 1 (accept) or 0 (reject).
+
+Note that the auxiliary input aux to KGen can accommodate the passing of the group parameters gp sampled by a bilinear group generator PGen or another algorithm PGen specifying the context the specific polynomial commitment is based on. To simplify notation, we assume that ck implicitly contains the auxiliary information aux and the degree bounds  $d = (d_1, \ldots, d_n)$  that were used to compute it, and the algorithms Com and Open can efficiently check that the input polynomial satisfies the appropriate degree bounds.
+
+In this work, we consider three instantiations of polynomial commitment schemes, depending on the structure of the committed polynomial:
+
+**Univariate PCS:** The committed polynomial is  $f(X) \in \mathbb{F}[X]$  of degree at most d. The evaluation point is a single  $z \in \mathbb{F}$ .
+
+**Bivariate PCS:** The committed polynomial is  $f(X,Y) \in \mathbb{F}[X,Y]$  with total degree at most d in each variable. The evaluation point is  $(z_1,z_2) \in \mathbb{F}^2$ .
+
+**Multilinear PCS:** The committed polynomial  $F(X_1, ..., X_n) \in \mathbb{F}[X_1, ..., X_n]$  where each variable  $X_i$  has degree at most 1. The evaluation point is  $\bar{z} \in \mathbb{F}^n$ .
+
+For clarity, we write  $\mathsf{PCS}_u$  to denote a univariate polynomial commitment scheme,  $\mathsf{PCS}_b$  for a bivariate polynomial commitment scheme, and  $\mathsf{PCS}$  for a multilinear or a general polynomial commitment scheme.
+
+The most basic security property of polynomial commitment schemes is evaluation binding, ensuring that the prover is bound to some function and, thus, cannot open the commitment to two distinct values at the same evaluation point.
+
+**Definition 2 (Evaluation Binding).** Let PCS = (KGen, Com, Open, Ver) be a polynomial commitment scheme. We say that the PCS is evaluation binding for PGen if for all PPT algorithms A, it holds that
+
+$$\Pr \begin{bmatrix} \mathsf{Ver}(\mathsf{ck}, C, z, \eta_1, \pi_1) = 1 \land \middle| \mathsf{gp} \leftarrow \mathsf{PGen}(1^\lambda), \\ \mathsf{Ver}(\mathsf{ck}, C, z, \eta_2, \pi_2) = 1 \land \middle| \mathsf{ck} \leftarrow \mathsf{KGen}(1^\lambda, \mathbf{d}, \mathsf{gp}), \\ \eta_1 \neq \eta_2 & (C, (\eta_1, \pi_1, z), (\eta_2, z, \pi_2)) \leftarrow \mathcal{A}(\mathsf{ck}) \end{bmatrix} \in \mathsf{negl}(\lambda).$$
+
+{8}------------------------------------------------
+
+The more meaningful notion of security for PCS in the context of higher-level protocols is knowledge soundness.
+
+<span id="page-8-1"></span>**Definition 3 (Knowledge Soundness).** A polynomial commitment scheme PCS is knowledge sound for PGen, if there exists an expected PPT extractor Ext, such that for every  $n, \mathbf{d} = (d_1, \dots, d_n) \in \mathsf{poly}(\lambda)$  and all  $\mathcal{A} = (\mathcal{A}_0, \mathcal{A}_1)$ , where  $\mathcal{A}_0$  is PPT and  $\mathcal{A}_1$  is DPT, it holds that
+
+$$\Pr \begin{bmatrix} \operatorname{Ver}(\mathsf{ck}, C, \bar{z}, \eta, \pi) = 1 \wedge & \operatorname{gp} \leftarrow \operatorname{PGen}(1^{\lambda}), \\ (C \neq \operatorname{Com}(\mathsf{ck}, f) \vee \\ \exists i \in [n] \deg_{X_i} f > d \ \vee \ f(\bar{z}) \neq \eta) & (C, \mathsf{st}) \leftarrow \mathcal{A}_0(\mathsf{ck}), \bar{z} \leftarrow \mathbb{F}^n, \\ (\pi, \eta) \leftarrow \mathcal{A}_1(\mathsf{st}, \bar{z}), \\ f \leftarrow \operatorname{Ext}^{\mathcal{A}_1(\mathsf{st}, \cdot)}(\mathsf{ck}, C, \bar{z}, \eta, \pi) \end{bmatrix} \in \operatorname{negl}(\lambda).$$
+
+We recall also the standard definition of an interactive proof.
+
+**Definition 4 (Interactive Proof).** A protocol (P,V) is an interactive proof for a language  $\mathcal{L} \subseteq \{0,1\}^*$  if V is a PPT algorithm and the following two properties hold:
+
+Completeness: For all  $x \in \mathcal{L}$ ,  $\Pr\left[(\mathsf{P},\mathsf{V})(x) = 1\right] \geq \frac{2}{3}$ . Soundness: For all  $x \notin \mathcal{L}$  and all  $\mathsf{P}^*$ ,  $\Pr\left[(\mathsf{P}^*,\mathsf{V})(x) = 1\right] \leq \frac{1}{3}$ .
+
+#### 4 Chopin: Multilinear PCS from Bivariate PCS
+
+While various works in the literature construct multilinear PCS by bootstrapping from a univariate PCS through some bijection from  $\mathbb{F}[X_1,\ldots,X_n]^{\leq 1}$  to  $\mathbb{F}[X]^{\leq 2^n}$ , we generalize this principle to the bivariate setting. Our approach maps a multilinear polynomial F to a bivariate "twin" f(X,Y) and commits to it via a bivariate PCS. The non-trivial task is to design an efficient protocol that enables evaluations of the multilinear F at arbitrary points, given only the bivariate commitment to f.
+
+#### <span id="page-8-0"></span>4.1 Interactive Proof for Evaluating Multilinear Polynomials
+
+We will repeatedly use the simple observation that multilinear polynomial evaluation can be viewed equivalently via matrix or vector products. Consequently, as we explain next, evaluation claims can be represented as statements about the univariate or bivariate polynomials representing the multilinear polynomial.
+
+Multilinears as bivariate polynomials. Let n=2m be the number of variables, and let  $M=2^m$ . For a binary vector  $\bar{u} \in \{0,1\}^m$ , we denote its integer representation by  $\langle \bar{u} \rangle = \sum_{j=1}^m u_j 2^{j-1}$ , and analogously for n-bit vectors. To instantiate CHOPIN, we consider 2m-variate multilinear polynomials represented w.r.t. the multilinear Lagrange basis  $\{\tilde{eq}(\bar{w}; X_1, \dots, X_{2m})\}_{\bar{w} \in B^{2m}}$ .
+
+multilinear Lagrange basis  $\{\tilde{eq}(\bar{w}; X_1, \dots, X_{2m})\}_{\bar{w} \in B^{2m}}$ . We define a bijection  $\Phi$  identifying the space of 2m-variate multilinear polynomials  $\mathbb{F}[X_1, \dots, X_{2m}]^{\leq 1}$  with the space of bivariate polynomials  $\mathbb{F}[X,Y]^{< M,M}$  of degree less than M in each variable. We split the variable set into two halves,  $\bar{X}_L = (X_1, \dots, X_m)$  and  $\bar{X}_R = (X_{m+1}, \dots, X_{2m})$ , and define the bijection as a tensor construction that maps Lagrange basis polynomials in  $\bar{X}_L$  to monomials in X and Lagrange basis polynomials in  $\bar{X}_R$  to monomials in Y in a natural way. Specifically, for all  $\bar{u}, \bar{v} \in \{0,1\}^m$ , the bijection is defined as follows:
+
+$$\Phi\big(\widetilde{eq}(\bar{u};\bar{X}_L)\cdot\widetilde{eq}(\bar{v};\bar{X}_R)\big)=X^{\langle\bar{u}\rangle}Y^{\langle\bar{v}\rangle}.$$
+
+Correspondingly, for any multilinear polynomial  $F(\bar{X}_L, \bar{X}_R)$ , its bivariate twin polynomial  $f = \Phi(F)$  is
+
+$$f(X,Y) = \sum_{\bar{u},\bar{v}\in Bd^m} F(\bar{u},\bar{v}) X^{\langle \bar{u}\rangle} Y^{\langle \bar{v}\rangle}.$$
+ (3)
+
+{9}------------------------------------------------
+
+A key property of this representation is that the coefficient of the monomial  $X^iY^j$  in f(X,Y) corresponds exactly to the evaluation of F on the hypercube point  $(\bar{u},\bar{v})$  such that  $i=\langle \bar{u}\rangle$  and  $j=\langle \bar{v}\rangle$ . Note that, when applied to a multilinear polynomial G supported only on the first (respectively second) half of the variables, the bijection  $\Phi$  returns a univariate polynomial in X (respectively Y). In those instances, we denote the bijection  $\Phi_X$  (respectively  $\Phi_Y$ ) to clarify that the output is a univariate polynomial.
+
+By the multilinearity of F in n=2m variables, we can rewrite the evaluation claim  $F(\bar{z})=\eta$  for  $\bar{z}=(\bar{z}_L,\bar{z}_R)\in\mathbb{F}^n$  as
+
+$$\eta = \sum_{\bar{b} \in B^n} F(\bar{b}) \widetilde{eq}(\bar{b}; \bar{z}) = \sum_{\bar{u}, \bar{v} \in B^m} F(\bar{u}, \bar{v}) \widetilde{eq}(\bar{u}; \bar{z}_L) \widetilde{eq}(\bar{v}; \bar{z}_R).$$
+
+Define the matrix  $\mathbf{F} \in \mathbb{F}^{M \times M}$  representing the multilinear polynomial F as  $\mathbf{F}_{\langle \bar{u} \rangle, \langle \bar{v} \rangle} = F(\bar{u}, \bar{v})$  for all  $\bar{u}, \bar{v} \in B^m$ . Using this matrix representation, we can rewrite the last expression more explicitly as an evaluation of the bilinear form corresponding to  $\mathbf{F}$  on vectors defined by evaluations of  $\tilde{eq}(\bar{X}_L; \bar{z}_L)$ , respectively  $\tilde{eq}(\bar{X}_R; \bar{z}_R)$ , on the m-dimensional Boolean hypercube:
+
+$$(\widetilde{eq}(0^m; \bar{z}_L), \ldots, \widetilde{eq}(1^m; \bar{z}_L)) \begin{pmatrix} \mathbf{F} \end{pmatrix} \begin{pmatrix} \widetilde{eq}(0^m; \bar{z}_R) \\ \vdots \\ \widetilde{eq}(1^m; \bar{z}_R) \end{pmatrix}.$$
+
+To simplify the exposition in the rest of the section, we introduce the notation
+
+$$\Psi_{\bar{z}} := (\widetilde{eq}(0^m; \bar{z}), \dots, \widetilde{eq}(1^m; \bar{z}))^T$$
+(4)
+
+to denote the vector of evaluations of the m-dimensional multilinear Lagrange basis on some  $\bar{z} \in \mathbb{F}^m$ .
+
+In the rest of this section, we will be switching between the representations of 2m-variate multilinear F as the above matrix  $\mathbf{F}$  or a bivariate twin  $f(X,Y) = \Phi(F)$ . Similarly, for m-variate G only in variables  $\bar{X}_L$  or  $\bar{X}_R$ , we will be switching between the vector representation  $\mathbf{G} \in \mathbb{F}^M$  defined by the coefficients of G or its univariate twin  $g(X) = \Phi(G)$ . We will sometimes overload the notation and denote the univariate twin  $g(X) = \Phi(G)$ , which is the same polynomial as  $\Phi(G)$ .
+
+Towards an efficient multilinear PCS through an interactive proof system. In the rest of this subsection, we present a robust interactive protocol that reduces the problem of 2m-variate multilinear evaluation to a single evaluation of a bivariate polynomial from  $\mathbb{F}[X,Y]^{< M,M}$ , two evaluations of univariate polynomials of degree less than M, and two inner product statements about coefficient vectors of the univariates. Notably, the verifier's complexity is dominated by the evaluation of the bivariate polynomial with  $M^2 = N$  coefficients, which has complexity O(N) while the original multilinear evaluation of F takes  $O(N \log(N))$ . The complexity of all remaining tasks is proportional to  $M = \sqrt{N}$ . The reduction to bivariate evaluation is also very much in line with our goal of building a multilinear PCS from a bivariate PCS for evaluating the committed bivariate twin representation f(X,Y) of F. Specifically, the evaluation of f(X,Y) will be outsourced to the prover, enabling fast verification.
+
+Reducing the size of the evaluation claim: By the associativity of matrix multiplication, we can rewrite the evaluation claim as a claim about an inner product of two vectors of dimension only  $2^m = \sqrt{N}$  (compared to the original  $N = 2^n$  terms in the matrix  $\mathbf{F}$ ) as follows:
+
+<span id="page-9-0"></span>
+$$\eta \stackrel{?}{=} F(\bar{z}) = \left( - \Psi_{\bar{z}_L}^T - \right) \begin{pmatrix} \mathbf{F} \\ \end{pmatrix} \begin{pmatrix} \Psi_{\bar{z}_R} \\ | \end{pmatrix} \\
+= \left( - \Psi_{\bar{z}_L}^T - \right) \begin{pmatrix} \mathbf{F}_{\bar{z}_R} \\ | \end{pmatrix} \\
+= \langle \Psi_{\bar{z}_L}, \mathbf{F}_{\bar{z}_R} \rangle.$$
+(5)
+
+{10}------------------------------------------------
+
+Note that the above vector Fz¯<sup>R</sup> has a particular interpretation with respect to the multilinear polynomial F. It is exactly the vector of coefficients of the partial restriction of F in the last m variables by z¯R. Indeed, for all u¯ ∈ B<sup>m</sup>
+
+$$\mathbf{F}_{\bar{z}_R,\langle\bar{u}\rangle} = \sum_{\bar{v}\in B^m} \mathbf{F}_{\langle\bar{u}\rangle,\langle\bar{v}\rangle} \widetilde{eq}(\bar{v};\bar{z}_R) = \sum_{\bar{v}\in B^m} F(\bar{u},\bar{v}) \widetilde{eq}(\bar{v};\bar{z}_R) = F(\bar{u},\bar{z}_R) = F_{\bar{z}_R}(\bar{u}),$$
+
+i.e., the location in the vector Fz¯<sup>R</sup> indexed by ⟨u¯⟩ equals the evaluation of the restriction Fz¯<sup>R</sup> at u¯.
+
+In other words, we have moved from evaluating the multilinear F(X¯L, X¯R) at (¯zL, z¯R) to evaluating the restriction F(X¯L, z¯R) = Fz¯<sup>R</sup> (X¯L) at z¯L. Thus, if we can efficiently verify the correctness of the vector of coefficients of the partial restriction Fz¯<sup>R</sup> relative to the matrix of coefficients of F then we can greatly simplify the evaluation of F at z¯.
+
+Verifying the correctness of the partial restriction: The matrix view of the evaluation claim suggests an efficient randomized verification check of the correctness of Fz¯<sup>R</sup> relative to F. To this end, we consider the univariate representation of Fz¯<sup>R</sup> , i.e., the univariate polynomial fz¯<sup>R</sup> = ΦX(Fz¯<sup>R</sup> ). Similarly to the soundness of many classical interactive proofs, the verification is based on evaluating the univariate fz¯<sup>R</sup> at a uniform α ← F, which we rewrite as an inner product of M-dimensional vectors:
+
+<span id="page-10-0"></span>
+$$f_{\bar{z}_{R}}(\alpha) \stackrel{?}{=} (1, \alpha, \dots, \alpha^{M-1}) \begin{pmatrix} \mathbf{F}_{\bar{z}_{R}} \\ \mathbf{F}_{\bar{z}_{R}} \end{pmatrix}$$
+
+$$= (1, \alpha, \dots, \alpha^{M-1}) \begin{pmatrix} \mathbf{F} \\ \mathbf{F} \end{pmatrix} \begin{pmatrix} \mathbf{\Psi}_{\bar{z}_{R}} \\ \mathbf{I} \end{pmatrix}$$
+
+$$= (- \mathbf{F}_{\alpha}^{T} -) \begin{pmatrix} \mathbf{\Psi}_{\bar{z}_{R}} \\ \mathbf{I} \end{pmatrix}$$
+
+$$= \langle \mathbf{F}_{\alpha}, \mathbf{\Psi}_{\bar{z}_{R}} \rangle.$$
+
+$$(6)$$
+
+The above reduces the problem of verifying the correctness of Fz¯<sup>R</sup> to an inner product statement about F<sup>α</sup> and the Lagrange vector Ψz¯<sup>R</sup> . Unlike Fz¯<sup>R</sup> , the vector F<sup>α</sup> cannot be interpreted as a restriction of the multilinear polynomial F as it is not a product of a Lagrange basis evaluation vector with F. Instead, it is simply a coefficient vector of the m-variate multilinear polynomial
+
+$$F_{\alpha}(X_{m+1},\ldots,X_{2m}) \coloneqq \sum_{\bar{u}\in B^m} \alpha^{\langle \bar{u}\rangle} F(\bar{u},X_{m+1},\ldots,X_{2m}),$$
+
+i.e., the function constructed as a linear combination of the "slices" of F obtained by restricting the first m variables by vectors from the m-dimensional hypercube. Indeed, for all v¯ ∈ B<sup>m</sup>,
+
+$$\mathbf{F}_{\alpha,\langle \bar{v}\rangle} = \sum_{\bar{u}\in B^m} \alpha^{\langle u\rangle} \mathbf{F}_{\langle \bar{u}\rangle,\langle \bar{v}\rangle} = \sum_{\bar{u}\in B^m} \alpha^{\langle u\rangle} F(\bar{u},\bar{v}) = F_{\alpha}(\bar{v}),$$
+
+i.e., the location in the vector F<sup>α</sup> indexed by ⟨v¯⟩ equals the evaluation of the function F<sup>α</sup> at v¯.
+
+Of course, we also need to verify the correctness of F<sup>α</sup> relative to F. This can be based on evaluating the univariate representation f<sup>α</sup> = Φ<sup>Y</sup> (Fα) of F<sup>α</sup> on a uniform β ← F, via the following derivation:
+
+{11}------------------------------------------------
+
+**Input:** Multilinear  $F(X_1, \ldots, X_{2m}) \in \mathbb{F}[X_1, \ldots, X_{2m}]^{\leq 1}$ , an evaluation point  $\bar{z} \in \mathbb{F}^n$ , and a claimed value  $\eta \in \mathbb{F}$ .
+
+1. P computes the m-variate restriction
+
+<span id="page-11-0"></span>
+$$F_{\bar{z}_R}(X_1,\ldots,X_m)=F(X_1,\ldots,X_m,\bar{z}_R)$$
+
+and sends the coefficient vector of  $F_{\bar{z}_R}$  to V.
+
+- 2. V samples  $\alpha \leftarrow \mathbb{F}$  uniformly at random and sends it to P.
+- 3. P computes the m-variate polynomial
+
+$$F_{\alpha}(X_{m+1},\ldots,X_{2m}) = \sum_{\bar{u}\in R^m} \alpha^{\langle \bar{u}\rangle} F(\bar{u},X_{m+1},\ldots,X_{2m}),$$
+
+and sends the coefficient vector of  $F_{\alpha}$  to V.
+
+4. V samples  $\beta \leftarrow \mathbb{F}$  uniformly at random. Denote by  $\mathbf{G}_0$ , respectively  $\mathbf{G}_1$ , the coefficient vectors received from P in round 1, respectively round 3. V accepts if and only if
+
+$$\eta = \langle \mathbf{\Psi}_{\bar{z}_L}, \mathbf{G}_0 \rangle, \quad g_0(\alpha) = \langle \mathbf{G}_1, \mathbf{\Psi}_{\bar{z}_R} \rangle, \quad \text{and} \quad g_1(\beta) = f(\alpha, \beta),$$
+
+where  $g_0(X) = \Phi_X(\mathbf{G}_0), g_1(Y) = \Phi_Y(\mathbf{G}_1), \text{ and } f(X, Y) = \Phi(F).$ 
+
+**Fig. 1.** Interactive proof for multilinear polynomial evaluation on  $\mathbb{F}[X_1,\ldots,X_{2m}]^{\leq 1}$ .
+
+<span id="page-11-1"></span>
+$$f_{\alpha}(\beta) \stackrel{?}{=} (\mathbf{F}_{\alpha}^{T} -) \begin{pmatrix} 1 \\ \beta \\ \vdots \\ \beta^{M-1} \end{pmatrix}$$
+
+$$= (1, \alpha, \dots, \alpha^{M-1}) \begin{pmatrix} \mathbf{F} \end{pmatrix} \begin{pmatrix} 1 \\ \beta \\ \vdots \\ \beta^{M-1} \end{pmatrix}$$
+
+$$= f(\alpha, \beta),$$
+
+$$(7)$$
+
+where  $f(X,Y) = \Phi(F)$  is the bivariate representation of the multilinear F.
+
+The interactive protocol. The interactive protocol based on the above discussion is presented in Figure 1. The prover first sends the coefficients of restriction  $F_{\bar{z}_R}$ . Upon receiving the challenge  $\alpha$ , the prover sends the coefficients of  $F_{\alpha}$ . Verifier then samples  $\beta$  and performs the checks equivalent to the checks derived in Equations (5), (6), and (7).
+
+Next, we establish the completeness and soundness of our protocol. Importantly, Lemma 1 shows that the soundness of the multilinear evaluation protocol in Figure 1 degrades with  $M=2^m$  and not solely with m, as one might expect. Nevertheless, the attained soundness error is meaningful for many values of m. A typical range of parameters for which one would use Lemma 1 is  $m \le 20$  and  $\log |\mathbb{F}| = 255$ . Then, we can upper bound the soundness error of the interactive proof in Figure 1 by  $2^{-205}$ .
+
+<span id="page-11-2"></span>**Lemma 1.** The protocol in Figure 1 is an interactive proof for multilinear evaluation on  $\mathbb{F}[X_1,\ldots,X_{2m}]^{\leq 1}$  with perfect completeness and soundness error at most  $2(M-1)|\mathbb{F}|^{-1}$ .
+
+*Proof.* Perfect completeness of the protocol follows by construction. In particular, the prescribed prover P sends  $\mathbf{G}_0 = \mathbf{F}_{\bar{z}_R}$  and  $\mathbf{G}_1 = \mathbf{F}_{\alpha}$ , and the verifier's check is equivalent to
+
+$$\eta = \langle \mathbf{\Psi}_{\bar{z}_L}, \mathbf{F}_{\bar{z}_R} \rangle, \quad f_{\bar{z}_R}(\alpha) = \langle \mathbf{F}_{\alpha}, \mathbf{\Psi}_{\bar{z}_R} \rangle, \quad \text{and} \quad f_{\alpha}(\beta) = f(\alpha, \beta),$$
+
+{12}------------------------------------------------
+
+where  $f_{\bar{z}_R}(X) = \Phi_X(F_{\bar{R}})$ ,  $f_{\alpha}(Y) = \Phi_Y(F_{\alpha})$ , and  $f(X,Y) = \Phi(F)$ . It follows from our motivating discussion in this section that all of the equalities hold and V accepts.
+
+Soundness. Suppose the evaluation claim does not hold, i.e.,  $F(\bar{z}) \neq \eta$ . Let us denote the coefficient vectors sent by the cheating prover  $P^*$  as  $\mathbf{G}_0$  and  $\mathbf{G}_1$ . If  $P^*$  sends the coefficient vector  $\mathbf{G}_0 = \mathbf{F}_{\bar{z}_R}$  then
+
+$$\langle \mathbf{\Psi}_{\bar{z}_L}, \mathbf{G}_0 \rangle = \langle \mathbf{\Psi}_{\bar{z}_L}, \mathbf{F}_{\bar{z}_R} \rangle = F(\bar{z}_L, \bar{z}_R) \neq \eta,$$
+
+and V rejects. Thus, we can assume that  $G_0 \neq F_{\bar{z}_R}$  so that  $P^*$  makes the first verifier's check pass.
+
+Let  $g_0 = \Phi_X(\mathbf{G}_0)$  and  $f_{\bar{z}_R} = \Phi_X(\mathbf{F}_{\bar{z}_R})$  denote the univariate polynomial representations of the vectors  $\mathbf{G}_0$  and  $\mathbf{F}_{\bar{z}_R}$  respectively. Since  $\mathbf{G}_0 \neq \mathbf{F}_{\bar{z}_R}$ , the polynomials  $g_0$  and  $f_{\bar{z}_R}$  are distinct and have degree at most M-1. Accordingly, the probability that they agree at a uniform  $\alpha \leftarrow \mathbb{F}$  is at most  $(M-1)|\mathbb{F}|^{-1}$ . We refer to the event  $g_0(\alpha) = f_{\bar{z}_R}(\alpha)$  as a collision in the first round. If this collision occurs,  $\mathsf{P}^*$  can send the honest vector  $\mathbf{G}_1 = \mathbf{F}_{\alpha}$  and satisfy all subsequent checks.
+
+Now, assume there was no collision in the first round, i.e.,  $g_0(\alpha) \neq f_{\bar{z}_R}(\alpha)$ . The verifier's second check requires that  $g_0(\alpha) = \langle \mathbf{G}_1, \mathbf{\Psi}_{\bar{z}_R} \rangle$ . Recall that the honest witness satisfies  $f_{\bar{z}_R}(\alpha) = \langle \mathbf{F}_{\alpha}, \mathbf{\Psi}_{\bar{z}_R} \rangle$ . Since the left sides differ  $(g_0(\alpha) \neq f_{\bar{z}_R}(\alpha))$ , the right sides must also differ, i.e.,
+
+$$\langle \mathbf{G}_1, \mathbf{\Psi}_{\bar{z}_R} \rangle \neq \langle \mathbf{F}_{\alpha}, \mathbf{\Psi}_{\bar{z}_R} \rangle.$$
+
+The above inequality implies that  $\mathbf{G}_1 \neq \mathbf{F}_{\alpha}$ . Consequently, the univariate polynomial  $g_1 = \Phi_Y(\mathbf{G}_1)$  sent by  $\mathsf{P}^*$  is distinct from the honest polynomial  $f_{\alpha} = \Phi_Y(\mathbf{F}_{\alpha})$ . Note that  $f_{\alpha}(Y)$  is identically the polynomial  $f(\alpha, Y)$  used in the final check. Since both  $g_1$  and  $f_{\alpha}$  have degree at most M-1, the probability that they agree at a uniform  $\beta \leftarrow \mathbb{F}$  is at most  $(M-1)|\mathbb{F}|^{-1}$ . Thus, if the prover is forced to send a wrong  $\mathbf{G}_1$ , the third verifier's check passes with probability at most  $(M-1)|\mathbb{F}|^{-1}$ .
+
+By a union bound over the two possible failure modes (a collision at  $\alpha$ , or a collision at  $\beta$  given no prior collision), the total soundness error is at most  $2(M-1)|\mathbb{F}|^{-1}$ .
+
+To clarify the difference between Chopin and the recent multilinear PCS proposals Mercury and Samaritan [EG25, GPS25], we present the interactive proof underlying those protocols in Appendix A. Crucially, they reduce to evaluating a *univariate* twin of the multilinear polynomial F, which introduces some additional overhead and makes the security of their IP degrade with N instead of  $M = \sqrt{N}$  as in Chopin (see Lemma 5).
+
+Similarly to other templates for efficient multilinear PCS schemes, the interactive proof presented in Figure 1 is implicitly based on the "sumcheck view" of the evaluation claim  $F(\bar{z}) = \eta$ . In fact, its first round is equivalent to the first round of the Divide-and-Conquer sumcheck protocol of Levrat, Medevielle, and Nardi [LMN25]. In their work, Levrat et al. presented a variant of the sumcheck protocol for n-variate polynomials that proceeds in  $\log(n)$  rounds. Their approach employs a more aggressive partial restriction strategy than the standard sumcheck protocol, fixing half of the input variables at each step, similar to the protocol in Figure 1. However, the consistency check in their protocol is established by evaluating the intermediate restricted polynomials at uniform values. In contrast, the protocol in Figure 1 performs the consistency check via a random "folding"  $F_{\alpha}$  of the slices of the multilinear F, giving rise to a constant-round protocol. Thus, the divide-and-conquer sumcheck analogy is not preserved throughout the rest of the protocol as the folding of F is defined by the evaluations of the univariate monomial basis of degree M-1 at  $\alpha$ . Consequently, with overwhelming probability,  $F_{\alpha}$  is not a random partial restriction of F in the first m variables.
+
+# <span id="page-12-0"></span>4.2 Matryoshka PCS: Bivariate and Univariate Evaluation Proofs under a Single Bivariate Commitment Key
+
+The verification checks from the protocol in Figure 1 require evaluating bivariate and univariate polynomials. When we move towards constructing a multilinear PCS based on this template, we implement these checks via a polynomial commitment scheme. In this section, we discuss a natural optimized variant based on a single bivariate commitment key.
+
+{13}------------------------------------------------
+
+$$\mathsf{KGen}(1^{\lambda},(d_X,d_Y),\mathsf{gp})$$
+: On input  $1^{\lambda}$ , sample  $\tau,\sigma\leftarrow\mathbb{F}$  and output
+
+$$\mathsf{ck} = \Big( ([\,\tau^i\sigma^j\,]_1)_{0 \leq i \leq d_X, \; 0 \leq j \leq d_Y}, \; ([\tau]_2, [\sigma]_2) \Big).$$
+
+Com(ck, f(X, Y )): On input a bivariate polynomial
+
+$$f(X,Y) = \sum_{i=0}^{d_1} \sum_{j=0}^{d_2} f_{i,j} X^i Y^j \in \mathbb{F}[X,Y],$$
+
+with degX(f) = d<sup>1</sup> ≤ d<sup>X</sup> and deg<sup>Y</sup> (f) = d<sup>2</sup> ≤ d<sup>Y</sup> , the algorithm outputs the commitment
+
+$$C = \sum_{i=0}^{d_1} \sum_{j=0}^{d_2} f_{i,j} [\tau^i \sigma^j]_1 = [f(\tau, \sigma)]_1 \in \mathbb{G}_1.$$
+
+Open(ck, C,(α, β), η): To open C at (α, β) ∈ F 2 , compute
+
+$$q_1(X,Y) = \frac{f(X,Y) - f(\alpha,Y)}{X - \alpha}, \qquad q_2(Y) = \frac{f(\alpha,Y) - f(\alpha,\beta)}{Y - \beta},$$
+
+and set
+
+<span id="page-13-0"></span>
+$$\pi_1 = [q_1(\tau, \sigma)]_1, \quad \pi_2 = [q_2(\sigma)]_1.$$
+
+Output π = (π1, π2).
+
+Ver(ck, C,(α, β), η,(π1, π2)): To verify C at (α, β) with value η, check
+
+$$C \bullet [1]_2 = \pi_1 \bullet [\tau - \alpha]_2 \otimes \pi_2 \bullet [\sigma - \beta]_2.$$
+
+Accept if true, else reject.
+
+Fig. 2. Bivariate KZG polynomial commitment scheme.
+
+The naive way of implementing the checks from our protocol in Figure [1](#page-11-0) would be to invoke both a bivariate and a univariate PCS. However, that would be unnecessarily wasteful. Note that a bivariate PCS supporting polynomials of degree less than M in each variable can, by definition, also be used to prove evaluations of univariate polynomials of degree less than M. This trivial observation does decrease the size of the commitment key, but it still comes with some additional overhead. Say that we commit to a univariate polynomial f(X) under a bivariate PCS. Then, to rely on the knowledge soundness of the bivariate PCS, we need to treat the committed polynomial as "bivariate" and evaluate the polynomial on uniform inputs (α, β) ← F 2 (cf. Definition [3\)](#page-8-1). Crucially, given a commitment and an evaluation claim with a proof, we are only guaranteed that the extractor outputs a bivariate polynomial consistent with the commitment and the evaluation claim from the adversary, and we would need to deal with this nuisance when designing an extractor for the whole protocol. Still, all of the above are mostly technical complications, and there is nothing fundamentally blocking us from using a bivariate PCS to handle univariate polynomials. That being said, we avoid the above technical issues by requiring a bivariate matryoshka PCS that directly supports univariate polynomials with a dedicated univariate extractor. Importantly, the bivariate KZG (Figure [2\)](#page-13-0) is a matryoshka PCS in the above sense as we discuss next.
+
+Recall the structure of a commitment key in bivariate and univariate KZG:
+
+$$\mathsf{ck}_b = (\{[\tau^i \sigma^j]_1\}_{0 \le i, j < M}, [1, \tau, \sigma]_2) \text{ and } \mathsf{ck}_u = \{[\tau^i]_1, [1, \tau]_2\}_{0 \le i < M},$$
+
+where τ and σ are the secret trapdoors. Note that the univariate ck<sup>u</sup> corresponds to a "slice" of the bivariate commitment key ck<sup>b</sup> by fixing j = 0.
+
+Let f(X) be a univariate polynomial of degree less than M. First note that, when committing to f under the bivariate key ckb, we are effectively using only its univariate slice ck<sup>u</sup> as all the monomials X<sup>i</sup>Y <sup>j</sup> with nonzero j have a zero coefficient in f(X). Thus, the commitment C<sup>f</sup> = bKZG.Com(ckb, f) = KZG.Com(cku, f) does not change whether we use a univariate or a bivariate commitment key.
+
+{14}------------------------------------------------
+
+To provide an evaluation proof at (α, β) ∈ F 2 , the prover computes the quotient polynomials
+
+$$q_1(X,Y) = \frac{f(X,Y) - f(\alpha,Y)}{X - \alpha}, \qquad q_2(Y) = \frac{f(\alpha,Y) - f(\alpha,\beta)}{Y - \beta},$$
+
+that, in the case of a univariate f(X), simplify to
+
+$$q_1(X) = \frac{f(X) - f(\alpha)}{X - \alpha}, \qquad q_2(Y) = \frac{f(\alpha) - f(\alpha)}{Y - \beta} = 0.$$
+
+In other words, the second quotient polynomial is identically zero, and the evaluation proof π = (π1, π2) = bKZG.Open(ckb, C<sup>f</sup> , f(X),(α, β), f(α)) comprises π<sup>1</sup> = [q1(τ )]<sup>1</sup> and π<sup>2</sup> = 1G<sup>1</sup> for all β ∈ F. Note that π<sup>1</sup> = [q1(τ )]<sup>1</sup> is exactly the univariate KZG evaluation proof for f(X) at α under cku. This is exactly the matryoshka PCS property: When we run the bivariate KZG scheme on a univariate polynomial in X, we are effectively running the univariate KZG scheme.
+
+Next, we discuss the corresponding matryoshka extractors. Both univariate, respectively bivariate, KZG schemes are knowledge sound under the ARSDH, respectively ARSDH(2), assumptions [\[LPS24,](#page-31-12) [BDH](#page-30-9)+25]. Since, as we observed, evaluation proofs for univariate polynomials under a bivariate commitment key have the structure of univariate evaluation proofs, it is in principle possible to use the univariate extractor. The main technical issue is that the adversary is given the bivariate ck<sup>b</sup> when constructing commitments to univariate polynomials. However, note that any adversary against univariate KZG can efficiently extend its univariate slice ck<sup>u</sup> to a valid bivariate commitment key ck<sup>b</sup> distributed identically to the bivariate security experiment (sample σ ← F and compute the shifts of the univariate key by powers of σ provided in ckb). So, the bivariate key does not help the adversary against the univariate extractor, and the extractor for univariate KZG succeeds on the restriction of the bivariate KZG to univariate polynomials even when the adversary is given a commitment key for bivariate KZG. In the rest of the paper, we assume that the extraction can securely proceed in a matryoshka fashion.
+
+## <span id="page-14-0"></span>4.3 Chopin Multilinear PCS
+
+In this section, we present Chopin PCS as an instantiation of the interactive proof from Figure [1](#page-11-0) using a suitable matryoshka bivariate PCS. Recall that, in Equations [\(5\)](#page-9-0), [\(6\)](#page-10-0), and [\(7\)](#page-11-1), we reduced verifying the correctness of the intermediate multilinear polynomials Fz¯<sup>r</sup> and F<sup>α</sup> to checking that, e.g., fz¯<sup>R</sup> (α) = ⟨Fα, Ψz¯<sup>R</sup> ⟩. Since, in a PCS, the verifier cannot afford to evaluate polynomials of degree M or inner product statements proportional to the size of the committed polynomials, we would like to verifiably outsource these evaluations to the prover. This is easy for the evaluations of the twin polynomials fz¯<sup>R</sup> and f<sup>α</sup> of the multilinears Fz¯<sup>R</sup> and Fα. Instead of sending their coefficient vectors, the prover simply commits to the univariate twins via a PCS. When queried at α or β, the prover sends the evaluations together with evaluation proofs. Outsourcing the evaluation of ⟨Fα, Ψz¯<sup>R</sup> ⟩ to the prover is more challenging as we need to verify an inner product statement with respect to the coefficients of the committed twin polynomial f<sup>α</sup> and a Lagrange evaluation vector Ψz¯<sup>R</sup> , and a special "Lagrange Inner Product Argument" (Lagrange IPA) is needed for that. We formalize the notion of Lagrange IPAs for polynomial commitments in the following definition of a Lagrange IPA supporting PCS.
+
+Definition 5. A polynomial commitment scheme PCS = (KGen, Com, Open, Ver) is a Lagrange IPA supporting polynomial commitment scheme with respect to PGen, if there exist a PPT algorithm OpenLgrIPA and a DPT algorithm VerLgrIPA such that:
+
+OpenLgrIPA(ck, C, f, z, η ¯ ): Given a commitment key ck, a commitment C derived from a polynomial f under ck, an evaluation point z¯ ∈ F <sup>m</sup>, where m = log(deg(f) + 1) and an inner product result η = ⟨f, Ψz¯⟩, where f is the coefficient vector of f, returns an inner product argument proof π.
+
+VerLgrIPA(ck, C, z, η, π ¯ ): Given a commitment key ck, a commitment C, an evaluation point z¯, a proposed inner product result η and its proof π, returns 1 (accept) or 0 (reject).
+
+{15}------------------------------------------------
+
+```
+Let \Pi = (\mathsf{KGen}_b, \mathsf{Com}_b, \mathsf{Open}_b, \mathsf{Ver}_b, \mathsf{OpenLgrIPA}, \mathsf{VerLgrIPA}) be a Lagrange IPA supporting bivariate PCS.
+\mathsf{KGen}(1^{\lambda},(1,\ldots,1),\mathsf{gp}): On input security parameter 1^{\lambda}, degree bound (1,\ldots,1) and number of variables n=2m,
+       set M = 2^m and output \mathsf{ck} \leftarrow \mathsf{KGen}_b(1^\lambda, (M-1, M-1)).
+Com(ck, F): On input ck and F \in \mathbb{F}[X_1, \dots, X_n]^{\leq 1}, output commitment C = \mathsf{Com}_b(\mathsf{ck}, \Phi(F)).
+(\mathsf{P}(F),\mathsf{V})(\mathsf{ck},C,\bar{z}=(\bar{z}_L,\bar{z}_R),\eta):
+         1. Set f(X,Y) = \Phi(F(X_1,\ldots,X_n)).
+         2. P computes a restriction F_{\bar{z}_R}(X_1,\ldots,X_m)=F(X_1,\ldots,X_m,\bar{z}_R), sets f_{\bar{z}_R}(X)=\Phi_X(F_{\bar{z}_R}(X_1,\ldots,X_m)),
+              commits to f_{\bar{z}_R} as C_0 = \mathsf{Com}_b(\mathsf{ck}, f_{\bar{z}_R}(X)) and sends C_0 to \mathsf{V}.
+         3. V samples \alpha \leftarrow \mathbb{F} uniformly at random and sends it to P.
+         4. P computes F_{\alpha}(X_{m+1},\ldots,X_n) = \sum_{\bar{u}\in B^m} \alpha^{\langle \bar{u}\rangle} F(\bar{u},X_{m+1},\ldots,X_n), sets f_{\alpha}(Y) = \Phi_Y(F_{\alpha}(X_{m+1},\ldots,X_n)), commits to f_{\alpha} as C_1 = \mathsf{Com}_b(\mathsf{ck},f_{\alpha}(Y)), and sends C_1 and a = f_{\bar{z}_R}(\alpha)
+              to V.
+         5. V samples \beta \leftarrow \mathbb{F} uniformly at random and sends it to P.
+         6. P computes b = f_{\alpha}(\beta) and the following evaluation proofs:
+                 -\pi_{\alpha,\beta} = \mathsf{Open}_b(\mathsf{ck}, C, f, (\alpha, \beta), b),
+                 - \pi_{0,\alpha} = \mathsf{Open}_b(\mathsf{ck}, C_0, f_{\bar{z}_R}, \alpha, a),
+                 -\pi_{1,\beta} = \mathsf{Open}_b(\mathsf{ck}, C_1, f_\alpha, \beta, b),
+                 -\pi_{R,L} = \mathsf{OpenLgrIPA}(\mathsf{ck}, C_0, f_{\bar{z}_R}, \bar{z}_L, \eta),
+                 -\pi_{\alpha,R} = \mathsf{OpenLgrIPA}(\mathsf{ck}, C_1, f_\alpha, \bar{z}_R, a).
+              P sends b and all the evaluation proofs to V.
+         7. V accepts iff
+                 - \operatorname{Ver}_b(\operatorname{ck}, C, (\alpha, \beta), b, \pi_{\alpha, \beta}) = 1,
+                 - \operatorname{Ver}_b(\operatorname{ck}, C_0, \alpha, a, \pi_{0,\alpha}) = 1,
+                 - Ver_b(ck, C_1, \beta, b, \pi_{1,\beta}) = 1,
+                 - VerLgrIPA(ck, C_0, \bar{z}_L, \eta, \pi_{R,L}) = 1,
+                 - VerLgrIPA(ck, C_1, \bar{z}_R, a, \pi_{\alpha,R}) = 1.
+              Otherwise, V rejects.
+```
+
+<span id="page-15-0"></span>Fig. 3. Chopin multilinear PCS from a Lagrange IPA supporting bivariate PCS.
+
+Additionally for all polynomials f supported by the PCS with degree  $\mathbf{d} \in \mathsf{poly}(\lambda)$  and for all  $\bar{z} \in \mathbb{F}^m$  it holds:
+
+$$\Pr\left[ \begin{aligned} \text{VerLgrIPA}(\mathsf{ck}, C, \bar{z}, \eta, \pi) &= 1 \begin{vmatrix} \mathsf{gp} \leftarrow \mathsf{PGen}(1^\lambda), \\ \mathsf{ck} \leftarrow \mathsf{KGen}(1^\lambda, \mathbf{d}, \mathsf{gp}), \\ C &= \mathsf{Com}(\mathsf{ck}, f), \eta = \langle \mathbf{f}, \mathbf{\Psi}_{\bar{z}} \rangle, \\ \pi \leftarrow \mathsf{OpenLgrIPA}(\mathsf{ck}, C, f, \bar{z}, \eta) \end{aligned} \right] = 1,$$
+
+where  $\mathbf{f}$  is the coefficient vector of f.
+
+We denote  $\Pi = (\mathsf{KGen}, \mathsf{Com}, \mathsf{Open}, \mathsf{Ver}, \mathsf{OpenLgrIPA}, \mathsf{VerLgrIPA})$  the IPA supporting PCS.
+
+Eagen and Gabizon [EG25] and Ganesh et al. [GPS25] presented efficient Lagrange IPAs for a univariate PCS. In Section 5, we discuss the specific construction from Eagen and Gabizon [EG25] and prove the knowledge soundness of its batched variant extended to the bivariate setting. In the rest of this section, we present and analyse a general variant of the Chopin multilinear PCS constructed from any Lagrange IPA supporting PCS.
+
+CHOPIN multilinear PCS. Recall some of the notation introduced in the previous section. For a binary vector  $\bar{u} \in \{0,1\}^m$ , we denote by  $\langle \bar{u} \rangle = \sum_{i=1}^m u_i 2^{i-1}$  the corresponding integer value. We use the bijection  $\Phi(\tilde{eq}(\bar{u}; \bar{X}_L) \cdot \tilde{eq}(\bar{v}; \bar{X}_R)) = X^{\langle \bar{u} \rangle} Y^{\langle \bar{v} \rangle}$  mapping multilinear polynomials to bivariate ones.
+
+Our multilinear PCS is presented in Figure 3. Let  $\Pi = (\mathsf{KGen}_b, \mathsf{Com}_b, \mathsf{Open}_b, \mathsf{Ver}_b, \mathsf{OpenLgrIPA}, \mathsf{VerLgrIPA})$  be a bivariate Lagrange IPA supporting PCS. The commitment key in Chopin is simply  $\mathsf{ck} \leftarrow \mathsf{KGen}_b(1^\lambda, (M-1, M-1), \mathsf{gp})$ , so that we can commit to bivariate polynomials with degree less than M in each variable,
+
+{16}------------------------------------------------
+
+and, thus, to univariate polynomials of degree less than M. In order to commit to a 2m-variate multilinear polynomial  $F(X_1, \ldots, X_{2m})$ , we commit to its bivariate twin  $f(X, Y) = \Phi(F)$  using the bivariate  $\mathsf{PCS}_b$ .
+
+The evaluation proof is presented as a public-coin interactive protocol between a prover and a verifier. The non-interactive algorithms Open and Ver for constructing and verifying an evaluation proof can be constructed from the interactive protocol via the Fiat-Shamir heuristic. The prover first sends a commitment to the univariate twin  $f_{\bar{z}_R}$  of the partial restriction  $F_{\bar{z}_R}$ . Upon receiving the challenge  $\alpha$ , the prover sends a commitment to the univariate twin  $f_{\alpha}$  of  $F_{\alpha}$  together with the value  $a = f_{\bar{z}_R}(\alpha)$ . Upon receiving the second challenge  $\beta$ , the prover prepares evaluation proofs and Lagrange IPA proofs for the checks derived in equations (5), (6), and (7), and sends them together with the value  $b = f_{\alpha}(\beta)$  to the verifier. The verifier accepts if and only if the received evaluation proofs and Lagrange IPA proofs are accepting.
+
+Knowledge soundness of CHOPIN. We prove the knowledge soundness of CHOPIN by reducing to the knowledge soundness of the underlying bivariate PCS and the Lagrange IPA. A natural approach is to invoke the bivariate PCS extractor to obtain f,  $f_{\bar{z}_R}$ , and  $f_{\alpha}$  consistent with the evaluation constraints, and, independently, use the Lagrange IPA extractor to extract  $f'_{\bar{z}_R}$  and  $f'_{\alpha}$  consistent with the Lagrange IPA constraints. Ideally, the extracted polynomials  $f_{\bar{z}_R}$  and  $f_{\alpha}$  would be equal to  $f'_{\bar{z}_R}$  and  $f'_{\alpha}$  and would satisfy Equations (5), (6), and (7), confirming that F is consistent with both the commitment and the claimed evaluation  $\eta$  at  $\bar{z}$ . However, this argument fails if the polynomials extracted via the PCS extractor differ from those extracted via the Lagrange IPA extractor. To bridge this gap, we introduce a definition of knowledge soundness for Lagrange IPA supporting PCS, which guarantees that we can directly extract a witness polynomial satisfying both an evaluation constraint and a Lagrange IPA constraint when given a pair of an evaluation proof and a Lagrange IPA proof.
+
+<span id="page-16-0"></span>Definition 6 (KS for Lagrange IPA supporting PCS). Let  $\Pi = (\mathsf{KGen}, \mathsf{Com}, \mathsf{Open}, \mathsf{Ver}, \mathsf{OpenLgrIPA})$ , VerLgrIPA) be an n-variate Lagrange IPA supporting PCS. We say that  $\Pi$  is knowledge sound for PGen, if there exists a PPT extractor Ext, such that for all adversaries  $\mathcal{A} = (\mathcal{A}_0, \mathcal{A}_1)$ , where  $\mathcal{A}_0$  is PPT and  $\mathcal{A}_1$  is DPT, and for all  $\mathbf{d} = (d_1, \ldots, d_n) \in \mathsf{poly}(\lambda)$ , it holds that
+
+$$\Pr \begin{bmatrix} \operatorname{Ver}(\mathsf{ck}, C, \bar{z}_1, \eta_1, \pi_1) = 1 \land \\ \operatorname{VerLgrIPA}(\mathsf{ck}, C, \bar{z}_2, \eta_2, \pi_2) = 1 \land \\ (C \neq \mathsf{Com}(\mathsf{ck}, f) \lor \\ \exists i \in [n], \deg_{X_i} f > d_i \lor \\ f(\bar{z}_1) \neq \eta_1 \lor \langle \boldsymbol{f}, \boldsymbol{\Psi}_{\bar{z}_2} \rangle \neq \eta_2 \ ) \end{bmatrix} \overset{\mathsf{gp}}{\leftarrow} \mathsf{PGen}(1^{\lambda}), \\ \mathsf{ck} \leftarrow \mathsf{KGen}(1^{\lambda}, \mathbf{d}, \mathsf{gp}), \\ (C, \mathsf{st}, \bar{z}_2) \leftarrow \mathcal{A}_0(\mathsf{ck}), \bar{z}_1 \leftarrow \mathbb{F}^n, \\ (\eta_1, \pi_1, \eta_2, \pi_2) \leftarrow \mathcal{A}_1(\mathsf{st}, \bar{z}_1, \bar{z}_2), \\ tr_1 = (\bar{z}_1, \eta_1, \pi_1), \ tr_2 = (\bar{z}_2, \eta_2, \pi_2), \\ f \leftarrow \mathsf{Ext}^{\mathcal{A}_1(\mathsf{st}, \cdot, \cdot)}(\mathsf{ck}, (C, tr_1, tr_2)) \end{bmatrix} \in \mathsf{negl}(\lambda),$$
+
+where  $\mathbf{f}$  is a vector of coefficients of f with respect to the Lagrange basis.
+
+<span id="page-16-1"></span>Using the above definition, we can prove the knowledge soundness of our protocol.
+
+Theorem 1 (Knowledge soundness of Chopin). Let  $\Pi = (\mathsf{KGen}_b, \mathsf{Com}_b, \mathsf{Open}_b, \mathsf{Ver}_b, \mathsf{OpenLgrIPA}, \mathsf{VerLgrIPA})$  be a Lagrange IPA supporting bivariate PCS. If  $\Pi$  is knowledge sound with matryoshka extractors, then the Chopin scheme defined in Figure 3 is a knowledge sound multilinear PCS.
+
+*Proof.* The correctness of the protocol follows directly from the correctness of the underlying interactive proof in Figure 1 established in Lemma 1 and the correctness of the Lagrange IPA supporting bivariate PCS. It remains to establish the knowledge soundness of the scheme as per Definition 3.
+
+Let  $\mathsf{P}^*$  be an arbitrary (possibly cheating) prover interacting with the verifier in the protocol defined in Figure 3. We construct an extractor Ext such that, if the verifier accepts with some probability  $\varepsilon$  when interacting with  $\mathsf{P}^*$  on common input  $\mathsf{ck}$ , C,  $\bar{z}$ ,  $\eta$  then, with probability at least  $\varepsilon - \mathsf{negl}(\lambda)$ , Ext outputs a multilinear polynomial  $F^*$  with  $F^*(\bar{z}) = \eta$  and  $\mathsf{Com}(\mathsf{ck}, F^*) = C$ .
+
+The extractor  $\operatorname{Ext}^{\operatorname{P*}}(\operatorname{ck},C,\bar{z},\eta)$  operates by invoking two sub-routines guaranteed by the knowledge soundness of the IPA supporting PCS. First, we utilize the extractor  $\operatorname{Ext}_{\operatorname{IPA},\operatorname{PCS}_b}$  to handle the commitments  $C_0$ 
+
+{17}------------------------------------------------
+
+and  $C_1$ , ensuring consistency with the inner product argument. Second, observing that this stronger definition implies standard knowledge soundness for  $PCS_b$ , we also employ the extractor  $Ext_{PCS_b}$  for the initial commitment C. Crucially, since we require that  $PCS_b$  supports matryoshka extractors, the existence of the bivariate extractor  $Ext_{PCS_b}$  implies the existence of a corresponding univariate extractor. To avoid cluttering the notation, we refrain from introducing a separate symbol for this univariate extractor. Instead, we adopt the convention that applying the bivariate extractor  $Ext_{PCS_b}$  to a commitment of a univariate polynomial implicitly invokes the underlying univariate extractor. The full extraction proceeds as follows.
+
+- 1. The extractor performs the evaluation proof protocol with  $P^*$  and obtains a transcript  $(C_0, \alpha, C_1, a, \beta, b, \bar{\pi})$ . If the transcript is rejecting, it restarts. Otherwise, it proceeds.
+- 2. Using its rewinding access to P\*, it extracts a polynomial
+  - (a)  $F^*$  from C using the extractor for  $PCS_b$ ,
+  - (b)  $f_{\bar{z}_R}^*$  from  $C_0$  using the extractor for IPA supporting  $PCS_b$ ,
+  - (c)  $f_{\alpha}^*$  from  $C_1$  using the extractor for IPA supporting  $\mathsf{PCS}_b$ .
+- 3. Outputs  $F^*$ .
+
+The extractor implicitly employs the recursive rewinding strategy of Attema et al. [ACK21]. We initiate the protocol and restart if the primary transcript is rejecting. Conditioned on an initial acceptance, this strategy guarantees a high probability of extracting a tree of transcripts which allows the extractor to reconstruct the underlying polynomials via interpolation.
+
+Since all the evaluation proofs in the transcript obtained during the first step of the extraction are accepting and the extracted polynomials are consistent with the observed evaluations (guaranteed by the extractor for  $PCS_b$  and for the IPA supporting  $PCS_b$ ), we have that:
+
+$$f^*(\alpha, \beta) = f_{\alpha}^*(\beta) \qquad \text{(from } \pi_{\alpha, \beta}, \pi_{1, \beta}),$$
+
+$$f_{\bar{z}_R}^*(\alpha) = \langle \mathbf{f}_{\alpha}^*, \mathbf{\Psi}_{\bar{z}_R} \rangle \qquad \text{(from } \pi_{\alpha, R}, \pi_{0, \alpha}),$$
+
+$$\eta = \langle \mathbf{f}_{\bar{z}_R}^*, \mathbf{\Psi}_{\bar{z}_L} \rangle \qquad \text{(from } \pi_{R, L}),$$
+
+where  $\mathbf{f}_{\alpha}^*$  and  $\mathbf{f}_{\bar{z}_R}^*$  are the coefficient vectors of  $f_{\alpha}^*$  and  $f_{\bar{z}_R}^*$ , respectively. The above consistency conditions are exactly those enforced in the IP for multilinear evaluation from Figure 1. Moreover, the interaction pattern is identical in both protocols. In the interactive proof, the prover sends the restriction  $F_{\bar{z}_R}$  before receiving the first challenge  $\alpha$ ; it then sends the folded polynomial  $F_{\alpha}$  before receiving the second challenge  $\beta$ . The verifier concludes by checking the consistency of these polynomials at the random points defined by the challenges. This matching structure ensures that the extracted polynomials from Chopin can be used directly to simulate a prover in the IP. Consequently, if  $F^*(\bar{z}) \neq \eta$ , these polynomials give us a prover for the IP in Figure 1 that makes the verifier accept despite the evaluation claim being false, thereby establishing a reduction.
+
+By Lemma 1, if  $F^*(\bar{z}) \neq \eta$  then the probability (over  $\alpha, \beta$ ) that all of the verifier's checks pass is at most  $2(M-1)/|\mathbb{F}|$ , where  $M=2^m=\sqrt{2^n}$ . Therefore, except with the probability  $2(M-1)/|\mathbb{F}|$ , it holds that  $F^*(\bar{z})=\eta$ .
+
+## <span id="page-17-0"></span>5 Lagrange IPA Supporting Bivariate PCS
+
+One of the core building blocks of our efficient multilinear polynomial commitment scheme is a Lagrange inner product argument (Lagrange IPA). General IPAs allow a prover to efficiently convince a verifier that the inner product of two vectors evaluates to a given field element. While various IPAs exist in the literature [BCC<sup>+</sup>16, BBB<sup>+</sup>18, MBKM19, GW21, PH23], we build upon the construction from Mercury [EG25]. We note that Samaritan [GPS25] offers an alternative Lagrange IPA, which is, though, conceptually very similar. Note that, unlike traditional IPAs that rely on vector commitments, our setting requires an IPA compatible with polynomial commitment schemes, as we need to prove inner product statements about coefficients of committed polynomials. Additionally, in Appendix B, we discuss a variant of the protocol for multilinear polynomials represented in the monomial basis.
+
+{18}------------------------------------------------
+
+#### <span id="page-18-1"></span>5.1 Lagrange IPA from Mercury
+
+The Lagrange IPA from Mercury [EG25] is inspired by [BCC<sup>+</sup>16] and [MBKM19]. It is based on the following lemma, establishing that the constant term of the symmetric Laurent polynomial defined by polynomials g(X) and h(X) is related to the inner product of their coefficient vectors. For notational convenience, throughout this section, we index vector coordinates starting from 0.
+
+<span id="page-18-0"></span>Lemma 2 (Symmetric decomposition of Laurent polynomials). For  $d \in \mathbb{N}$ , let  $\mathbf{g} = (g_0, \dots, g_{d-1})$  and  $\mathbf{h} = (h_0, \dots, h_{d-1})$  be elements of  $\mathbb{F}^d$ , and define the associated univariate polynomials  $g(X) = \sum_{i=0}^{d-1} g_i X^i$  and  $h(X) = \sum_{i=0}^{d-1} h_i X^i$ . Then  $v = \langle \mathbf{g}, \mathbf{h} \rangle$  if and only if there exists a polynomial  $S(X) \in \mathbb{F}[X]$  of degree at most d-2 such that
+
+$$g(X)h(1/X) + g(1/X)h(X) = 2v + XS(X) + \frac{1}{X}S(1/X).$$
+
+*Proof.* We first show the forward implication. Consider the Laurent polynomial L(X) = g(X)h(1/X) + g(1/X)h(X) from the statement of the lemma. Using  $g(X) = \sum_{i=0}^{d-1} g_i X^i$  and  $h(X) = \sum_{j=0}^{d-1} h_j X^j$ , we obtain
+
+$$g(X)h(1/X) = \left(\sum_{i=0}^{d-1} g_i X^i\right) \left(\sum_{j=0}^{d-1} h_j X^{-j}\right) = \sum_{i,j=0}^{d-1} g_i h_j X^{i-j},$$
+
+and similarly  $g(1/X)h(X) = \sum_{i,j=0}^{d-1} g_i h_j X^{j-i}$ . Hence,
+
+$$L(X) = \sum_{i,j=0}^{d-1} g_i h_j (X^{i-j} + X^{j-i}) = \sum_{k=-(d-1)}^{d-1} a_k X^k.$$
+
+Note that all exponents k satisfy  $|k| \le d-1$ , since  $0 \le i, j \le d-1$ .
+
+Consider the constant term  $a_0$  of L(X), which receives contributions only from index pairs (i,j) with i=j. For each i, we get  $g_ih_i(X^0+X^0)=2g_ih_i$ , so  $a_0=2\sum_{i=0}^{d-1}g_ih_i=2\langle \boldsymbol{g},\boldsymbol{h}\rangle=2v$ .
+
+Now, we consider the other coefficients for  $k \in \{1, \ldots, d-1\}$ . The coefficient  $a_k$  of  $X^k$  in L(X) comes from the terms  $X^{i-j}$  with i-j=k in g(X)h(1/X) and the terms  $X^{j-i}$  with j-i=k in g(1/X)h(X). Thus,  $a_k = \sum_{i-j=k} g_i h_j + \sum_{j-i=k} g_i h_j$  and, by symmetry,  $a_{-k} = \sum_{i-j=-k} g_i h_j + \sum_{j-i=-k} g_i h_j$ . But i-j=k if and only if j-i=-k, and j-i=k if and only if i-j=-k, so the two sums coincide, and, hence,  $a_{-k} = a_k$  for all k.
+
+Define  $S(X) = \sum_{k=1}^{d-1} a_k X^{k-1}$  that, by construction, is of degree at most (d-1) - 1 = d-2. Moreover,
+
+$$2v + XS(X) + 1/XS(1/X) = a_0 + \sum_{k=1}^{d-1} a_k X^k + \sum_{k=1}^{d-1} a_k X^{-k} = \sum_{k=-(d-1)}^{d-1} a_k X^k$$
+$$= L(X) = g(X)h(1/X) + g(1/X)h(X),$$
+
+as claimed. To show the converse implication, observe that in the equation above the term  $XS(X) + \frac{1}{X}S(1/X)$  has no constant coefficient. On the other hand, the constant term of g(X)h(1/X) + g(1/X)h(X) is  $2\langle \boldsymbol{g}, \boldsymbol{h} \rangle$ . Therefore, by comparing constant terms on both sides, we obtain  $2v = 2\langle \boldsymbol{g}, \boldsymbol{h} \rangle$ , and hence  $\langle \boldsymbol{g}, \boldsymbol{h} \rangle = v$ .
+
+In particular, the polynomial identity in Lemma 2 allows us to translate an inner product claim to a polynomial identity that we can test via a random evaluation check. Recall that we are interested in "Lagrange inner product claims," i.e., inner product claims about the coefficient vector  $\mathbf{g}$  of a committed polynomial g and some Lagrange evaluation vector  $\Psi_{\bar{z}}$ . Note that the Lagrange evaluation vector is the coefficient vector of the univariate twin of  $\tilde{eq}(X_1, \ldots, X_m; \bar{z})$ , which can be written in the following equivalent ways
+
+$$\psi_{\bar{z}}(X) = \Phi_X(\widetilde{eq}(X_1, \dots, X_m; \bar{z})) = \sum_{\bar{b} \in B^m} \widetilde{eq}(\bar{b}; \bar{z}) X^{\langle \bar{b} \rangle} = \prod_{i=0}^{m-1} (1 - z_i + z_i X^{2^i}).$$
+
+{19}------------------------------------------------
+
+**Setup:** Let  $\mathsf{PCS}_b = (\mathsf{KGen}_b, \mathsf{Com}_b, \mathsf{Open}_b, \mathsf{Ver}_b)$  be a bivariate polynomial commitment scheme. For  $m \in \mathbb{N}$ , denote  $M = 2^m$ , and let  $\mathsf{ck} \leftarrow \mathsf{KGen}_b(1^\lambda, (M-1, M-1), \mathsf{gp})$  be a commitment key supporting polynomials of degree at most M-1 in each variable.
+
+Given commitments  $C_g$  and  $C_h$  and  $\bar{z}_1, \bar{z}_2 \in \mathbb{F}^m$ , the prover claims that  $\langle \mathbf{g}, \mathbf{\Psi}_{\bar{z}_1} \rangle = v_1$  and  $\langle \mathbf{h}, \mathbf{\Psi}_{\bar{z}_2} \rangle = v_2$ , where  $\mathbf{g}, \mathbf{h} \in \mathbb{F}^M$  are the coefficient vectors of univariate polynomials  $g, h \in \mathbb{F}[X]^{\leq M-1}$  committed in  $C_g$  and  $C_h$ , respectively.
+
+ $(P(g(X), h(X)), V)(ck, C_g, C_h, \bar{z}_1, \bar{z}_2, v_1, v_2)$ :
+
+- 1. V samples  $\gamma \leftarrow \mathbb{F}$  uniformly at random and sends it to P.
+- 2. P constructs  $\psi_{\bar{z}_1}(X)$  and  $\psi_{\bar{z}_2}(X)$ , and computes the polynomial S(X) satisfying
+
+$$g(X)\psi_{\bar{z}_1}(1/X) + g(1/X)\psi_{\bar{z}_1}(X) + \gamma \left(h(X)\psi_{\bar{z}_2}(1/X) + h(1/X)\psi_{\bar{z}_2}(X)\right)$$
+$$= 2\left(v_1 + \gamma v_2\right) + XS(X) + \frac{1}{X}S(1/X).$$
+
+Then, P sends the commitment  $C_S = \mathsf{Com}_b(\mathsf{ck}, S(X))$  to V.
+
+- 3. V samples  $\alpha \leftarrow \mathbb{F}$  uniformly at random and sends it to P.
+- 4. P computes the proofs for the following evaluation claims
+
+<span id="page-19-1"></span>
+$$a_1 = g(\alpha), \ a_2 = g(\alpha^{-1}), \ b_1 = h(\alpha),$$
+  
+ $b_2 = h(\alpha^{-1}), \ s_1 = S(\alpha), \ s_2 = S(\alpha^{-1}),$ 
+
+and sends them to V.
+
+5. V evaluates  $\psi_{\bar{z}_1}$  and  $\psi_{\bar{z}_2}$  at  $\alpha$  and  $\alpha^{-1}$  and accepts iff all received evaluation proofs are accepting and it holds that
+
+$$a_1 \psi_{\bar{z}_1}(\alpha^{-1}) + a_2 \psi_{\bar{z}_1}(\alpha) + \gamma (b_1 \psi_{\bar{z}_2}(\alpha^{-1}) + b_2 \psi_{\bar{z}_2}(\alpha))$$
+  
+=  $2(v_1 + \gamma v_2) + \alpha s_1 + \alpha^{-1} s_2$ .
+
+Fig. 4. Batched univariate Lagrange IPA under a bivariate PCS.
+
+Thus, to prove a Lagrange inner product claim  $\langle \mathbf{g}, \Psi_{\bar{z}} \rangle = v$ , the prover constructs  $\psi_{\bar{z}}(X)$  and computes a polynomial S(X) such that
+
+<span id="page-19-0"></span>
+$$g(X)\psi_{\bar{z}}(1/X) + g(1/X)\psi_{\bar{z}}(X) = 2v + XS(X) + (1/X)S(1/X). \tag{8}$$
+
+The prover then sends a commitment to S(X) to the verifier, who samples a uniform challenge evaluation point  $\alpha \leftarrow \mathbb{F}$  and sends it back to the prover. The prover computes the values and evaluation proofs for g(X) and S(X) at  $\alpha$  and  $\alpha^{-1}$  and sends them to the verifier. Using the representation of  $\psi_{\bar{z}}(X)$  as a product of m terms, the verifier can efficiently evaluate  $\psi_{\bar{z}}(X)$  at  $\alpha$  and  $\alpha^{-1}$  and accept if and only if the provided evaluation proofs are accepting and the identity in Equation (8) holds at  $\alpha$ .
+
+#### 5.2 Batched Lagrange IPA under a Bivariate PCS
+
+Eagen and Gabizon [EG25] presented a batch Lagrange IPA based on the protocol we discussed in the previous section. Their batch IPA allows proving two Lagrange inner product claims by taking a random linear combination of the two corresponding polynomial identities derived from Equation (8) and performing a random evaluation check on it. Importantly, the combined polynomial identity can be witnessed by a single polynomial S(X), yielding a strict improvement in communication complexity over the trivial non-batched variant. In Figure 4, we present a variant of their protocol adapted to the setting of univariate polynomials committed under a bivariate PCS. Again, in the analysis of the scheme, we assume that the bivariate PCS supports direct extraction of univariate polynomials in a matryoshka fashion.
+
+<span id="page-19-2"></span>**Theorem 2.** Let  $PCS_b = (KGen_b, Com_b, Open_b, Ver_b)$  be a bivariate PCS, and (OpenLgrIPA, VerLgrIPA) be the batch Lagrange IPA algorithms based on the protocol in Figure 4. If  $PCS_b$  is knowledge sound with
+
+{20}------------------------------------------------
+
+ $matryoshka\ extractors\ and\ evaluation\ binding,\ then\ \Pi = (\mathsf{KGen}_b, \mathsf{Com}_b, \mathsf{Open}_b, \mathsf{Ver}_b, \mathsf{OpenLgrIPA}, \mathsf{VerLgrIPA})$  is a knowledge sound batch Lagrange IPA supporting bivariate PCS in the sense of Definition 6.
+
+*Proof. The correctness* of the scheme follows from the correctness of the bivariate PCS and the existence of a polynomial S(X) of degree at most M-2 witnessing the symmetric decomposition of the Laurent polynomial. Since  $\langle \mathbf{g}, \mathbf{\Psi}_{\bar{z}_1} \rangle = v_1$  and  $\langle \mathbf{h}, \mathbf{\Psi}_{\bar{z}_2} \rangle = v_2$ , by Lemma 2, there exist polynomials  $S_1(X)$  and  $S_2(X)$ , each of degree at most M-2, such that
+
+$$g(X)\psi_{\bar{z}_1}(1/X) + g(1/X)\psi_{\bar{z}_1}(X) = 2v_1 + XS_1(X) + 1/XS_1(1/X)$$
+$$h(X)\psi_{\bar{z}_2}(1/X) + h(1/X)\psi_{\bar{z}_2}(X) = 2v_2 + XS_2(X) + 1/XS_2(1/X).$$
+
+If we multiply the second equation by  $\gamma$  and add it to the first equation, we get
+
+$$g(X)\psi_{\bar{z}_1}(1/X) + g(1/X)\psi_{\bar{z}_1} + \gamma \left(h(X)\psi_{\bar{z}_2}(1/X) + h(1/X)\psi_{\bar{z}_2}(X)\right) = 2(v_1 + \gamma v_2) + XS(X) + 1/XS(1/X),$$
+
+where  $S(X) = S_1(X) + \gamma S_2(X)$  is of degree at most M-2.
+
+Next, we establish the knowledge soundness of the scheme based on the matryoshka nesting of a univariate PCS in a bivariate PCS. Let  $C_g$  and  $C_h$  be commitments and  $\bar{z}_1, \bar{z}_2 \in \mathbb{F}^m$  vectors chosen by the adversary, and  $u_1, u_2 \leftarrow \mathbb{F}$  independently sampled challenge evaluation points. We want to establish that, given evaluation claim  $(u_1, \eta_1)$  with an evaluation proof  $\pi_1$  relative to  $C_g$ , evaluation claim  $(u_2, \eta_2)$  with an evaluation proof  $\pi_2$  relative to  $C_h$ , and batch Lagrange IPA proof  $\pi_3$  for the Lagrange inner product statements  $(\bar{z}_1, v_1)$  relative to  $C_g$  and  $(\bar{z}_2, v_2)$  relative to  $C_h$ , if the evaluation proofs are accepting and the batch Lagrange IPA is accepting, we can extract from the adversary polynomials  $g^*(X)$  and  $h^*(X)$  satisfying all the above evaluations and Lagrange inner product claims.
+
+Note that the batch Lagrange IPA proof  $\pi_3$  comprises a commitment  $C_S$  and evaluation proofs w.r.t.  $C_S$ ,  $C_g$ , and  $C_h$ . The extractor uses the underlying univariate extractor on these evaluation proofs to extract polynomials  $g^*(X)$ ,  $h^*(X)$ , and  $S^*(X)$  such that  $C_g = \text{Com}(\mathsf{ck}, g^*(X))$ ,  $C_h = \text{Com}(\mathsf{ck}, h^*(X))$ , and  $C_S = \text{Com}(\mathsf{ck}, S^*(X))$ . Since we are assuming that the bivariate PCS is evaluation binding, the extracted polynomials  $g^*(X)$ ,  $h^*(X)$  and  $S^*(X)$  are consistent with the evaluation claims
+
+$$a_1 = g^*(\alpha), \ a_2 = g^*(\alpha^{-1}), \ b_1 = h^*(\alpha), \ b_2 = h^*(\alpha^{-1}), \ s_1 = S^*(\alpha), \ s_2 = S^*(\alpha^{-1}),$$
+
+respectively. Therefore, we have polynomials in X of degree at most M-1 that satisfy the equation
+
+$$g^*(X)\psi_{\bar{z}_1}(1/X) + g^*(1/X)\psi_{\bar{z}_1}(X) + \gamma \left(h^*(X)\psi_{\bar{z}_2}(1/X) + h^*(1/X)\psi_{\bar{z}_2}(X)\right)$$
+  
+=  $2(v_1 + \gamma v_2) + XS^*(X) + \frac{1}{X}S^*(1/X),$ 
+
+at a uniform  $\alpha \leftarrow \mathbb{F}$ , which can happen with probability at most  $2(M-1)/|\mathbb{F}|$ , unless the equation holds as a polynomial identity. Since the above polynomial identity cannot hold with  $S^*(X)$  of degree M-1, the degree of  $S^*(X)$  must be at most M-2. By Lemma 2, we can now conclude that  $\langle \mathbf{g}^*, \Psi_{\bar{z}_1} \rangle = v_1$  and  $\langle \mathbf{h}^*, \Psi_{\bar{z}_2} \rangle = v_2$ , where  $\mathbf{g}^*$  and  $\mathbf{h}^*$  are the coefficient vectors of the extracted polynomials  $g^*(X)$  and  $h^*(X)$  respectively. Moreover, the evaluation binding property of the PCS ensures the consistency of the extracted polynomials  $g^*$  and  $h^*$  with the evaluation claims  $(u_1, \eta_1)$  and  $(u_2, \eta_2)$ .
+
+## <span id="page-20-0"></span>6 Optimized Chopin PCS from Bivariate KZG
+
+In this section, we give an optimized instantiation of the generic Chopin protocol from Figure 3 using bivariate KZG [PST13] (see Figure 2). The scheme makes explicit use of the batched Lagrange IPA from Figure 4 and batches all univariate evaluations arising throughout the protocol into a single batch univariate KZG proof (for example, from Section 7). Additionally, the prover computes a single bivariate KZG evaluation
+
+{21}------------------------------------------------
+
+ $\mathsf{KGen}(1^{\lambda}, (1, \dots, 1), \mathsf{gp})$ : On input security parameter  $1^{\lambda}$  and degree bound  $(1, \dots, 1)$  with the number of variables n = 2m, denote  $M = 2^m$  and output  $\mathsf{ck} \leftarrow \mathsf{bKZG}.\mathsf{KGen}(1^{\lambda}, (M-1, M-1), \mathsf{gp})$ .
+
+Com(ck, F): On input ck and  $F \in \mathbb{F}[X_1, \dots, X_{2m}]^{\leq 1}$ , denote  $f(X, Y) = \Phi(F)$  the bivariate twin of F and output commitment  $C = \mathsf{bKZG}.\mathsf{Com}(\mathsf{ck}, f(X, Y))$ .
+
+ $(\mathsf{P}(F),\mathsf{V})(\mathsf{ck},C,\bar{z}=(\bar{z}_L,\bar{z}_R),\eta)$ :
+
+- 1. P computes the partial restriction  $F_{\bar{z}_R} = F(X_1, \dots, X_m, \bar{z}_R)$ . For  $f_{\bar{z}_R}(X) = \Phi_X(F_{\bar{z}_R})$ , computes  $C_0 = \mathsf{bKZG}.\mathsf{Com}(\mathsf{ck}, f_{\bar{z}_R}(X))$  and sends  $C_0$  to  $\mathsf{V}$ .
+- 2. V samples  $\alpha \leftarrow \mathbb{F}$  uniformly at random and sends it to P.
+- 3. P computes  $F_{\alpha}(X_{m+1},...,X_n) = \sum_{\bar{u}\in B^m} \alpha^{\langle \bar{u}\rangle} F(\bar{u},X_{m+1},...,X_n)$ . For  $f_{\alpha}(X) = \Phi_X(F_{\alpha})$ , computes  $C_1 = \mathsf{bKZG.Com}(\mathsf{ck},f_{\alpha}(X))$ , and sends  $C_1$  and  $a = f_{\bar{z}_R}(\alpha)$  to  $\mathsf{V}$ .
+- 4. V samples  $\gamma \leftarrow \mathbb{F}$  uniformly at random and sends it to P.
+- 5. P computes the polynomials  $\psi_{\bar{z}_L}(X) = \Phi_X(\tilde{eq}(X_1, \dots, X_m; \bar{z}_L))$  and  $\psi_{\bar{z}_R}(X) = \Phi_X(\tilde{eq}(X_1, \dots, X_m; \bar{z}_R))$ , and a polynomial S(X) such that
+
+$$f_{\bar{z}_R}(X)\psi_{\bar{z}_L}(1/X) + f_{\bar{z}_R}(1/X)\psi_{\bar{z}_L}(X) + \gamma \left(f_\alpha(X)\psi_{\bar{z}_R}(1/X) + f_\alpha(1/X)\psi_{\bar{z}_R}(X)\right)$$
+  
+=  $2(\eta + \gamma a) + XS(X) + (1/X)S(1/X).$ 
+
+P computes  $C_S = \mathsf{bKZG}.\mathsf{Com}(\mathsf{ck}, S(X))$  and sends it to V.
+
+- 6. V samples  $\beta \leftarrow \mathbb{F}$  uniformly at random and sends it to P.
+- 7. P computes a batched univariate KZG proof  $\pi_1$  for the evaluation claims
+
+<span id="page-21-0"></span>
+$$a = f_{\bar{z}_R}(\alpha), \quad a_1 = f_{\bar{z}_R}(\beta), \quad a_2 = f_{\bar{z}_R}(1/\beta),$$
+  
+ $b_1 = f_{\alpha}(\beta), \quad b_2 = f_{\alpha}(1/\beta), \quad s_1 = S(\beta), \quad s_2 = S(1/\beta).$ 
+
+For  $f(X,Y) = \Phi(F)$ , P computes a bivariate KZG proof  $\pi_2$  for the evaluation claim  $f(\alpha,\beta) = b_1$ . Finally, P sends  $(a, a_1, a_2, b_1, b_2, s_1, s_2, \pi = (\pi_1, \pi_2))$  to V.
+
+8. V accepts iff the univariate batched KZG proof and the bivariate KZG proof are accepting and
+
+$$a_1\psi_{\bar{z}_L}(\beta^{-1}) + a_2\psi_{\bar{z}_L}(\beta) + \gamma \left(b_1\psi_{\bar{z}_R}(\beta^{-1}) + b_2\psi_{\bar{z}_R}(\beta)\right) = 2(\eta + \gamma a) + \beta s_1 + \beta^{-1}s_2.$$
+
+Fig. 5. Optimized Chopin PCS instantiated with bivariate KZG.
+
+proof. As we discussed in detail in Section 2, the bivariate and univariate proofs are not batched together to minimize the overhead of the prover.
+
+The concrete instantiation of Chopin might obscure the conceptual steps of the verification. To clarify, we reiterate the logical structure and map the concrete checks back to the abstract protocol requirements. The verification in Step 8. effectively enforces three properties simultaneously.
+
+Correctness of Evaluations: The verifier checks the univariate batched proof  $\pi_1$ . This guarantees that the evaluation claims in Step 7. are indeed the correct evaluations of the prover's committed univariate polynomials  $f_{\bar{z}_R}$  and  $f_{\alpha}$ .
+
+Correctness of the IPA: The linear equation checked in Step 8. corresponds to the batched IPA verification at the random point  $\beta$ . By establishing this identity, and relying on the correctness of the evaluations from  $\pi_1$ , the verifier effectively enforces the two core inner product relations  $\langle \Psi_{\bar{z}_L}, \mathbf{f}_{\bar{z}_R} \rangle = \eta$  and  $\langle \mathbf{f}_{\alpha}, \Psi_{\bar{z}_R} \rangle = a = f_{\bar{z}_R}(\alpha)$ , where  $\mathbf{f}_{\bar{z}_R}$  and  $\mathbf{f}_{\alpha}$  are the coefficient vectors of the corresponding polynomials. These correspond exactly to the first and second checks defined in our interactive proof from Figure 1.
+
+Consistency with the Global Commitment: Finally,  $\pi_2$  the bivariate KZG proof establishes that  $f(\alpha, \beta) = b_1$ . Since  $\pi_1$  guarantees that  $b_1 = f_{\alpha}(\beta)$ , this step confirms the link  $f(\alpha, \beta) = b_1 = f_{\alpha}(\beta)$ . This corresponds exactly to the last consistency check in our interactive proof from Figure 1.
+
+**Theorem 3.** Assuming that the bivariate KZG scheme is knowledge sound and there exists a knowledge sound batch evaluation proof for multiple univariate polynomials at multiple evaluation points under the bivariate KZG scheme, the protocol in Figure 5 is a knowledge sound multilinear PCS.
+
+{22}------------------------------------------------
+
+Besides the cost of the univariate KZG batch proof, the proof size is 7 field elements and 5 group elements. Besides the cost of the univariate KZG batch proof, the verifier performs three pairings.
+
+Proof. Correctness follows by construction and correctness of the interactive proof from Figure 1, batched Lagrange IPA proof from Figure 4, bivariate KZG and batched univariate KZG. The knowledge soundness is established by a similar reduction to the soundness of the interactive proof in Figure 1 as in Theorem 1. The main difference is that we can extract directly from the univariate KZG batch proof and the bivariate KZG proof. Finally, we verify the claim about the complexity by inspection. P sends the seven field elements  $a, s_1, s_2, a_1, a_2, b_1, b_2$  and three commitments  $C_0$ ,  $C_1$  and  $C_S$ . The bivariate KZG evaluation proof comprises two group elements. Verification of the bivariate KZG evaluation proof necessitates three pairings.
+
+#### <span id="page-22-0"></span>7 Batch Evaluation Proofs in the Standard Model
+
+There are several batch evaluation proofs for univariate polynomial commitment schemes, including the protocol of Boneh, Drake, Fisch, and Gabizon [BDFG20]. Their security analysis is predominantly carried out in the Algebraic Group Model (AGM) of Fuchsbauer, Kiltz, and Loss [FKL18]. Recently, Lipmaa et al. [LPS24] proved standard-model knowledge soundness for a simpler batching setting, namely, batching multiple polynomials opened at a single evaluation point, assuming special soundness of the underlying univariate PCS. For Chopin, we require batching of multiple polynomials (namely  $f_{\bar{z}_R}$ ,  $f_{\alpha}$ , and S) at multiple points (namely  $\alpha$ ,  $\beta$ , and  $\beta^{-1}$ ). To the best of our knowledge, the multi-polynomial, multi-point variant of the Boneh et al. batching protocol has not previously been proven knowledge sound in the standard model under standard assumptions. To close this gap and to enable a complete standard-model knowledge-soundness proof for the optimized Chopin based on bivariate KZG (Figure 5), we prove knowledge soundness of a modified multi-polynomial, multi-point batching protocol.
+
+On a very high-level, we show that a specially structured set of accepting transcripts for the batch proof can be used to extract polynomials consistent with any batch evaluation proof. Additionally, we argue that, when batching a constant number of polynomials, it is possible to extract such a structured set of accepting transcripts in expected polynomial time from any prover that has a non-negligible success probability. First, we recall and discuss an efficient protocol for batch evaluation proofs at multiple evaluation points across multiple polynomials, introduced by Boneh et al. [BDFG20].
+
+The batching protocol is presented in Figure 6. It is based on standard univariate KZG commitments and supports multiple polynomials  $p_t \in \mathbb{F}[X]^{\leq M}$  with a common degree bound M and arbitrary non-empty evaluation domains  $S_t \subseteq \mathbb{F}$ . Given m polynomials, we define  $T = \bigcup_{t \in [m]} S_t$  to be the union of the evaluation domains for all polynomials whose evaluations are batched in the protocol. For any  $S \subseteq \mathbb{F}$ ,  $Z_S = \prod_{z \in S} (X - z)$  denotes the vanishing polynomial of the set S. Then, for all  $t \in [m]$ , we have  $S_t \subseteq T$  and thus  $Z_{T \setminus S_t}$  is a well defined polynomial of degree  $|T \setminus S_t|$  for all  $t \in [m]$ . Furthermore, we use the convention that  $\ell_t \in \mathbb{F}[X]^{\leq |S_t|}$  denotes the polynomial encoding the alleged evaluations of  $p_t$ , i.e.,  $\ell_t$  is the unique polynomial of degree  $|S_t| - 1$  such that  $\ell_t(z) = p_t(z) = \eta_z$  for all  $z \in S_t$ . Note that under this convention, the claim that  $p_t(z) = \eta_z$  for all  $z \in S_t$  is equivalent to the polynomial  $p_t(X) - \ell_t(X)$  being divisible by  $Z_{S_t}(X)$ .
+
+for all  $z \in S_t$  is equivalent to the polynomial  $p_t(X) - \ell_t(X)$  being divisible by  $Z_{S_t}(X)$ . Observe that in Step (5) of the protocol in Figure 6, the verifier can perform the final check as  $(C_s + aW') \bullet [1]_2 \stackrel{?}{=} W' \bullet [\tau]_2$  where the commitment  $C_s$  is computed as
+
+$$C_s = \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(a) C_t + \left[ \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(a) \ell_t(a) \right]_1 - Z_T(a) W.$$
+
+Then, simple computations yield that the batching protocol has the following properties:
+
+- 1. For positive integer M, the commitment key  $\mathsf{ck} = \mathsf{KGen}(1^{\lambda}, M, \mathsf{gp})$  consists of  $M \, \mathbb{G}_1$  elements and  $2 \, \mathbb{G}_2$  elements.
+- 2. For integer  $n \leq M$ , computing Com(ck, p) for  $p \in \mathbb{F}[X]^{\leq n}$  requires  $n \in \mathbb{G}_1$  exponentiations.
+- 3. Consider  $T = \bigcup_{t \in [m]} S_t = \{z_1, ..., z_N\} \subseteq \mathbb{F}, p_1, ..., p_t \in \mathbb{F}[X]^{\leq \tilde{M}}$  and  $n = \max\{\deg(p_t)\}_{t \in [m]}$ . Then, given the common input  $\{C_t = \mathsf{Com}(\mathsf{ck}, p_t), S_t, (z, \eta_z)_{z \in S_t}\}_{t \in [m]}$  the batch opening in Figure 6 requires
+
+{23}------------------------------------------------
+
+KGen(1<sup>λ</sup> , M, gp): Return ck ← KGen(1<sup>λ</sup> , M − 1, gp).
+
+Com(ck, p): For p<sup>t</sup> ∈ F[X] <M, output C<sup>t</sup> = Com(ck, pt) for all t ∈ [m].
+
+Batch evaluation proof: Common input:
+
+$$\mathsf{ck} = ([1]_1, ..., [\tau^{M-1}]_1, [1]_2, [\tau]_2), \ \{C_t, S_t \ (z, \eta_z)_{z \in S_t}\}_{t \in [m]}, \ T = \cup_{t=1}^m S_t.$$
+
+- 1. V samples γ ∈ F uniformly at random and sends it to P.
+- 2. P computes the polynomial q<sup>T</sup> (X) s.t. p(X) = Z<sup>T</sup> (X) q<sup>T</sup> (X), where
+
+<span id="page-23-0"></span>
+$$p(X) = \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(X) \left( p_t(X) - \ell_t(X) \right).$$
+
+For each t ∈ [m], ℓ<sup>t</sup> is the interpolation polynomial which satisfies lt(z) = η<sup>z</sup> for all z ∈ St. Commit to q<sup>T</sup> via W = Com(ck, q<sup>T</sup> (X)) and send W to V.
+
+- 3. V samples a ∈ F uniformly at random and sends it to P.
+- 4. P computes
+
+$$s(X) = \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(a) \left( p_t(X) - \ell_t(a) \right) - Z_T(a) q_T(X)$$
+
+By construction s(a) = 0, so (X −a) divides s. Hence, P computes and sends W′ = Com(ck, s(X)/(X −a)) to V.
+
+5. V computes ℓt(X) for each t ∈ [m] and constructs the commitment to s by computing
+
+$$C_s = \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(a) (C_t - [\ell_t(a)]_1) - Z_T(a) W$$
+
+Then V accepts if and only if C<sup>s</sup> • [1]<sup>2</sup> = W′ • [τ − a]<sup>2</sup>
+
+Fig. 6. Univariate KZG multi-polynomial, multi-point batch proof [\[BDFG20\]](#page-30-2).
+
+- 2 G<sup>1</sup> elements sent from P to V.
+- At most 2n + 1 G<sup>1</sup> exponentiations by P.
+- m + 3 G<sup>1</sup> exponentiations and 2 pairings by V.
+
+Boneh et al. established that the batch opening protocol in Figure [6](#page-23-0) is knowledge sound in the AGM. Lipmaa et al. [\[LPS25\]](#page-31-7) recently revisited a simpler batch opening protocol for committing to multiple univariate polynomials and opening them at a single evaluation point, and proved its knowledge soundness in the standard model via a reduction to the special soundness of univariate KZG. Their extractor crucially uses that the evaluation point is sampled uniformly after the commitment phase. This enables a direct algebraic transformation from accepting batch transcripts to standard KZG opening transcripts at the same random point. From these transformed transcripts one can extract the committed polynomials by invoking special soundness of KZG. Moreover, reversing the transformation immediately implies that the extracted polynomials are consistent with the original batch claim.
+
+We do not see how to extend th approach from [\[LPS25\]](#page-31-7) to the multi-point batching protocol of Figure [6.](#page-23-0) The difficulty is that the verifier checks a polynomial identity that simultaneously couples multiple evaluation points through the vanishing polynomial Z<sup>T</sup> (X). As a result, a single accepting batch transcript does not directly yield a collection of independent KZG openings that can be unbatched and fed to a KZG specialsoundness extractor. In our setting, we also cannot assume that the evaluation points are sampled uniformly. For our higher-level protocol, the evaluation sets (St)t∈[m] and the claimed values (ηz)z∈<sup>T</sup> must be fixed as part of the batch statement. This motivates us to present a slight modification of the protocol from Figure [6](#page-23-0) for which we can construct an extractor for an arbitrary batch evaluation claim.
+
+{24}------------------------------------------------
+
+KGen(1<sup>λ</sup> , M, gp): Return ck ← KGen(1<sup>λ</sup> , M − 1, gp).
+
+Com(ck, p): For p<sup>t</sup> ∈ F[X] <M, output C<sup>t</sup> = Com(ck, pt) for all t ∈ [m].
+
+Batch evaluation proof: Common input:
+
+$$\mathsf{ck} = ([1]_1, ..., [\tau^{M-1}]_1), \{C_t, (z, \eta_z)_{z \in S_t}\}_{t \in [m]}, T = \bigcup_{t=1}^m S_t.$$
+
+- 1. V samples γ ∈ F uniformly at random and sends it to P.
+- 2. P finds a polynomial q<sup>T</sup> (X) s.t. p(X) = Z<sup>T</sup> (X) q<sup>T</sup> (X), where
+
+$$p(X) = \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(X) \left( p_t(X) - \ell_t(X) \right).$$
+
+For each t, ℓ<sup>t</sup> is the interpolated polynomial with values η<sup>z</sup> at z for all (z, ηz) ∈ St. Commit to q<sup>T</sup> via W = Comu(ck, q<sup>T</sup> (X)) and send W to V.
+
+- 3. V samples a ∈ F uniformly at random and sends it to P.
+- 4. Define
+
+<span id="page-24-0"></span>
+$$s(X) = \sum_{t=1}^{m} \gamma^{t-1} Z_{T \setminus S_t}(a) \left( p_t(X) - \ell_t(a) \right),$$
+$$q_{\mathsf{sh}}(X) = Z_T(a) q_T(X),$$
+
+and let y = s(a) (note that qsh(a) = y holds if honest). P computes KZG proofs (π (s) , π(q) ) opening both polynomials s(X) and qsh(X) at point a to the value y, and sends π (s) , π(q) to V.
+
+5. V computes each polynomial ℓt(X) from the common commitments and computes
+
+$$C_s = \sum_{t=1}^m \gamma^{t-1} Z_{T \setminus S_t}(a) (C_t - [\ell_t(a)]_1),$$
+
+$$C_{\mathsf{sh}} = Z_T(a) W,$$
+
+and checks
+
+$$(C_s - [y]_1) \bullet [1]_2 = \pi^{(s)} \bullet [\tau - a]_2,$$
+  
+ $(C_{\mathsf{sh}} - [y]_1) \bullet [1]_2 = \pi^{(q)} \bullet [\tau - a]_2.$ 
+
+Fig. 7. Modified univariate KZG multi-polynomial, multi-point batch proof.
+
+Extraction for many polynomials at many points. In Figure [7,](#page-24-0) we present the modified variant of the protocol from Figure [6](#page-23-0) of Boneh et al. The key change is that we split the original witness polynomial identity into two identities by introducing an auxiliary quotient polynomial qsh(X). Correspondingly, the prover sends two group elements, and the verifier checks two pairing equations. This split is designed so that, from a product-structured family of accepting batch transcripts, we can derive sufficiently many accepting KZG opening transcripts at verifier-chosen points. We then invoke special soundness of univariate KZG to extract the underlying polynomials and to argue consistency with the batch evaluation claim.
+
+In the rest of this section, we establish knowledge soundness of the protocol in the standard model for batching a constant number of polynomials. The constant-batch restriction is used only in the preliminary grid-extraction step that obtains a product-structured family of accepting transcripts with a shared set of evaluation challenges. Extending the proof to super-constant batch sizes, or establishing the knowledgesoundness of the original protocol from [\[BDFG20\]](#page-30-2) without our modification is left for future work.
+
+Theorem 4. Assume that univariate KZG for degree less than M satisfies M-special soundness. Then the protocol in Figure [7](#page-24-0) is knowledge sound in the standard model for batching any constant number of polynomials.
+
+{25}------------------------------------------------
+
+Special-soundness for a structured tree of accepting transcript. We consider an (m, L)-grid of transcripts of the batch evaluation protocol, where L = |T| + M. The grid is product structured. All transcripts in the grid share the same first-round message, and in particular the same commitments  $(C_t)_{t=1}^m$ , the same claimed evaluation sets  $(S_t)_{t=1}^m$ , and the same claimed values  $(\eta_z)_{z\in T}$ , where  $T = \bigcup_{t=1}^m S_t$ . The grid has two challenge dimensions. Along the first dimension, the verifier challenge is  $\gamma \in \mathbb{F}$  and we consider m pairwise distinct values  $\gamma_1, \ldots, \gamma_m \in \mathbb{F}$ . Along the second dimension, the verifier challenge is  $a \in \mathbb{F}$  and we consider  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$ . The  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$ . For each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for all  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$  for each pair  $a_i \neq 0$ 
+
+$$\mathsf{tr}_{ij} = \Big( (C_t)_{t=1}^m, \ (S_t)_{t=1}^m, \ ((\eta_z)_{z \in S_t})_{t=1}^m, \ \gamma_i, \ W_i, \ a_j, \ y_{ij}, \ \pi_{ij}^{(s)}, \ \pi_{ij}^{(q)} \Big),$$
+
+and is accepting for the verifier of Figure 7. We refer to such a family  $\mathcal{T} = (\mathsf{tr}_{ij})_{i \in [m], j \in [L]}$  as a product-structured accepting (m, L)-tree.
+
+<span id="page-25-2"></span>**Lemma 3.** Let  $m, M, M' \in \mathsf{poly}(\lambda)$ . Let  $T = \bigcup_{t=1}^m S_t$  and let L = |T| + M. Assume that KZG for degree less than M has M-special soundness in the following sense. From any set of  $M' \geq M$  accepting KZG opening transcripts for the same commitment C at M' distinct points  $a_1, \ldots, a_{M'}$  with  $a_j \neq \tau$ , one can extract a polynomial  $p \in \mathbb{F}[X]^{\leq M}$  such that  $C = [p(\tau)]_1$  and  $p(a_j) = y_j$  for all  $j \in [M']$ . Then there exists an extractor that, given as input any product-structured accepting (m, L)-tree  $\mathcal{T} = (\mathsf{tr}_{ij})_{i \in [m], j \in [L]}$  for the batch evaluation protocol of Figure 7, outputs polynomials  $p_1, \ldots, p_m \in \mathbb{F}[X]^{\leq M}$  such that  $C_t = [p_t(\tau)]_1$  for all  $t \in [m]$  and  $p_t(z) = \eta_z$  for all  $t \in [m]$  and all  $z \in S_t$ . Equivalently, the batch evaluation protocol is (m, L)-special sound with respect to product-structured accepting transcript trees.
+
+Proof. Let  $\mathcal{T} = (\mathsf{tr}_{ij})$  be an (m, L)-tree of accepting transcripts of the protocol, where L = |T| + M. The tree has product structure. At level 1 it contains m pairwise distinct challenges  $\gamma_1, \ldots, \gamma_m \in \mathbb{F}$  and responses  $W_1, \ldots, W_m \in \mathbb{G}_1$ . At level 2 it contains the same L pairwise distinct challenges  $a_1, \ldots, a_L \in \mathbb{F}$  on every branch, with  $a_j \notin T$  for all  $j \in [L]$ . For each  $(i, j) \in [m] \times [L]$ , the leaf transcript is
+
+$$\mathsf{tr}_{ij} = \Big( (C_t)_{t=1}^m, \ (S_t)_{t=1}^m, \ ((\eta_z)_{z \in S_t})_{t=1}^m, \ \gamma_i, \ W_i, \ a_j, \ y_{ij}, \ \pi_{ij}^{(s)}, \ \pi_{ij}^{(q)} \Big),$$
+
+We assume also  $a_j \neq \tau$  for all  $j \in [L]$ .
+
+For each  $t \in [m]$ , let  $S_t \subseteq \mathbb{F}$  be the set of claimed evaluation points for polynomial  $p_t$ , and let  $\eta_z \in \mathbb{F}$  denote the claimed value at  $z \in S_t$ . Let  $T = \bigcup_{t=1}^m S_t$ . Let  $Z_T(X) = \prod_{z \in T} (X - z)$ . For each  $t \in [m]$ , let  $Z_{T \setminus S_t}(X) = \prod_{z \in T \setminus S_t} (X - z)$ . For each  $t \in [m]$ , let  $\ell_t(X)$  be the unique interpolant of the pairs  $(z, \eta_z)_{z \in S_t}$ , so  $\deg(\ell_t) \leq |S_t| - 1$  and  $\ell_t(z) = \eta_z$  for all  $z \in S_t$ .
+
+Because each transcript  $\mathsf{tr}_{ij}$  is accepting, the following two pairing equations hold for all  $(i,j) \in [m] \times [L]$ . The *q-check* equation is
+
+<span id="page-25-1"></span>
+$$(Z_T(a_j)W_i - [y_{ij}]_1) \bullet [1]_2 = \pi_{ij}^{(q)} \bullet [\tau - a_j]_2.$$
+(9)
+
+The s-check equation is
+
+<span id="page-25-0"></span>
+$$\left(\sum_{t=1}^{m} \gamma_i^{t-1} Z_{T \setminus S_t}(a_j) \left( C_t - [\ell_t(a_j)]_1 \right) - [y_{ij}]_1 \right) \bullet [1]_2 = \pi_{ij}^{(s)} \bullet [\tau - a_j]_2.$$
+ (10)
+
+The extractor: Fix any  $j \in [L]$ . Define  $\mu_t^{(j)} = Z_{T \setminus S_t}(a_j)$ . Since  $a_j \notin T$  and  $T \setminus S_t \subseteq T$ , we have  $\mu_t^{(j)} \neq 0$  for all  $t \in [m]$ . For convenience, define the  $m \times m$  matrix  $\widetilde{V}^{(j)}$  by
+
+$$\widetilde{V}_{it}^{(j)} = \gamma_i^{t-1} \mu_t^{(j)}.$$
+
+Let V be the Vandermonde matrix corresponding to  $\gamma_1, \ldots, \gamma_m$ , i.e.,  $V_{it} = \gamma_i^{t-1}$ . Since  $\gamma_1, \ldots, \gamma_m$  are pairwise distinct, V is invertible. Since all  $\mu_t^{(j)} \neq 0$ , the diagonal matrix  $\operatorname{diag}(\mu_1^{(j)}, \ldots, \mu_m^{(j)})$  is also invertible. Thus,  $\widetilde{V}^{(j)} = V \cdot \operatorname{diag}(\mu_1^{(j)}, \ldots, \mu_m^{(j)})$  is invertible. Let  $A^{(j)} = (\widetilde{V}^{(j)})^{-1}$ .
+
+{26}------------------------------------------------
+
+For each  $i \in [m]$ , define the commitment
+
+$$C_i^{(j)} = \sum_{t=1}^m \widetilde{V}_{it}^{(j)} \left( C_t - [\ell_t(a_j)]_1 \right) = \sum_{t=1}^m \gamma_i^{t-1} \mu_t^{(j)} \left( C_t - [\ell_t(a_j)]_1 \right).$$
+
+Then Equation (10) says exactly that  $(C_i^{(j)}, a_j, y_{ij}, \pi_{ij}^{(s)})$  is an accepting KZG opening transcript for each  $i \in [m]$ .
+
+For each  $t \in [m]$ , define
+
+$$u_t^{(j)} = \sum_{i=1}^m A_{ti}^{(j)} y_{ij}$$
+ and  $\widehat{\pi}_{tj} = \sum_{i=1}^m A_{ti}^{(j)} \pi_{ij}^{(s)}$ .
+
+By bilinearity of the pairing, for each fixed t we can take the same linear combination of the m accepting transcripts to obtain that
+
+$$\left(\sum_{i=1}^{m} A_{ti}^{(j)} C_i^{(j)} - [u_t^{(j)}]_1\right) \bullet [1]_2 = \widehat{\pi}_{tj} \bullet [\tau - a_j]_2$$
+
+is accepting. We now simplify the combined commitment. We have
+
+$$\sum_{i=1}^{m} A_{ti}^{(j)} C_i^{(j)} = \sum_{i=1}^{m} A_{ti}^{(j)} \sum_{k=1}^{m} \widetilde{V}_{ik}^{(j)} \left( C_k - [\ell_k(a_j)]_1 \right) = \sum_{k=1}^{m} \left( \sum_{i=1}^{m} A_{ti}^{(j)} \widetilde{V}_{ik}^{(j)} \right) \left( C_k - [\ell_k(a_j)]_1 \right).$$
+
+Since  $A^{(j)}\widetilde{V}^{(j)} = I$ , we have  $\sum_{i=1}^{m} A_{ti}^{(j)}\widetilde{V}_{ik}^{(j)} = \delta_{t,k}$  (the Kronecker delta). Hence,
+
+$$\sum_{i=1}^{m} A_{ti}^{(j)} C_i^{(j)} = C_t - [\ell_t(a_j)]_1.$$
+
+Therefore, for each  $(t, j) \in [m] \times [L]$ , we obtain
+
+$$\left(C_t - [\ell_t(a_j)]_1 - [u_t^{(j)}]_1\right) \bullet [1]_2 = \widehat{\pi}_{tj} \bullet [\tau - a_j]_2,$$
+
+and
+
+$$\left(C_t, a_j, \ell_t(a_j) + u_t^{(j)}, \widehat{\pi}_{tj}\right)$$
+
+is an accepting KZG opening transcript for each  $(t,j) \in [m] \times [L]$ . Since  $L \geq M$  and the  $a_j$  are pairwise distinct and  $a_j \neq \tau$ , the M-special soundness of the univariate KZG gives that we can extract a polynomial  $p_t \in \mathbb{F}[X]^{< M}$  such that
+
+<span id="page-26-0"></span>
+$$C_t = [p_t(\tau)]_1$$
+ and  $p_t(a_j) = \ell_t(a_j) + u_t^{(j)}$  for all  $j \in [L]$ . (11)
+
+The extractor outputs the polynomials  $(p_t)_{t\in[m]}$ . In the rest, we establish the consistency of the extracted polynomials with the evaluation claims.
+
+Step 1: Relate the values  $y_{ij}$  to the extracted polynomials. Fix  $j \in [L]$ . Let  $y^{(j)} \in \mathbb{F}^m$  be the column vector with entries  $(y^{(j)})_i = y_{ij}$ , and let  $u^{(j)} \in \mathbb{F}^m$  be the column vector with entries  $(u^{(j)})_t = u_t^{(j)}$ . By the definition of  $u_t^{(j)}$ , we have  $u^{(j)} = A^{(j)}y^{(j)}$ , and hence  $y^{(j)} = \widetilde{V}^{(j)}u^{(j)}$ . Therefore, for all  $(i,j) \in [m] \times [L]$ ,
+
+<span id="page-26-1"></span>
+$$y_{ij} = \sum_{t=1}^{m} \widetilde{V}_{it}^{(j)} u_t^{(j)} = \sum_{t=1}^{m} \gamma_i^{t-1} \mu_t^{(j)} u_t^{(j)}.$$
+(12)
+
+By Equation (11), we have  $u_t^{(j)} = p_t(a_j) - \ell_t(a_j)$ , and substituting  $\mu_t^{(j)} = Z_{T \setminus S_t}(a_j)$  in Equation (12) yields
+
+<span id="page-26-2"></span>
+$$y_{ij} = \sum_{t=1}^{m} \gamma_i^{t-1} Z_{T \setminus S_t}(a_j) (p_t(a_j) - \ell_t(a_j)).$$
+ (13)
+
+{27}------------------------------------------------
+
+Step 2: Extracting the quotient polynomials  $q_T^{(i)}$ . Fix  $i \in [m]$ . Since  $a_j \notin T$ , we have  $Z_T(a_j) \neq 0$  for all  $j \in [L]$ . We rescale Equation (9) by  $1/Z_T(a_j)$ , obtaining
+
+$$\left(W_i - \left[\frac{y_{ij}}{Z_T(a_j)}\right]_1\right) \bullet [1]_2 = \left(Z_T(a_j)^{-1} \cdot \pi_{ij}^{(q)}\right) \bullet [\tau - a_j]_2.$$
+
+Thus, for each  $j \in [L]$ , the tuple  $(W_i, a_j, y_{ij}/Z_T(a_j), Z_T(a_j)^{-1} \cdot \pi_{ij}^{(q)})$  is an accepting KZG opening transcript. Since  $L \ge M$ , we can use the M-special soundness of univariate KZG to extract a polynomial  $q_T^{(i)} \in \mathbb{F}[X]^{\le M}$  such that
+
+<span id="page-27-0"></span>
+$$W_i = [q_T^{(i)}(\tau)]_1 \quad \text{and} \quad q_T^{(i)}(a_j) = \frac{y_{ij}}{Z_T(a_j)} \quad \text{for all } j \in [L].$$
+ (14)
+
+Step 3: Define an error polynomial and show it is identically zero. Fix  $i \in [m]$ . Define the polynomial
+
+<span id="page-27-1"></span>
+$$R_i(X) = \sum_{t=1}^m \gamma_i^{t-1} Z_{T \setminus S_t}(X) \left( p_t(X) - \ell_t(X) \right) - Z_T(X) q_T^{(i)}(X). \tag{15}$$
+
+We first show  $R_i(a_j) = 0$  for all  $j \in [L]$ . By Equation (14), we have  $y_{ij} = Z_T(a_j)q_T^{(i)}(a_j)$ . By Equation (13), we have  $y_{ij} = \sum_t \gamma_i^{t-1} Z_{T \setminus S_t}(a_j)(p_t(a_j) - \ell_t(a_j))$ . Subtracting these equalities yields  $R_i(a_j) = 0$  for all  $j \in [L]$ .
+
+We now bound the degree of  $R_i$ . We have  $\deg(p_t(X)) \leq M - 1$  and  $\deg(\ell_t(X)) \leq |S_t| - 1$ . Thus  $\deg(p_t(X) - \ell_t(X)) \leq \max(M - 1, |S_t| - 1)$ . Also,  $\deg(Z_{T \setminus S_t}(X)) = |T| - |S_t|$  and  $\deg(Z_T) = |T|$ . Therefore,
+
+$$\deg(Z_{T\setminus S_t}(X)(p_t(X) - \ell_t(X))) \le (|T| - |S_t|) + \max(M - 1, |S_t| - 1) \le |T| + M - 1,$$
+
+where the last inequality holds in both cases  $|S_t| \leq M$  and  $|S_t| > M$ . Also  $\deg(Z_T(X)q_T^{(i)}(X)) \leq |T| + (M-1) = |T| + M - 1$ . Hence  $\deg(R_i(X)) \leq |T| + M - 1$ .
+
+Since L = |T| + M and the  $a_j$  are pairwise distinct, we have that  $R_i$  has at least L = |T| + M distinct roots. Since  $\deg(R_i) \le |T| + M - 1$ , we conclude  $R_i \equiv 0$ .
+
+Step 4: Conclude evaluation correctness on every  $S_t$ . Fix any  $z \in T$ . Since  $z \in T$ , we have  $Z_T(z) = 0$ . Evaluating  $R_i \equiv 0$  at z in Equation (15) gives, for every  $i \in [m]$ ,
+
+<span id="page-27-2"></span>
+$$\sum_{t=1}^{m} \gamma_i^{t-1} Z_{T \setminus S_t}(z) \left( p_t(z) - \ell_t(z) \right) = 0.$$
+ (16)
+
+If  $z \notin S_t$ , then  $z \in T \setminus S_t$  and thus  $Z_{T \setminus S_t}(z) = 0$ . If  $z \in S_t$ , then  $z \notin T \setminus S_t$  and thus  $Z_{T \setminus S_t}(z) \neq 0$ . Let  $T_z = \{t \in [m] : z \in S_t\}$ . For each  $t \in T_z$ , define
+
+$$c_{t,z} = Z_{T \setminus S_t}(z) (p_t(z) - \ell_t(z)).$$
+
+Then Equation (16) simplifies to, for every  $i \in [m]$ ,
+
+<span id="page-27-3"></span>
+$$\sum_{t \in T} \gamma_i^{t-1} c_{t,z} = 0. \tag{17}$$
+
+Define the polynomial  $P_z(X) = \sum_{t \in T_z} c_{t,z} X^{t-1}$ . Then, by Equation (17),  $\deg(P_z) \leq m-1$  and  $P_z(\gamma_i) = 0$  for all  $i \in [m]$ . Since the values  $\gamma_i$  are pairwise distinct,  $P_z$  is a polynomial of degree at most m-1 with at least m distinct roots. So, we have  $P_z \equiv 0$ , and therefore all coefficients  $c_{t,z}$  are zero. Thus,  $c_{t,z} = 0$  for all  $t \in T_z$ . Since each  $Z_{T \setminus S_t}(z) \neq 0$  for  $t \in T_z$ , it must be the case that  $p_t(z) - \ell_t(z) = 0$  for all  $t \in T_z$ . Hence, for every  $t \in T_z$ , we have  $p_t(z) = \ell_t(z)$ . Finally, fix any  $t \in [m]$  and any  $z \in S_t$ . Then  $t \in T_z$ , so the above implies  $p_t(z) = \ell_t(z)$ . By the definition of  $\ell_t$ , we have  $\ell_t(z) = \eta_z$  for all  $z \in S_t$ , and therefore  $p_t(z) = \eta_z$  for all  $z \in S_t$ , establishing the consistency of the extracted polynomials with all the evaluation claims.
+
+We have already shown the respective consistency of the extracted polynomials  $p_t$  with the commitments  $C_t$  in Equation (11). This completes the analysis of the extractor, and, hence, the protocol has (m, |T| + M)-special soundness.
+
+{28}------------------------------------------------
+
+Extracting the structured tree of accepting transcripts. Next, we show that, for a constant number of batched polynomials, it is possible to extract a product-structured tree of accepting transcripts in expected polynomial time.
+
+We consider the multi-polynomial multi-point batch evaluation protocol in the natural message order. The prover  $\mathsf{P}^*$  first sends a first-round message  $\mathsf{msg}_0$  that fixes the instance, and in particular contains the commitments  $(C_t)_{t=1}^m$  and the claimed evaluation table  $(\eta_z)_{z\in T}$ . After  $\mathsf{msg}_0$  is fixed, the verifier samples an independent batching challenge  $\gamma \leftarrow \mathbb{F}$  and an independent evaluation challenge  $a \leftarrow A$ , where  $T = \bigcup_{t=1}^m S_t$  is the set of all claimed evaluation points and  $A \subseteq \mathbb{F}$  is an admissible challenge domain satisfying  $A \cap T = \emptyset$ . For concreteness we take  $A = \mathbb{F} \setminus T$ , so that  $Z_T(a) \neq 0$  and  $\tau - a \neq 0$  for all  $a \in A$ . We let  $\mathsf{acc}(\gamma, a)$  denote the acceptance indicator of the verifier when interacting with  $\mathsf{P}^*$  starting from the fixed post- $\mathsf{msg}_0$  state. We assume  $\mathsf{Pr}_{\gamma \leftarrow \mathbb{F}, \ a \leftarrow A}[\mathsf{acc}(\gamma, a) = 1] = \varepsilon$ . We assume  $m = \mathcal{O}(1)$  is a strict constant,  $L \in \mathsf{poly}(\lambda)$ , and  $|\mathbb{F}|$  is exponentially large in  $\lambda$ .
+
+**Lemma 4.** Under the setup above, there exists an expected polynomial time extractor  $\mathcal{E}$  with black-box access to  $\mathsf{P}^*$  that outputs an (m,L)-tree of accepting transcripts with the product structure. Specifically,  $\mathcal{E}$  outputs pairwise distinct challenges  $\gamma_1,\ldots,\gamma_m\in\mathbb{F}$  and pairwise distinct challenges  $a_1,\ldots,a_L\in A$  such that all mL transcripts corresponding to pairs  $(\gamma_i,a_j)$  are accepting and share the same first-round message  $\mathsf{msg}_0$ . Moreover,  $\mathcal{E}$  makes an expected number of oracle queries to  $\mathsf{P}^*$  bounded by  $\mathcal{O}(m \cdot L \cdot \varepsilon^{-2m})$ .
+
+*Proof.* The extractor  $\mathcal{E}$  first runs  $\mathsf{P}^*$  once to obtain the first-round message  $\mathsf{msg}_0$ . The extractor then rewinds  $\mathsf{P}^*$  to the point immediately after  $\mathsf{msg}_0$  is sent. Because  $\mathsf{P}^*$  is deterministic, rewinding to this point fixes  $\mathsf{msg}_0$  across all subsequent rewound executions.
+
+For challenges  $(\gamma, a) \in \mathbb{F} \times A$ , let  $\mathsf{acc}(\gamma, a) \in \{0, 1\}$  be the indicator that the verifier accepts the transcript produced by  $\mathsf{P}^*$  on input  $(\gamma, a)$  when started from the fixed state after outputting  $\mathsf{msg}_0$ . By premise, we have  $\mathbb{E}_{\gamma \leftarrow \mathbb{F}}[\mathsf{acc}(\gamma, a)] = \varepsilon$ . For any fixed  $a \in A$ , define  $x_a = \mathbb{E}_{\gamma \leftarrow \mathbb{F}}[\mathsf{acc}(\gamma, a)]$ . By linearity of expectation, it holds that  $\mathbb{E}_{a \leftarrow A}[x_a] = \varepsilon$ .
+
+The extractor aims to find a tuple of m pairwise distinct first-round challenges  $\gamma = (\gamma_1, \dots, \gamma_m)$  and L pairwise distinct second-round challenges  $(a_1, \dots, a_L)$  such that all the mL corresponding transcripts are accepting. For  $\gamma \in \mathbb{F}^m$ , define the common acceptance rate
+
+$$p(\gamma) = \mathbb{E}_{a \leftarrow A} \left[ \prod_{i=1}^m \mathsf{acc}(\gamma_i, a) \right].$$
+
+Equivalently,  $p(\gamma)$  is the fraction of points  $a \in A$  that accept simultaneously for all  $\gamma_i$  in  $\gamma$ .
+
+We next lower bound  $\mathbb{E}_{\gamma}[p(\gamma)]$  when  $\gamma$  is sampled uniformly from  $\mathbb{F}^m$  with independent coordinates. Fix any  $a \in A$ . Because the coordinates of  $\gamma$  are independent and uniform, we have
+
+$$\mathbb{E}_{\gamma}\left[\prod_{i=1}^{m}\mathrm{acc}(\gamma_{i},a)\right] = \prod_{i=1}^{m}\mathbb{E}_{\gamma\leftarrow\mathbb{F}}[\mathrm{acc}(\gamma,a)] = x_{a}^{m}.$$
+
+By exchanging expectations, we obtain
+
+$$\mathbb{E}_{\gamma}[p(\gamma)] = \mathbb{E}_{a \leftarrow A} \left[ \mathbb{E}_{\gamma} \left[ \prod_{i=1}^{m} \mathrm{acc}(\gamma_i, a) \right] \right] = \mathbb{E}_{a \leftarrow A}[x_a^m].$$
+
+Because  $f(x) = x^m$  is convex for  $m \ge 1$  on  $x \ge 0$ , Jensen's inequality implies
+
+$$\mathbb{E}_{a \leftarrow A}[x_a^m] \ge (\mathbb{E}_{a \leftarrow A}[x_a])^m = \varepsilon^m.$$
+
+Therefore,  $\mathbb{E}_{\gamma}[p(\gamma)] \geq \varepsilon^m$ . We call  $\gamma$  heavy if  $p(\gamma) \geq \varepsilon^m/2$ . Since  $p(\gamma) \in [0,1]$  and  $\mathbb{E}_{\gamma}[p(\gamma)] \geq \varepsilon^m$ , we have
+
+$$\Pr_{\gamma}[p(\gamma) \ge \varepsilon^m/2] \ge \varepsilon^m/2.$$
+
+{29}------------------------------------------------
+
+Indeed, letting  $q = \Pr[p(\gamma) \ge \varepsilon^m/2]$  and using  $p(\gamma) \le 1$  gives
+
+$$\varepsilon^m \leq \mathbb{E}[p] \leq (1-q) \cdot (\varepsilon^m/2) + q \cdot 1 \leq \varepsilon^m/2 + q$$
+
+hence  $q \geq \varepsilon^m/2$ .
+
+We also require  $\gamma$  to have pairwise distinct entries. The probability that a uniformly sampled  $\gamma \in \mathbb{F}^m$  contains a collision is at most  $\binom{m}{2}/|\mathbb{F}|$ . Because m is constant and  $|\mathbb{F}|$  is exponentially large, this collision probability is negligible. Thus,
+
+$$\Pr_{\gamma}[\gamma \text{ is heavy and has distinct entries}] \geq \varepsilon^m/2 - \mathsf{negl}(\lambda) \geq \varepsilon^m/4$$
+
+for all sufficiently large  $\lambda$ .
+
+We now describe  $\mathcal{E}$ . The extractor repeats the following outer iteration until it succeeds: In each outer iteration,  $\mathcal{E}$  samples  $\gamma = (\gamma_1, \ldots, \gamma_m)$  uniformly from  $\mathbb{F}^m$ . If  $\gamma$  contains a duplicate entry,  $\mathcal{E}$  aborts the iteration and restarts. Otherwise,  $\mathcal{E}$  samples  $K = \lceil 8L/\varepsilon^m \rceil$  independent points  $a_1, \ldots, a_K \leftarrow A$ . For each sampled  $a_k$ , the extractor queries  $\mathsf{P}^*$  on each branch  $(\gamma_i, a_k)$  and evaluates  $\mathsf{acc}(\gamma_i, a_k)$  for all  $i \in [m]$ . The extractor records those  $a_k$  for which  $\mathsf{acc}(\gamma_i, a_k) = 1$  for all  $i \in [m]$ . If  $\mathcal{E}$  records at least L pairwise distinct such points, it outputs the (m, L)-tree of accepting transcripts with rows indexed by  $\gamma_1, \ldots, \gamma_m$  and columns indexed by any L of the recorded points, and then halts. Otherwise, the iteration fails and  $\mathcal{E}$  discards the current data and restarts.
+
+We analyze the success probability of a single outer iteration. With probability at least  $\varepsilon^m/4$ , the sampled  $\gamma$  is heavy and has distinct entries. Condition on this event. Then a uniformly random  $a \leftarrow A$  is simultaneously accepting for all m branches with probability
+
+$$\Pr_{a \leftarrow A} [\forall i \in [m], \ \operatorname{acc}(\gamma_i, a) = 1] = p(\gamma) \ge \varepsilon^m / 2.$$
+
+Let X be the number of simultaneously accepting points among the K independent samples. Then  $\mathbb{E}[X] \ge K \cdot \varepsilon^m/2 \ge 4L$ . By a standard Chernoff bound, we obtain
+
+$$\Pr[X < L] \le e^{-9L/8} < 1/2.$$
+
+Therefore, conditioned on  $\gamma$  being heavy and distinct, the extractor finds at least L simultaneously accepting samples with probability at least 1/2.
+
+We also require the extracted L points to be distinct. Since the  $a_k$  are sampled from A with  $|A| \ge |\mathbb{F}| - |T| - 1$ , we have  $|A| = |\mathbb{F}| - \mathsf{poly}(\lambda)$ . Because  $K = \mathsf{poly}(\lambda, 1/\varepsilon)$  and  $|\mathbb{F}|$  is exponential, the probability that there is any collision among the K samples is at most  $\binom{K}{2}/|A| \in \mathsf{negl}(\lambda)$ . Thus, conditioned on heaviness and distinctness of  $\gamma$ , the probability that  $\mathcal{E}$  obtains L pairwise distinct simultaneously accepting points is at least  $1/2 - \mathsf{negl}(\lambda) \ge 1/3$  for all sufficiently large  $\lambda$ .
+
+Consequently, the unconditional probability that a single outer iteration succeeds is at least
+
+$$(\varepsilon^m/4) \cdot (1/3) = \varepsilon^m/12.$$
+
+Thus, the expected number of outer iterations is at most  $12/\varepsilon^m$ .
+
+We bound the expected query complexity. Within each outer iteration, the extractor makes mK oracle queries to evaluate  $\operatorname{acc}(\gamma_i, a_k)$  for all  $i \in [m]$  and all  $k \in [K]$ . Thus, the number of queries per iteration is  $\mathcal{O}(mK) = \mathcal{O}(mL\varepsilon^{-m})$ . Multiplying by the expected number of iterations yields
+
+$$\mathbb{E}[\#\text{queries}] \leq \frac{12}{\varepsilon^m} \cdot \mathcal{O}(mL\varepsilon^{-m}) = \mathcal{O}(m \cdot L \cdot \varepsilon^{-2m}).$$
+
+Because  $m = \mathcal{O}(1)$  is a strict constant and  $L \in \mathsf{poly}(\lambda)$ , this is expected-polynomial in  $\lambda$ . Therefore,  $\mathcal{E}$  runs in expected-polynomial time and outputs an (m, L)-tree of accepting transcripts with product structure, as required.
+
+{30}------------------------------------------------
+
+Declaration of generative AI and AI-assisted technologies in the manuscript preparation process. During the preparation of this work, the authors used the LLM-based system Bolzano ([\[Bol26\]](#page-30-12)) to draft the proof of Lemma [3.](#page-25-2) After using this tool/service, the authors reviewed and edited the content as needed and take full responsibility for the content of the article.
+
+Acknowledgments. Juraj Belohorec, Pavel Hubáček, and Kristýna Mašková were partially supported by the Academy of Sciences of the Czech Republic (RVO 67985840), Czech Science Foundation GAČR grant No. 25-16311S, and by Zircuit. Aleksi Kalsta was supported by Business Finland through the BlimPQC project under decision number 422/31/2024. Pavel Hubáček thanks Vašek Rozhoň for giving him access to the LLM-based service Bolzano and allowing him to experiment with it.
+
+## References
+
+- <span id="page-30-10"></span>ACK21. Thomas Attema, Ronald Cramer, and Lisa Kohl. A compressed Σ-protocol theory for lattices. In Tal Malkin and Chris Peikert, editors, Advances in Cryptology - CRYPTO 2021 - 41st Annual International Cryptology Conference, CRYPTO 2021, Virtual Event, August 16-20, 2021, Proceedings, Part II, volume 12826 of Lecture Notes in Computer Science, pages 549–579. Springer, 2021.
+- <span id="page-30-5"></span>AGL<sup>+</sup>22. Arasu Arun, Chaya Ganesh, Satya V. Lokam, Tushar Mopuri, and Sriram Sridhar. Dew: Transparent constant-sized zkSNARKs. IACR Cryptol. ePrint Arch., page 419, 2022.
+- <span id="page-30-8"></span>AHIV23. Scott Ames, Carmit Hazay, Yuval Ishai, and Muthuramakrishnan Venkitasubramaniam. Ligero: lightweight sublinear arguments without a trusted setup. Des. Codes Cryptogr., 91(11):3379–3424, 2023.
+- <span id="page-30-3"></span>BBB<sup>+</sup>18. Benedikt Bünz, Jonathan Bootle, Dan Boneh, Andrew Poelstra, Pieter Wuille, and Gregory Maxwell. Bulletproofs: Short proofs for confidential transactions and more. In 2018 IEEE Symposium on Security and Privacy, SP 2018, Proceedings, 21-23 May 2018, San Francisco, California, USA, pages 315–334. IEEE Computer Society, 2018.
+- <span id="page-30-6"></span>BBHR18. Eli Ben-Sasson, Iddo Bentov, Yinon Horesh, and Michael Riabzev. Fast Reed-Solomon interactive oracle proofs of proximity. In 45th International Colloquium on Automata, Languages, and Programming, ICALP 2018, July 9-13, 2018, Prague, Czech Republic, pages 14:1–14:17, 2018.
+- <span id="page-30-11"></span>BCC<sup>+</sup>16. Jonathan Bootle, Andrea Cerulli, Pyrros Chaidos, Jens Groth, and Christophe Petit. Efficient zeroknowledge arguments for arithmetic circuits in the discrete log setting. In Advances in Cryptology - EUROCRYPT 2016 - 35th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Vienna, Austria, May 8-12, 2016, Proceedings, Part II, pages 327–357, 2016.
+- <span id="page-30-1"></span>BCHO22. Jonathan Bootle, Alessandro Chiesa, Yuncong Hu, and Michele Orrù. Gemini: Elastic SNARKs for diverse environments. In Advances in Cryptology - EUROCRYPT 2022 - 41st Annual International Conference on the Theory and Applications of Cryptographic Techniques, Trondheim, Norway, May 30 - June 3, 2022, Proceedings, Part II, pages 427–457, 2022.
+- <span id="page-30-7"></span>BCR<sup>+</sup>19. Eli Ben-Sasson, Alessandro Chiesa, Michael Riabzev, Nicholas Spooner, Madars Virza, and Nicholas P. Ward. Aurora: Transparent succinct arguments for R1CS. In Advances in Cryptology - EUROCRYPT 2019 - 38th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Darmstadt, Germany, May 19-23, 2019, Proceedings, Part I, pages 103–128, 2019.
+- <span id="page-30-2"></span>BDFG20. Dan Boneh, Justin Drake, Ben Fisch, and Ariel Gabizon. Efficient polynomial commitment schemes for multiple points and polynomials. IACR Cryptol. ePrint Arch., page 81, 2020.
+- <span id="page-30-9"></span>BDH<sup>+</sup>25. Juraj Belohorec, Pavel Dvořák, Charlotte Hoffmann, Pavel Hubáček, Kristýna Mašková, and Martin Pastyřík. On extractability of the KZG family of polynomial commitment schemes. In Yael Tauman Kalai and Seny F. Kamara, editors, Advances in Cryptology - CRYPTO 2025 - 45th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 17-21, 2025, Proceedings, Part VI, volume 16005 of Lecture Notes in Computer Science, pages 584–616. Springer, 2025.
+- <span id="page-30-4"></span>BHR<sup>+</sup>21. Alexander R. Block, Justin Holmgren, Alon Rosen, Ron D. Rothblum, and Pratik Soni. Time- and space-efficient arguments from groups of unknown order. In Advances in Cryptology - CRYPTO 2021 - 41st Annual International Cryptology Conference, CRYPTO 2021, Virtual Event, August 16-20, 2021, Proceedings, Part IV, pages 123–152, 2021.
+- <span id="page-30-12"></span>Bol26. Bolzano team. Bolzano. <https://github.com/vaclavrozhon/problem-solver/>, 2026. GitHub repository.
+- <span id="page-30-0"></span>CBBZ23. Binyi Chen, Benedikt Bünz, Dan Boneh, and Zhenfei Zhang. HyperPlonk: Plonk with linear-time prover and high-degree custom gates. In Carmit Hazay and Martijn Stam, editors, Advances in Cryptology -
+
+{31}------------------------------------------------
+
+- EUROCRYPT 2023 42nd Annual International Conference on the Theory and Applications of Cryptographic Techniques, Lyon, France, April 23-27, 2023, Proceedings, Part II, volume 14005 of Lecture Notes in Computer Science, pages 499–530. Springer, 2023.
+- <span id="page-31-6"></span>CHS26. Petr Chmel, Pavel Hubáček, and Dominik Stejskal. Knowledge soundness of polynomial commitments in the algebraic group model does not guarantee extractability. IACR Cryptol. ePrint Arch., page 284, 2026.
+- <span id="page-31-3"></span>EG25. Liam Eagen and Ariel Gabizon. MERCURY: A multilinear polynomial commitment scheme with constant proof size and no prover ffts. IACR Cryptol. ePrint Arch., page 385, 2025.
+- <span id="page-31-5"></span>FKL18. Georg Fuchsbauer, Eike Kiltz, and Julian Loss. The algebraic group model and its applications. In Hovav Shacham and Alexandra Boldyreva, editors, Advances in Cryptology - CRYPTO 2018 - 38th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 19-23, 2018, Proceedings, Part II, volume 10992 of Lecture Notes in Computer Science, pages 33–62. Springer, 2018.
+- <span id="page-31-9"></span>GLS<sup>+</sup>23. Alexander Golovnev, Jonathan Lee, Srinath T. V. Setty, Justin Thaler, and Riad S. Wahby. Brakedown: Linear-time and field-agnostic SNARKs for R1CS. In Advances in Cryptology - CRYPTO 2023 - 43rd Annual International Cryptology Conference, CRYPTO 2023, Santa Barbara, CA, USA, August 20-24, 2023, Proceedings, Part II, pages 193–226, 2023.
+- <span id="page-31-4"></span>GPS25. Chaya Ganesh, Sikhar Patranabis, and Nitin Singh. Samaritan: Linear-time prover SNARK from new multilinear polynomial commitments. IACR Cryptol. ePrint Arch., page 419, 2025.
+- <span id="page-31-15"></span>GW21. Ariel Gabizon and Zachary J. Williamson. fflonk: a fast-Fourier inspired verifier efficient version of PlonK. IACR Cryptol. ePrint Arch., page 1167, 2021.
+- <span id="page-31-2"></span>KT24. Tohru Kohrita and Patrick Towa. Zeromorph: Zero-knowledge multilinear-evaluation proofs from homomorphic univariate commitments. J. Cryptol., 37(4):38, 2024.
+- <span id="page-31-8"></span>Lee21. Jonathan Lee. Dory: Efficient, transparent arguments for generalised inner products and polynomial commitments. In Kobbi Nissim and Brent Waters, editors, Theory of Cryptography - 19th International Conference, TCC 2021, Raleigh, NC, USA, November 8-11, 2021, Proceedings, Part II, volume 13043 of Lecture Notes in Computer Science, pages 1–34. Springer, 2021.
+- <span id="page-31-13"></span>LMN25. Christophe Levrat, Tanguy Medevielle, and Jade Nardi. A divide-and-conquer sumcheck protocol. IACR Commun. Cryptol., 2(1):15, 2025.
+- <span id="page-31-12"></span>LPS24. Helger Lipmaa, Roberto Parisella, and Janno Siim. Constant-size zk-SNARKs in ROM from falsifiable assumptions. In Marc Joye and Gregor Leander, editors, Advances in Cryptology - EUROCRYPT 2024 - 43rd Annual International Conference on the Theory and Applications of Cryptographic Techniques, Zurich, Switzerland, May 26-30, 2024, Proceedings, Part VI, volume 14656 of Lecture Notes in Computer Science, pages 34–64. Springer, 2024.
+- <span id="page-31-7"></span>LPS25. Helger Lipmaa, Roberto Parisella, and Janno Siim. On knowledge-soundness of Plonk in ROM from falsifiable assumptions. In Yael Tauman Kalai and Seny F. Kamara, editors, Advances in Cryptology - CRYPTO 2025 - 45th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 17-21, 2025, Proceedings, Part VII, volume 16006 of Lecture Notes in Computer Science, pages 362–395. Springer, 2025.
+- <span id="page-31-10"></span>LZL<sup>+</sup>25. Chongrong Li, Pengfei Zhu, Yun Li, Cheng Hong, Wenjie Qu, and Jiaheng Zhang. Hyperpianist: Pianist with linear-time prover and logarithmic communication cost. In IEEE Symposium on Security and Privacy, SP 2025, San Francisco, CA, USA, May 12-15, 2025, pages 3383–3401, 2025.
+- <span id="page-31-14"></span>MBKM19. Mary Maller, Sean Bowe, Markulf Kohlweiss, and Sarah Meiklejohn. Sonic: Zero-knowledge SNARKs from linear-size universal and updateable structured reference strings. IACR Cryptol. ePrint Arch., page 99, 2019.
+- <span id="page-31-16"></span>PH23. Shahar Papini and Ulrich Haböck. Improving logarithmic derivative lookups using GKR. IACR Cryptol. ePrint Arch., page 1284, 2023.
+- <span id="page-31-1"></span>PST13. Charalampos Papamanthou, Elaine Shi, and Roberto Tamassia. Signatures of correct computation. In Theory of Cryptography - 10th Theory of Cryptography Conference, TCC 2013, Tokyo, Japan, March 3-6, 2013. Proceedings, pages 222–242, 2013.
+- <span id="page-31-0"></span>Set20. Srinath T. V. Setty. Spartan: Efficient and general-purpose zkSNARKs without trusted setup. In Daniele Micciancio and Thomas Ristenpart, editors, Advances in Cryptology - CRYPTO 2020 - 40th Annual International Cryptology Conference, CRYPTO 2020, Santa Barbara, CA, USA, August 17-21, 2020, Proceedings, Part III, volume 12172 of Lecture Notes in Computer Science, pages 704–737. Springer, 2020.
+- <span id="page-31-11"></span>WSVZ24. Wenhao Wang, Fangyan Shi, Dani Vilardell, and Fan Zhang. Cirrus: Performant and accountable distributed SNARK. IACR Cryptol. ePrint Arch., page 1873, 2024.
+
+{32}------------------------------------------------
+
+Input: Multilinear F(X1, . . . , X2m) ∈ F[X1, . . . , X2m] ≤1 , an evaluation point z¯ ∈ F n , and a claimed value η ∈ F.
+
+1. P computes the m-variate restriction
+
+$$F_{\bar{z}_R}(X_1,\ldots,X_m)=F(X_1,\ldots,X_m,\bar{z}_R)$$
+
+and sends the coefficient vector of Fz¯<sup>R</sup> to V.
+
+- 2. V samples α ← F uniformly at random and sends it to P.
+- 3. P computes the coefficients of the m-variate polynomial
+
+$$F_{\alpha}(X_{m+1},\ldots,X_{2m}) = \sum_{\bar{u}\in B^m} \alpha^{\langle \bar{u}\rangle} F(\bar{u},X_{m+1},\ldots,X_{2m}),$$
+
+as the coefficients of the remainder in univariate polynomial division:
+
+<span id="page-32-3"></span>
+$$f(X) = q_{\alpha}(X)(X^{M} - \alpha) + f_{\alpha}(X),$$
+
+where f(X) = Φ(F) is the univariate twin of F.
+
+P sends the coefficient vectors of f<sup>α</sup> and q<sup>α</sup> to V.
+
+4. V samples β ← F uniformly at random. Denote by G0, respectively G<sup>1</sup> and G2, the coefficient vectors received from P in round 1, respectively round 3.
+
+V accepts if and only if
+
+$$\eta = \langle \mathbf{\Psi}_{\bar{z}_L}, \mathbf{G}_0 \rangle, \quad g_0(\alpha) = \langle \mathbf{G}_2, \mathbf{\Psi}_{\bar{z}_R} \rangle, \quad \text{and}$$
+
+$$f(\beta) = g_2(\beta)(\beta^M - \alpha) + g_1(\beta),$$
+
+where g0(X) = Φ(G0), g1(X) = Φ(G1), g2(X) = Φ(G2), and f(X) = Φ(F).
+
+Fig. 8. Mercury/Samaritan IP for multilinear polynomial evaluation.
+
+- <span id="page-32-0"></span>XZS22. Tiancheng Xie, Yupeng Zhang, and Dawn Song. Orion: Zero knowledge proof with linear prover time. In Yevgeniy Dodis and Thomas Shrimpton, editors, Advances in Cryptology - CRYPTO 2022 - 42nd Annual International Cryptology Conference, CRYPTO 2022, Santa Barbara, CA, USA, August 15-18, 2022, Proceedings, Part IV, volume 13510 of Lecture Notes in Computer Science, pages 299–328. Springer, 2022.
+- <span id="page-32-1"></span>ZCF24. Hadas Zeilberger, Binyi Chen, and Ben Fisch. Basefold: Efficient field-agnostic polynomial commitment schemes from foldable codes. In Advances in Cryptology - CRYPTO 2024 - 44th Annual International Cryptology Conference, Santa Barbara, CA, USA, August 18-22, 2024, Proceedings, Part X, pages 138– 169, 2024.
+
+## <span id="page-32-2"></span>A Mercury/Samaritan IP for Multilinear Evaluation
+
+In this section, we present the interactive proof system underlying the multilinear PCS from Mercury [\[EG25\]](#page-31-3) and Samaritan [\[GPS25\]](#page-31-4). The interactive proof is presented in Figure [8.](#page-32-3) The main difference to our protocol in Figure [1](#page-11-0) is the verification of correctness of the folded function F<sup>α</sup> computed by the prover in round 3. Instead of our bivariate view, Mercury and Samaritan leverage the observation that the coefficients of F<sup>α</sup> are exactly the coefficients of the remainder in polynomial division of the univariate twin f of F by the polynomial (X<sup>M</sup> − α). The verification is then performed via a random evaluation check of the polynomial identity testing that f(X) = qα(X)(X<sup>M</sup> − α) + fα(X). To facilitate this check, the prover sends to the verifier also the coefficients of the quotient polynomial qα(X) together with the coefficients of fα(X). Their approach is motivated by the goal of constructing a multilinear PCS from a univariate PCS. However, there are two downsides to relying only on univariate representations of multilinears.
+
+First, as shown in the lemma below, the security guarantee of protocol in Figure [8](#page-32-3) degrades with N instead of M = √ N as in our protocol in Figure [1.](#page-11-0) This stems from the verifier's consistency check, which involves a random evaluation of the degree N univariate twin of F.
+
+{33}------------------------------------------------
+
+**Public inputs:** Let  $\mathsf{PCS}_u = (\mathsf{KGen}_u, \mathsf{Com}_u, \mathsf{Open}_u, \mathsf{Ver}_u)$  be a univariate polynomial commitment scheme. For  $m \in \mathbb{N}$ , denote  $M = 2^m$ , and let  $\mathsf{ck} \leftarrow \mathsf{KGen}_u(1^\lambda, M - 1, \mathsf{gp})$  be a commitment key supporting polynomials of degree at most M - 1.
+
+Given commitments  $C_g$  and  $C_h$  and  $\bar{z}_1, \bar{z}_2 \in \mathbb{F}^m$ , the prover claims that  $\langle \mathbf{g}, \boldsymbol{\Theta}_{\bar{z}_1} \rangle = v_1$  and  $\langle \mathbf{h}, \boldsymbol{\Theta}_{\bar{z}_2} \rangle = v_2$ , where  $\mathbf{g}, \mathbf{h} \in \mathbb{F}^M$  are the coefficient vectors of univariate polynomials  $g, h \in \mathbb{F}[X]^{\leq M}$  committed in  $C_g$  and  $C_h$ , respectively and  $\boldsymbol{\Theta}_{\bar{z}}$  is the coefficient vector of the polynomial  $\theta_{\bar{z}}(X) = \prod_{i=1}^m (1 + z_i X^{2^{i-1}})$ . (P(g(X), h(X)), V)(ck,  $C_g, C_h, \bar{z}_1, \bar{z}_2, v_1, v_2$ ):
+
+- 1. V samples a random  $\gamma \in \mathbb{F}$  and sends it to P.
+- 2. P sends a commitment to a polynomial S(X) satisfying
+
+<span id="page-33-2"></span>
+$$g(X)\theta_{\bar{z}_1}(1/X) + g(1/X)\theta_{\bar{z}_1}(X) + \gamma \left(h(X)\theta_{\bar{z}_2}(1/X) + h(1/X)\theta_{\bar{z}_2}(X)\right)$$
+  
+=  $2(v_1 + \gamma v_2) + XS(X) + \frac{1}{X}S(1/X).$ 
+
+- 3. V chooses a random  $a \in \mathbb{F}^*$  and sends it to P.
+- 4. P sends the evaluations g(a), g(1/a), h(a), h(1/a), S(a), S(1/a) and their opening proofs.
+- 5. V evaluates  $\theta_{\bar{z}_1}$  and  $\theta_{\bar{z}_2}$  at a and 1/a.
+- 6. V accepts if and only if the proofs sent by P in Step 4 are accepting and the equation in Step 2 holds when evaluated at a.
+
+Fig. 9. Batched multilinear (in monomial base) evaluation protocol, using univariate polynomial commitment scheme.
+
+Second, the prover must send the quotient polynomial  $q_{\alpha}$  which is of a large degree  $N-\sqrt{N}$ . In the context of the multilinear PCS, the prover must commit to  $q_{\alpha}$ , which requires an additional large Multi-Scalar Multiplication (MSM). Effectively, this doubles the prover's complexity for the evaluation proof since large MSMs dominate prover's running time.
+
+<span id="page-33-0"></span>**Lemma 5.** The protocol in Figure 8 is an interactive proof system for multilinear evaluation on  $\mathbb{F}[X_1, \ldots, X_{2m}]^{\leq 1}$  with perfect completeness and soundness error at most  $(M-1)(N-1)|\mathbb{F}|^{-1}$ .
+
+*Proof.* The proof is analogous to that of Lemma 1, with the primary difference lying in the analysis of the "bad" events. Here, a bad event corresponds to sampling a root of either 1) a polynomial derived from  $f_{\alpha}$  (degree less than M), or 2) a polynomial derived from the *univariate* twin of F (degree less than N). This gives rise to the larger bound on the soundness error as stated in the lemma.
+
+#### <span id="page-33-1"></span>B Lagrange IPA for the Multilinear Monomial Basis
+
+In this section, we revisit the multilinear polynomial evaluation approach of the IPA introduced in the previous sections. We then describe an alternative variant of the IPA in which multilinear polynomials are represented in the monomial basis.
+
+The protocol presented in Section 5.1 is specifically tailored to the Lagrange basis. There, we assume that the input polynomial is given in the form
+
+$$G(X_1,\ldots,X_n)=\sum_{\bar{b}\in B^n}g_{\langle\bar{b}\rangle}\,\widetilde{eq}(\bar{b};X_1,\ldots,X_n),$$
+
+where the coefficients are taken with respect to the multilinear Lagrange basis.
+
+To prove that the polynomial G evaluates to v at a point  $\bar{z} \in \mathbb{F}^n$ , we apply the Lagrange IPA to the vector  $\mathbf{g} = (g_0, \dots, g_{N-1})$  and the vector  $\mathbf{\Psi}_{\bar{z}} = (\tilde{eq}(bin(0); \bar{z}), \dots, \tilde{eq}(bin(N-1); \bar{z}))$ .
+
+However, if the committed vector represents the coefficients of the multilinear polynomial in the monomial basis, the protocol can no longer be applied in a straightforward manner.
+
+Suppose the multilinear polynomial  $G(X_1, \ldots, X_n)$  is represented as
+
+$$G(X_1,\ldots,X_n)=\sum_{\bar{b}\in B^m}g_{\langle\bar{b}\rangle}X_1^{b_1}\ldots X_n^{b_n}.$$
+
+{34}------------------------------------------------
+
+Then, for a point  $\bar{z}$ , we have
+
+$$v = G(\bar{z}) = \sum_{\bar{b} \in B^m} g_{\langle \bar{b} \rangle} z_1^{b_1} \dots z_n^{b_n}.$$
+
+In this case, v is the inner product of the coefficient vector  $\boldsymbol{g}$  and the vector
+
+$$\boldsymbol{\Theta}_{\bar{z}} = (1, z_1, \dots, z_1 z_2 \dots z_n),$$
+
+where the *i*-th component of  $\Theta_{\bar{z}}$  is  $z_1^{b'_1} \dots z_n^{b'_n}$  and  $(b'_1, \dots, b'_n)$  is the binary representation of the index *i*.
+
+As one can observe, the vector  $\boldsymbol{\Theta}_{\bar{z}}$  differs from the vector  $\boldsymbol{\Psi}_{\bar{z}}$  used in the protocol in Figure 4. In particular, while  $\boldsymbol{\Psi}_{\bar{z}}$  consists of evaluations of the multilinear Lagrange basis polynomials at  $\bar{z}$ , the vector  $\boldsymbol{\Theta}_{\bar{z}}$  contains the corresponding monomials evaluated at  $\bar{z}$ .
+
+To apply the protocol in Figure 4 to a multilinear polynomial represented in the monomial basis, the prover would first need to perform a basis transformation, converting the monomial coefficients into their representation in the Lagrange basis before invoking the protocol. This basis conversion would require a computational overhead of  $O(N \log N)$ .
+
+To address this issue, we adapt the Lagrange IPA protocol to work directly in the monomial basis, thereby enabling the evaluation of multilinear polynomials represented in the monomial basis.
+
+Consider the case where the prover's vector g represents the coefficients of a multilinear polynomial G in the monomial form
+
+$$G(X_1,\ldots,X_n) = \sum_{\bar{b}\in B^n} g_{\langle \bar{b}\rangle} X_1^{b_1} \cdots X_n^{b_n}.$$
+
+Since the inner product argument verifies the relation  $\langle \boldsymbol{g}, \boldsymbol{\Theta}_{\bar{z}} \rangle = v$ , it suffices to ensure that the vector  $\boldsymbol{\Theta}_{\bar{z}}$  correctly encodes the evaluations of the monomial basis at the point  $\bar{z}$ .
+
+Conceptually, the only modification required in the Lagrange IPA concerns the polynomial  $\psi_{\bar{z}}(X)$  computed by the verifier. In the original protocol, this polynomial is defined as
+
+$$\psi_{\bar{z}}(X) = \prod_{i=0}^{n-1} (1 - z_i + z_i X^{2^i}),$$
+
+whose coefficients encode the values  $\tilde{eq}(\bar{b};\bar{z})$  of the multilinear Lagrange basis over the Boolean hypercube. To instead obtain a polynomial whose coefficients correspond to the evaluations of the monomial basis at the point  $\bar{z}$ , it suffices to apply a slight modification to this construction, leading to the following adjusted polynomial:
+
+$$\theta_{\bar{z}}(X) = \prod_{i=0}^{n-1} (1 + z_i X^{2^i}).$$
+
+Expanding this product yields
+
+$$\theta_{\bar{z}}(X) = \sum_{\bar{b} \in \mathbb{R}^n} z_1^{b_1} \cdots z_n^{b_n} X^{\langle \bar{b} \rangle}.$$
+
+Therefore, taking the inner product of the vector  $\bar{g}$  with the coefficient vector of  $\theta_{\bar{z}}(X)$  gives
+
+$$\sum_{\bar{b}\in B^n} g_{\langle \bar{b}\rangle} z_1^{b_1} \cdots z_n^{b_n} = G(\bar{z}).$$
+
+Thus the same protocol structure applies: we must only take a slightly different evaluation polynomial  $\theta_{\bar{z}}$ . We present the corresponding protocol in Figure 9. The correctness of the protocol in Figure 9 follows directly from the same argument as in Lemma 2. When the prover behaves honestly, all verifier checks are satisfied by construction. The knowledge soundness can be established via the same argument as in Theorem 2.

--- a/data/markdown/eprint/2026_480/2026_480_meta.json
+++ b/data/markdown/eprint/2026_480/2026_480_meta.json
@@ -1,0 +1,40 @@
+{
+  "eprint": {
+    "title": "CHOPIN: Optimal Pairing-Based Multilinear Polynomial Commitments from Bivariate KZG",
+    "authors": [
+      {
+        "name": "Juraj Belohorec",
+        "email": "belohorec@math",
+        "affiliation": ""
+      },
+      {
+        "name": "Pavel Hubáček",
+        "email": "czhubacek@math",
+        "affiliation": ""
+      },
+      {
+        "name": "Aleksi Kalsta",
+        "email": "kalsta@vtt",
+        "affiliation": ""
+      },
+      {
+        "name": "Kristýna Mašková",
+        "email": "fimaskova@math",
+        "affiliation": ""
+      }
+    ],
+    "abstract": "We present CHOPIN, a pairing-based multilinear polynomial commitment scheme (PCS) achieving constant proof size and a linear-time prover, constructed modularly from a bivariate PCS. CHOPIN generalizes the recent compilers from univariate to multilinear PCS  MERCURY (Eagen and Gabizon, ePrint 2025/385) and Samaritan (Ganesh, Patranabis, and Singh, ASIACRYPT 2025). Due to its modular design, we obtain a direct proof of knowledge soundness via a reduction to the knowledge soundness of the underlying bivariate PCS in the standard model. In particular, our analysis avoids idealized models such as the Algebraic Group Model.\r\n\r\nWhen instantiated with the bivariate KZG scheme (Papamanthou, Shi, and Tamassia, TCC 2013), CHOPIN achieves a similar proof size to Mercury and Samaritan while offering a two-fold speedup in the main bottleneck for the prover time, which arises because CHOPIN requires only a single large MSM proportional to the size of the committed multilinear polynomial, in contrast to the two large MSMs required by the prior works, at the cost of one additional pairing for the verifier.",
+    "keywords": [
+      "Polynomial Commitment Schemes",
+      "KZG",
+      "Multilinear",
+      "Bivariate",
+      "Proof Batching"
+    ],
+    "category": "Cryptographic protocols",
+    "publication_info": "Preprint.",
+    "last_updated": "2026-03-09",
+    "license": "CC BY",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2026_480/conversion_info.json
+++ b/data/markdown/eprint/2026_480/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "modal-marker",
+  "converted_at": "2026-04-25T18:05:11.138913+00:00",
+  "elapsed_seconds": 194.88,
+  "pdf_sha256": "cc6babe8fe3cdf1d2a83a2f166f8801f1c90fa1643e922b0718a841bb6f390ea",
+  "source_pdf": "2026_480.pdf",
+  "output_path": "2026_480/2026_480.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "modal",
+    "os": "Linux",
+    "os_version": "4.4.0",
+    "arch": "x86_64",
+    "python_version": "3.12.10",
+    "cpu_count": 17,
+    "provider": "modal",
+    "gpu_count": 1,
+    "gpu_name": "NVIDIA A100-SXM4-40GB",
+    "gpu_vram_mb": 40441,
+    "cuda_version": "12.8"
+  },
+  "estimated_cost_usd": 0.059635
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2026/480

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit a16329b)
Website: https://papyrus.badaas.eu