### PR TITLE
Add markdown for 2026/430

### DIFF
--- a/data/markdown/eprint/2026_430/2026_430.md
+++ b/data/markdown/eprint/2026_430/2026_430.md
@@ -1,0 +1,1171 @@
+
+
+{0}------------------------------------------------
+
+# An attack on the CFS scheme and on TII McEliece challenges
+
+Magali Bardet<sup>1</sup> , Axel Lemoine2,3, and Jean-Pierre Tillich<sup>2</sup>
+
+<sup>1</sup> Université de Rouen Normandie, LITIS UR 4108
+
+2 Inria, France
+
+<sup>3</sup> DGA, France
+
+Abstract. It has been a very long standing open question whether the CFS signature scheme [\[CFS01\]](#page-31-0) whose security is basically that of a McEliece scheme based on very high rate binary Goppa codes could be attacked or not. There was a first cryptanalytic result [\[FGO](#page-32-0)<sup>+</sup>11] consisting in finding a distinguisher for the binary Goppa codes used in this scheme showing that these codes can be distinguished in polynomial time from a random binary linear code. However despite numerous cryptanalytic attempts [\[COT14,](#page-31-1) [BMT24,](#page-31-2) [CMT23a,](#page-31-3) [Mor25,](#page-33-0) [Ran25\]](#page-33-1) and even if the original distinguisher has been significantly improved, no attack on the McEliece scheme based on binary Goppa codes has been found so far except for very peculiar Goppa codes of degree 2 [\[Mor25\]](#page-33-0). We show here that the Pfaffian modeling used in the distinguishing attack of [\[CMT23a\]](#page-31-3) can actually be used together with a shortening trick and looking for squares in the corresponding ideal to find a polynomial attack on the CFS scheme based on very high rate binary Goppa codes.This breaks this 25 years old signature scheme. We demonstrate the effectiveness of this approach by recovering the key of TII McEliece challenges with a claimed key security of up to 210 bits.
+
+# 1 Introduction
+
+#### 1.1 The McEliece scheme
+
+The McEliece encryption scheme [\[McE78\]](#page-33-2), which is only a few months younger than RSA [\[RSA78\]](#page-33-3), is the oldest public key cryptosystem that is still resistant to a classical or quantum computer. Its underlying security assumption is radically different from RSA. It relies partly on decoding a generic linear code which is known to be NP-hard [\[BMvT78\]](#page-31-4). The public key is a generic description of a linear code C by the means of a generator matrix G. In its simplest form, encryption is basically performed as
+
+$$\operatorname{Enc}: \boldsymbol{m} \longmapsto \boldsymbol{m} \boldsymbol{G} + \boldsymbol{e},$$
+
+where e is a random error vector whose Hamming weight is equal to the error correcting capability of C . An efficient decoding algorithm is then used to remove the error and recover the original message m. This algorithm must be kept secret 
+
+{1}------------------------------------------------
+
+and plays the role of the private key. The public description of the code should obviously not leak any information about the secret decoding algorithm. On the other hand, the code cannot be random, as this would prevent the existence of an efficient decoding algorithm. In the original proposal, McEliece suggested the use of binary Goppa codes. They indeed benefit from a good error-correcting capability, and their weight distribution is close to that of random codes.
+
+This scheme has withstood tremendous cryptanalytic efforts, be they (i) combinatorial key recovery attacks [\[Gib91,](#page-32-1) [Sen00,](#page-33-4) [Pan25\]](#page-33-5), (ii) algebraic key recovery attacks [\[FOPT10,](#page-32-2) [COT14,](#page-31-1) [FPdP14,](#page-32-3) [BMT24,](#page-31-2) [CMT23b,](#page-31-5) [Mor25,](#page-33-0) [Lem25\]](#page-33-6), (iii) message recovery attacks [\[LB88,](#page-32-4) [Ste88,](#page-34-0) [Dum89,](#page-32-5) [CC98,](#page-31-6) [MMT11,](#page-33-7) [BJMM12,](#page-30-0) [MO15,](#page-33-8) [BM17,](#page-30-1) [CDMT22,](#page-31-7) [Ess22,](#page-32-6) [EZ23,](#page-32-7) [CDMT24,](#page-31-8) [DEEK24\]](#page-31-9) that hardly decreased the exponent of these attacks which are exponential with respect to the decoding capacity of the underlying Goppa code used in the scheme, (iv) clever implementations of message recovery attacks that attacked successfully the original McEliece parameters [\[BLP08\]](#page-30-2) resulting in a speed-up of several orders of magnitude of the best attacks known at that time but without changing the exponent of the best message recovery attacks which can be easily thwarted by a slight increase of the parameters, quantum key recovery attacks [\[DMR11\]](#page-32-8) or quantum message attacks [\[Ber10,](#page-30-3) [KT17,](#page-32-9) [Tra24\]](#page-34-1). This very strong resistance against attacks was a very convincing argument in the NIST post-quantum cryptography competition for the variation of this public key cryptosystem intended to be IND-CCA secure and an associated key exchange protocol Classic McEliece [\[ABC](#page-30-4)<sup>+</sup>22] which went into the final round of this competition. Note that, although it was ultimately not chosen by NIST for standardization, it is currently undergoing a standardization process by the ISO.
+
+## 1.2 An overview of algebraic cryptanalysis of related schemes
+
+The Goppa distinguishing problem. The scheme is provably secure under the assumption that the family of codes is indistinguishable from that of random linear codes with identical parameters [\[CFS01\]](#page-31-0). The family of binary Goppa codes provides indeed a good candidate, for they share many properties with random codes, such as their weight distribution [\[LL97,](#page-33-9) [Fin03\]](#page-32-10). It was for a long time believed that this problem was intractable before [\[FGO](#page-32-0)<sup>+</sup>11] showed that it could be done in polynomial time for the very high rate Goppa codes used in the CFS signature scheme [\[CFS01\]](#page-31-0). This did not provide an actual attack on the scheme but undermined its security proof.
+
+The interesting feature of this line of research is that it is apparently a somewhat simpler problem than the formidable problem of breaking the McEliece scheme itself. Moreover, it has proved fruitful for making progress on understanding the features of the Goppa codes which could be used to eventually mount an attack. While the distinguisher of [\[FGO](#page-32-0)<sup>+</sup>11] was only able to distinguish Goppa codes of rate <sup>1</sup> <sup>−</sup> <sup>O</sup><sup>e</sup> √ 1 n where n is the codelength, some recent developments [\[CMT23b,](#page-31-5) [Ran25,](#page-33-1) [Wie25\]](#page-34-2) extended the regime where distinguishing is doable in polynomial time. These new distinguishers even apply in the constant rate 
+
+{2}------------------------------------------------
+
+regime, but then lose their polynomial time complexity. It is worthwhile to note that they are able to distinguish the Goppa codes used in the McEliece scheme, sometimes at a cost which is smaller than the state-of-the-art key attacks which are based on the support splitting algorithm [Sen00]. In particular, key distinguishing in subexponential complexity with respect to the decoding capacity of the underlying Goppa code was achieved for the first time in the breakthrough paper [Ran25]. This is remarkable since the complexities of the best message attacks are exponential in this quantity. Note however that this is an asymptotic result, and it does not directly threaten the security of the NIST submission Classic McEliece for which the actual complexity of the [Ran25] distinguisher is significantly higher than the security target  $2^{\lambda}$  which corresponds in this case to the complexity of the best message attacks.
+
+Alternant codes and Goppa codes. Interestingly enough these distinguishers also distinguish a slightly more general family of codes than Goppa codes, namely alternant codes. Indeed, the latter family really carries the essential polynomial structure which is the distinctive feature of Goppa codes that makes it amenable to this family of distinguishers. Let us recall the definition of such codes. Basically alternant codes are a way to keep some of the nice decoding properties of the family of Reed-Solomon codes while being defined over a fixed alphabet. Indeed, such codes are defined as subfield subcodes of (generalized) Reed-Solomon codes.
+
+**Definition 1.1 (Generalized Reed-Solomon code).** Let  $\mathbf{x} = (x_1, \dots, x_n) \in \mathbb{F}^n$  be a vector of pairwise-distinct elements,  $\mathbf{y} = (y_i)_{1 \leq i \leq n}$  a vector of nonzero elements and r < n be an integer. The Generalized Reed-Solomon code (GRS) of degree r, support  $\mathbf{x}$  and multiplier  $\mathbf{y}$  is defined as
+
+$$\mathbf{GRS}_r(\boldsymbol{x}, \boldsymbol{y}) \stackrel{\text{def}}{=} \{ (y_i f(x_i))_{1 \le i \le n} \mid f \in \mathbb{F}[X]_{\le r} \}.$$
+
+Alternant codes are defined as subfield subcodes of GRS codes defined over an extension field  $\mathbb{F}_{q^m}$ , *i.e.* if  $\mathscr{C}$  is a GRS code defined over  $\mathbb{F}_{q^m}$  then the associated alternant code  $\mathscr{A}$  over  $\mathbb{F}_q$  is nothing but
+
+$$\mathscr{A} = \mathscr{C} \cap \mathbb{F}_q^n$$
+
+where n is the length of  $\mathscr{C}$  and  $\mathscr{A}$ . Obviously any decoding algorithm for the GRS code can be used to decode the alternant code. It is a little bit more convenient to define such codes through the dual code by using the fact that the dual of a GRS code is itself a GRS code (see Proposition 2.2).
+
+**Definition 1.2 (Alternant code).** Let  $\mathbf{x} \in \mathbb{F}_{q^m}^n$  be a vector whose entries are all distinct,  $\mathbf{y} \in (\mathbb{F}_{q^m}^{\times})^n$  and let r < n be an integer. The alternant code over  $\mathbb{F}_q$  of support  $\mathbf{x}$ , multiplier  $\mathbf{y}$ , degree r and extension degree m is defined by
+
+$$\mathscr{A}_r\left(\boldsymbol{x},\boldsymbol{y}\right) \stackrel{\mathrm{def}}{=} \left(\mathbf{GRS}_r\left(\boldsymbol{x},\boldsymbol{y}\right)^{\perp}\right) \cap \mathbb{F}_q^n.$$
+ (1)
+
+{3}------------------------------------------------
+
+The dimension of the alternant code satisfies  $\dim_{\mathbb{F}_q} \mathscr{A}_r(\boldsymbol{x}, \boldsymbol{y}) \geq n - rm$ . For generic alternant codes, this bound holds actually with equality. Now, Goppa codes are nothing but alternant codes with an algebraic relation between the support and the multiplier.
+
+**Definition 1.3 (Goppa code).** Let  $\mathbf{x} \in \mathbb{F}_{q^m}^n$  be a vector whose entries are all distinct. Let r < n be an integer and  $\Gamma \in \mathbb{F}_{q^m}[X]$  be some monic polynomial such that  $\Gamma(x_i) \neq 0$ , i = 1, ..., n. The Goppa code over  $\mathbb{F}_q$  of support  $\mathbf{x}$  and Goppa polynomial  $\Gamma$  is defined as
+
+$$\mathscr{G}(\boldsymbol{x}, \Gamma) \stackrel{\text{def}}{=} \mathscr{A}_r \left( \boldsymbol{x}, \frac{1}{\Gamma(\boldsymbol{x})} \right),$$
+ (2)
+
+where 
+$$\frac{1}{\Gamma(\boldsymbol{x})}$$
+ is the vector  $\left(\frac{1}{\Gamma(x_i)}\right)_{1\leq i\leq n}$ .
+
+Interestingly enough, it turns out that the slightly more structured Goppa codes behave a little bit better for the distinguisher of [FGO<sup>+</sup>13].
+
+Attacks on variants of the McEliece scheme. The original McEliece scheme is based on binary Goppa codes. Over the years, many variants were proposed in order to decrease the size of the public key, such as quasi-cyclic alternant or Goppa codes [BCGO09, CBB<sup>+</sup>17] or quasi-dyadic Goppa codes [MB09, BLM11, BBB<sup>+</sup>17]. Another way was to use Goppa codes defined over a larger alphabet and with very small extension degree and better decoding capacities, resulting in smaller codes and smaller public keysizes [BLP10, BLP11].
+
+Thanks to the algebraic polynomial structure of alternant codes, the problem consisting in retrieving a support and a multiplier from the mere knowledge of the public key can be modelized by an algebraic system [FOPT10] which can be solved with Gröbner basis techniques. This approach was successful in the quasi cyclic/dyadic case [BCGO09, MB09], as this structure allowed to reduce drastically the number of unknowns of the algebraic system when compared to the original McEliece cryptosystem. Another attack |BC18| also exploited in a crucial way the quasi-dyadic structure of the DAGS NIST submission [BBB+17]. A variant of this algebraic modeling was introduced in [FPdP14] to attack certain parameters of the variant of the McEliece cryptosystem [BLP10, BLP11] based on wild Goppa codes and wild Goppa codes incognito. The McEliece cryptosystem based on plain binary Goppa codes seems immune to both [FOPT10] and FPdP14 approaches. The first one because the degree and the number of variables of the resulting system are most certainly too big to make such an approach likely to succeed and the second one because this modeling does not apply to binary Goppa codes.
+
+The square code distinguisher and attack. The polynomial structure of alternant codes and Goppa codes makes them susceptible to square attacks. Basically this comes from considering the algebra on  $\mathbb{F}_q^n$  based on the following seemingly uninteresting component-wise product of vectors
+
+$$\boldsymbol{a} \star \boldsymbol{b} \stackrel{\text{def}}{=} (a_1 b_1, \dots, a_n b_n)$$
+
+{4}------------------------------------------------
+
+with  $\mathbf{a} = (a_i)_{1 \leq i \leq n}$  and  $\mathbf{b} = (b_i)_{1 \leq i \leq n}$ . There is an associated product of codes which is defined as
+
+**Definition 1.4.** The component-wise product of codes  $\mathscr{C}, \mathscr{D}$  over  $\mathbb{F}_q$  with the same length n is defined as
+
+$$\mathscr{C}\star\mathscr{D}\stackrel{\mathrm{def}}{=} \langle \, \boldsymbol{c}\star\boldsymbol{d} \mid \boldsymbol{c}\in\mathscr{C}, \boldsymbol{d}\in\mathscr{D}\, \rangle_{\mathbb{F}_a}\,.$$
+
+If  $\mathscr{C} = \mathscr{D}$ , we call  $\mathscr{C}^{\star 2} \stackrel{\text{def}}{=} \mathscr{C} \star \mathscr{C}$  the square code of  $\mathscr{C}$ .
+
+It can be verified [CCMZ15] that for a random code of length n we typically have dim  $\mathcal{C}^{\star 2} = \min\left\{n, \binom{\dim \mathcal{C}+1}{2}\right\}$ , meaning that the square code of a random code quickly fills up the whole space when the dimension becomes bigger than  $\sqrt{2n}$ . On the other hand it is easy to see that the polynomial structure of GRS codes gives a much smaller dimension. We namely have
+
+$$\mathbf{GRS}_{k}\left(\boldsymbol{x},\boldsymbol{y}\right)^{\star2}=\mathbf{GRS}_{2k-1}\left(\boldsymbol{x},\boldsymbol{y}\star\boldsymbol{y}\right),$$
+
+which implies that
+
+$$\dim \left(\mathbf{GRS}_k\left(\boldsymbol{x},\boldsymbol{y}\right)^{\star 2}\right) = \min \left(2 \cdot \dim \mathbf{GRS}_k\left(\boldsymbol{x},\boldsymbol{y}\right) - 1, n\right).$$
+
+This property was used for the first time in [Wie10] for cryptanalyzing the Berger-Loidreau variant [BL04] of the McEliece cryptosystem replacing the binary Goppa code by a subcode of a GRS code. It was also used in [CGG<sup>+</sup>14] to mount an attack on McEliece or Niederreiter schemes based on GRS codes [Nie86] different from the original cryptanalysis [SS92]. This property that the square code of a GRS code does not fill the whole space as soon as the rate is below  $\frac{1}{2}$  can also be used to distinguish such algebraic codes from random codes. This property survives for the dual of very high rate alternant or Goppa codes. It was shown in [MP12] that this square code approach for alternant and Goppa codes is equivalent to the original distinguisher [FGO<sup>+</sup>11] (see also [MT22]).
+
+It also turned out that suitable shortened (see Definition 2.1) wild Goppa codes also have an abnormally low dimension when the degree of extension is only 2 [COT14]. In this case, working directly on the Goppa code itself did not only provide a distinguisher, it also provided an attack [COT14]. The situation was much more complicated for the distinguisher of [FGO+11] where it took more than ten years to transform the distinguisher of [FGO+11] into an attack [BMT24]. This attack works in the case of generic alternant codes that are "square-distinguishable" over  $\mathbb{F}_2$  and  $\mathbb{F}_3$ . Amazingly enough, this attack completely fails in the case of Goppa codes which forms a more structured subfamily of alternant codes.
+
+Matrices of low rank in the code of quadratic relationships (aka the quadratic hull). In characteristic 2, a generalization of the distinguisher of [FGO<sup>+</sup>11] has been proposed in [CMT23b]. It expands significantly the range of alternant and Goppa codes that can be distinguished by it. There are four ingredients. The first one considers the extension of the dual code over the extension field  $\mathbb{F}_{q^m}$  for an alternant/Goppa code defined over  $\mathbb{F}_q$ . Such code is defined by
+
+{5}------------------------------------------------
+
+Definition 1.5 (Extension of a code over a field extension). Let  $\mathscr{C}$  be a linear code over  $\mathbb{F}_q$ . We denote by  $\mathscr{C}_{\mathbb{F}_{q^m}}$  the  $\mathbb{F}_{q^m}$ -linear span of  $\mathscr{C}$  in  $\mathbb{F}_{q^m}^n$ .
+
+The point is that the extension over  $\mathbb{F}_{q^m}$  of the dual of an alternant code of extension degree m over  $\mathbb{F}_q$  contains the underlying GRS code, as
+
+<span id="page-5-1"></span>
+$$(\mathscr{A}_r(\boldsymbol{x}, \boldsymbol{y})^{\perp})_{\mathbb{F}_{q^m}} = \sum_{j=0}^{m-1} \mathbf{GRS}_r(\boldsymbol{x}^{q^j}, \boldsymbol{y}^{q^j}),$$
+ (3)
+
+(see for instance [BMT24, prop. 14]). The second ingredient then notices that we have triples of codewords  $c_1, c_2, c_3$  in this extended code that satisfy
+
+<span id="page-5-0"></span>
+$$\boldsymbol{c}_1 \star \boldsymbol{c}_2 = \boldsymbol{c}_3^2. \tag{4}$$
+
+An example of such a triple is obviously  $c_1 = y$ ,  $c_2 = y * x^2$ ,  $c_3 = y * x$ . One could argue that these triples lie in the private basis of the code. Here comes the third ingredient. From an arbitrary basis  $\mathcal{B} = (b_1, \dots, b_k)$  of the extension  $\mathscr{C}$  over  $\mathbb{F}_{q^m}$  of the dual of the alternant or Goppa code we want to distinguish, one computes the vector space formed by all vectors  $\mathbf{c} = (c_{ij})_{i,j \in [\![1,k]\!]} \in \mathbb{F}_{q^m}^{k(k+1)/2}$ 
+
+such that  $\sum_{i\leq j} c_{ij} \boldsymbol{b}_i \star \boldsymbol{b}_j = 0$ . We call this space the code of quadratic relations of  $\mathscr{C}$  with respect to  $\mathscr{B}$  and denote it with  $\mathscr{C}_{rel}(\mathscr{B})$ . In other words this is the linear space  $\mathscr{Q}$  of quadratic relations involving  $(\boldsymbol{c}_1, \dots, \boldsymbol{c}_k)$ . It is also called the quadratic hull of  $\mathscr{C}$ . Elements  $\boldsymbol{c}$  of this space can be viewed as a quadratic form
+
+$$Q_{\boldsymbol{c}}(\boldsymbol{x}) = \sum_{i < j} c_{ij} x_i x_j,$$
+
+or as symmetric matrices by taking the associated polar form  $M_c$  defined by
+
+$$xM_c y^{\mathsf{T}} = Q_c(x+y) - Q_c(x) - Q_c(y),$$
+
+where  $\mathbf{x} \stackrel{\text{def}}{=} (x_1, \dots, x_k)$  and  $\mathbf{y} \stackrel{\text{def}}{=} (y_1, \dots, y_k)$ . We denote this space of polar forms as the matrix code of quadratic relations associated to  $\mathscr{C}$  and the basis  $\mathcal{B}$ :
+
+Definition 1.6 (Matrix code of relations). Let  $\mathscr{C}$  be an [n,k] linear code over  $\mathbb{F}$  with basis  $\mathcal{B} = \{b_1, \ldots, b_k\}$ . The matrix code of quadratic relations with respect to  $\mathcal{B}$  is
+
+$$\mathscr{C}_{\mathrm{mat}}(\mathcal{B}) \stackrel{\mathrm{def}}{=} \{ M_{\boldsymbol{c}} = (m_{i,j})_{\substack{1 \leq i \leq k \\ 1 \leq j \leq k}} \mid \boldsymbol{c} = (c_{i,j})_{1 \leq i \leq j \leq k} \in \mathscr{C}_{\mathrm{rel}}(\mathcal{B}) \} \subseteq \mathbf{Sym}(k, \mathbb{F}),$$
+
+where  $M_c$  is defined as  $m_{i,j} \stackrel{\text{def}}{=} m_{j,i} \stackrel{\text{def}}{=} c_{i,j}, i \neq j$  and  $m_{i,i} \stackrel{\text{def}}{=} 2c_{i,i}, 1 \leq i \leq k$ .
+
+Assume now we have chosen a basis  $\mathcal{A}$  of  $\mathscr{C}$  where the first three elements are  $c_1 = y$ ,  $c_2 = y \star x^2$ ,  $c_3 = y \star x$ . In characteristic 2, it is readily seen that the matrix of the polar form corresponding to the quadratic relation (4) is 0
+
+{6}------------------------------------------------
+
+everywhere except in the first  $3 \times 3$  block where it is equal to  $\begin{bmatrix} 0 & 0 & 1 \\ 0 & 0 & 0 \\ 1 & 0 & 0 \end{bmatrix}$ , giving a
+
+matrix of rank 2. In an arbitrary basis  $\mathcal{B} = (\boldsymbol{b}_1, \dots, \boldsymbol{b}_k)$  the polar form of the quadratic relation (4) would still be a matrix of rank 2 because if  $\mathcal{A}$  and  $\mathcal{B}$  are two different bases of the same code, there exists (see [CMT23b, Prop. 4]) an invertible  $\boldsymbol{P} \in \mathbb{F}_{q^m}^{k \times k}$  such that
+
+$$\mathscr{C}_{\text{mat}}(\mathcal{A}) = \mathbf{P}^{\intercal} \mathscr{C}_{\text{mat}}(\mathcal{B}) \mathbf{P}. \tag{5}$$
+
+This is the third ingredient, namely that the matrix code of quadratic relations contains rank 2 matrices, regardless of the basis  $\mathcal{B}$ .
+
+The fourth ingredient consists in finding such a matrix of rank 2 in the matrix code of quadratic relations. This is a MinRank problem associated to the matrix code  $\mathscr{C}_{\mathrm{mat}}(\mathcal{B})$ . The key fact here is that this is a space of antisymmetric matrices when the field characteristic is 2. We use an algebraic approach by
+
+(1) expressing an element M of  $\mathscr{C}_{\mathrm{mat}}(\mathcal{B})$  as a  $k \times k$  matrix with entries that are linear forms in  $(z_1, \ldots, z_K)$  where the  $z_i$ 's are such that
+
+$$M = z_1 M_1 + \cdots + z_K M_K$$
+
+with  $M_1, \dots, M_K$  being a basis of antisymmetric matrices of  $\mathscr{C}_{\mathrm{mat}}(\mathcal{B})$ ,
+
+(2) writing a quadratic system in  $z_1, \dots, z_K$  expressing the fact that every  $4 \times 4$  principal minor of such an element of rank 2 in  $\mathscr{C}_{\text{mat}}(\mathcal{B})$  should be zero. The determinant of this antisymmetric submatrix of size 4 is indeed the square of what is called a Pfaffian and is therefore a quadratic form.
+
+The distinguisher consists in observing that solving this algebraic system by Gröbner basis techniques differs from solving a quadratic system with the same number of unknowns and equations [CMT23b, §5]. It basically amounts to the distinguisher of [FGO+11] in the very high rate alternant or Goppa code regime, stays subexponential in the error correction code capacity when the dimension s of the dual satisfies  $s = \mathcal{O}(n^{1-\varepsilon})$  for some constant  $\varepsilon > 0$ .
+
+TII challenges. TII published on its website<sup>4</sup> in 2023 a whole set of challenges aiming at better understanding the security of the McEliece cryptosystem and fostering further research on the topic. There were two kinds of contributions to the topic of the key attack challenges:
+
+- An algebraic attack [Mor25] using the Pfaffian modeling and distinguisher of [CMT23b]. It consisted in solving with Gröbner basis techniques the resulting algebraic system by specializing a suitable number of variables and finding for a given specialization a rank 2 matrix in the matrix code of quadratic relations. By finding two matrices of rank 2, using two different specializations, the support and Goppa polynomial of the Goppa code could
+
+<span id="page-6-0"></span><sup>4</sup> https://crowdchallenge.tii.ae/mceliece-challenges
+
+{7}------------------------------------------------
+
+be recovered. This attack only applies to the very specific case r = 2 which concerns only some very small parameters with claimed security ranging between 22 and 69 bits. All the parameter sets corresponding to r = 2 were broken, the attack taking only a few seconds (see [\[Mor25,](#page-33-0) table I]) except for one. This showed that the Pfaffian modeling of [\[CMT23b\]](#page-31-5) is not only restricted to give a distinguisher but can be transformed into an actual attack on the McEliece scheme when r = 2.
+
+– A clever and highly optimized implementation [\[Pan25\]](#page-33-5) of the support splitting attack of [\[Sen00\]](#page-33-4) which first finds by brute force the Goppa polynomial and then solves the code equivalence problem between the public code and the Goppa code related to a putative Goppa polynomial. It was able to break a challenge of up to 91 bits of claimed security in about 1470 core days of computation. This time the attack was not restricted to r = 2. For instance, the attacked instance corresponded to r = 6, m = 8, n = 253.
+
+#### 1.3 Contributions
+
+Our main contribution is to show that very high rate binary Goppa codes can indeed be attacked successfully. The attack works in polynomial time in the distinguisher regime of [\[FGO](#page-32-0)<sup>+</sup>11]. It basically breaks the CFS scheme [\[CFS01\]](#page-31-0) in polynomial time which has withstood quarter of a century of cryptanalytic efforts and is able to attack successfully some difficult TII challenges as shown by the following table.
+
+<span id="page-7-0"></span>
+
+| n       |  | m r Estimated security by TII | Attack [Pan25]           | Our attack         | Language |
+|---------|--|-------------------------------|--------------------------|--------------------|----------|
+| 253 8 5 |  | 83 bits                       | 19.06s<br>2<br>≈ 6.3 d   | 320.180s / 4.2GB   | Magma    |
+| 252 8 5 |  | 89 bits                       | 24.94s<br>2<br>≈ 1.02 yr | 315.420s / 4.3GB   | Magma    |
+| 507 9 7 |  | 125 bits                      | N/A                      | 34088.150s / 223GB | Magma    |
+| 500 9 7 |  | 166 bits                      | N/A                      | 33123.319s / 213GB | Magma    |
+| 491 9 7 |  | 210 bits                      | N/A                      | 15508.471s / 12GB  | C        |
+
+Table 1: Summary of the attacks against the TII challenges. We gave for the same parameters the complexity of the very carefully implemented support splitting algorithm given in [\[Pan25,](#page-33-5) Table 2] which held previous records in the TII key challenges. Our attack is a Magma script running on a machine equipped with an Intel Xeon Gold 6240L (Cascade Lake-SP), x86\_64, 2.60GHz, 4 CPUs/node, 18 cores/CPU and 6.0TiB of RAM. We give its time and memory complexity. The C implementation makes heavily use of the m4ri library [https://github.com/](https://github.com/malb/m4ri) [malb/m4ri](https://github.com/malb/m4ri).
+
+The bottleneck of our approach is the echelonization of a rather large binary matrix (Step [3](#page-24-0) of Algorithm [2\)](#page-24-0), although the size of the matrix is still polynomial in r and m. We give below a pessimistic estimate of how large these matrices can get for the cryptographic parameters of CFS.
+
+{8}------------------------------------------------
+
+| m    | r | # rows               | # columns |
+|------|---|----------------------|-----------|
+| 16 9 |   | ≈ 2, 980, 000        | 1,091,503 |
+| 18 9 |   | ≈ 4, 360, 000        | 1,314,631 |
+| 20 8 |   | ≈ 3, 540, 000        | 808,356   |
+|      |   | 24 10 ≈ 18, 150, 000 | 3,686,970 |
+
+<span id="page-8-0"></span>Table 2: Size of the matrices involved in Step [3](#page-24-0) of Algorithm [2.](#page-24-0) Performing linear algebra over binary matrices of such size (O (log r) times) is enough to recover a CFS private key. The number of rows we give comes from Heuristic [2.](#page-39-0) The number of columns is the number of monomials of degree ≤ 2 in the underlying polynomial ring. These estimations are pessimistic because the bound of Theorem [3.7](#page-19-0) proved to not be tight in our experiments, which suggests that we might shorten even more.
+
+Results on Tables [1](#page-7-0) and [2](#page-8-0) were obtained with our implementation written in Magma and C, available at [https://github.com/Crypto2026submission/](https://github.com/Crypto2026submission/CFS_TII) [CFS\\_TII](https://github.com/Crypto2026submission/CFS_TII).
+
+The approach. Basically we use the Pfaffian modeling of [\[CMT23b\]](#page-31-5) for finding rank 2 matrices in the matrix code of quadratic relations and use this knowledge in order to recover the support and Goppa polynomial with several new ingredients which are essential for performing the attack.
+
+- Instead of performing directly a hybrid attack by specifying some of the unknowns in the Pfaffian modeling as in [\[Mor25\]](#page-33-0), we first shorten the dual code in a relatively high number of positions. A lower bound on the number of times we can shorten is given in Theorems [3.5](#page-17-0) (alternant case) and [3.7](#page-19-0) (Goppa case). Note that this is also the crucial ingredient used in [\[Ran25\]](#page-33-1) to obtain a distinguisher whose complexity is subexponential in the error correction capacity of the Goppa code, thus beating asymptotically the best known attacks on the scheme which are exponential in this quantity. It turns out that the Pfaffian modeling of [\[CMT23b\]](#page-31-5) can also be improved by shortening the code. This first step reduces significantly the number of unknowns.
+- We use here the explicit Pfaffian modeling of [\[LMT25\]](#page-33-15) which reduces the number of unknowns and specify just one unknown in the homogeneous degree 2 system.
+- In both the CFS and the TII challenges that we attack, the number of equations is significantly higher than the number of monomials appearing in all of them, leading lots of redundancy. We can thus afford to generate only a subset of all possible equations.
+- Then instead of performing the standard Gröbner computation, we observed that the algebraic system is highly structured and contains many equations of degree 2 that are squares, i.e. of the form fi(z1, · · · , zK) <sup>2</sup> = 0, where f<sup>i</sup> is an affine equation in the unknowns z1, · · · , zK. Due to squaring being linear in characteristic 2, we can find such equations by solving a mere linear
+
+{9}------------------------------------------------
+
+system. Once these equations have been obtained, we use them for reducing the unknowns in the quadratic equations even further. This step is crucial to finish the computation of the Gröbner basis at degree 2 and is a key step of the attack. In other words, we have now enough quadratic equations to finish the computation without having to consider higher degree equations. Our algorithm has therefore polynomial complexity with respect to the degree r of the Goppa code and its extension degree m.
+
+## 2 Notation and Algebraic Coding Preliminaries
+
+#### 2.1 General notation
+
+General notation. [a, b] indicates the closed integer interval between a and b.  $\mathbb{F}_q$  denotes the finite field with q elements.
+
+Vector and matrix notation. Vectors are indicated by lowercase bold letters such as  $\boldsymbol{x}$  and matrices by uppercase bold letters such as  $\boldsymbol{M}$ . For a square matrix  $\boldsymbol{M} = (m_{ij})_{\substack{1 \leq i \leq n \\ 1 \leq j \leq n}}$  and an increasing subset  $I \subset [\![1,n]\!]$  of columns of  $\boldsymbol{M}$ , we
+
+denote by M[I] the square submatrix of M given by  $M[I] \stackrel{\text{def}}{=} (m_{ij})_{i,j \in I}$ . We will also simplify the notation and just write  $M[i,j,k,\ell]$  for  $M[\{i,j,k,\ell\}]$  when  $I = \{i,j,k,\ell\}$  is an increasing subset of columns of M.
+
+Given a function f acting on  $\mathbb{F}_q$  and a vector  $\mathbf{x} = (x_i)_{1 \leq i \leq n} \in \mathbb{F}_q^n$ , the expression  $f(\mathbf{x})$  is the component-wise mapping of f on  $\mathbf{x}$ , i.e.  $f(\mathbf{x}) = (f(x_i))_{1 \leq i \leq n}$ . We will also apply this for functions f acting on  $\mathbb{F}_q^n \times \mathbb{F}_q^n$ : for instance for two vectors  $\mathbf{x}$  and  $\mathbf{y}$  in  $\mathbb{F}_q^n$  and two positive integers a and b we denote by  $\mathbf{x}^a\mathbf{y}^b$  the vector  $(x_i^a y_i^b)_{1 \leq i \leq n}$ . We will use the same operation over matrices, but in order to avoid confusion with the matrix product, we use for a matrix  $\mathbf{A} = (a_{i,j})_{i,j}$  the notation  $\mathbf{A}^{(s)}$  which stands for the entries of  $\mathbf{A}$  all raised to the power s, i.e. the entry (i,j) of  $\mathbf{A}^{(s)}$  is equal to  $a_{i,j}^s$ . The scalar product between  $\mathbf{x} = (x_i)_{1 \leq i \leq n} \in \mathbb{F}_q^n$  and  $\mathbf{y} = (y_i)_{1 \leq i \leq n} \in \mathbb{F}_q^n$  is denoted by  $\mathbf{x} \cdot \mathbf{y}$  and is defined by  $\mathbf{x} \cdot \mathbf{y} = \sum_{i=1}^n x_i y_i$ .
+
+*Ideals*. Ideals are indicated by calligraphic  $\mathcal{I}$ . Given a sequence S of polynomials,  $\mathcal{I}(S)$  refers to the polynomial ideal generated by such sequence. Given the polynomials  $f_1, \ldots, f_m$ , we denote by  $\mathcal{I}(f_1, \ldots, f_m)$  the ideal generated by them.
+
+Codes. A linear code  $\mathscr{C}$  of length n and dimension k over  $\mathbb{F}_q$  is a k dimensional subspace of  $\mathbb{F}_q^n$ . We refer to it as an [n,k]-code. Linear codes can be specified compactly by a generator matrix, i.e. a  $k \times n$  matrix  $\mathbf{G}$  over  $\mathbb{F}_q$  whose rows generate the associated k-dimensional linear code  $\mathscr{C}$  over  $\mathbb{F}_q$  or equivalently
+
+$$\mathscr{C} = \{ \boldsymbol{u}\boldsymbol{G}: \ \boldsymbol{u} \in \mathbb{F}_q^k \}.$$
+
+<span id="page-9-0"></span>The dual of a code  $\mathscr{C}$  is defined as  $\mathscr{C}^{\perp} \stackrel{\text{def}}{=} \{ \boldsymbol{d} \in \mathbb{F}^n \mid \forall \boldsymbol{c} \in \mathscr{C}, \ \boldsymbol{c} \cdot \boldsymbol{d} = 0 \}$ . We also consider the *shortening* operation which reduces the dimension and length of a code
+
+{10}------------------------------------------------
+
+**Definition 2.1 (Shortening).** Let  $\mathscr{C}$  be an [n,k]-code and  $I \subset \{1,...,n\}$ . The shortening of  $\mathscr{C}$  at I is the  $[n-|I|, \geq k-|I|]$ -linear code given by
+
+$$\mathbf{Sh}_{I}(\mathscr{C}) \stackrel{\mathrm{def}}{=} \{(c_{j})_{j \neq I} \in \mathbb{F}_{q}^{n-|I|} \mid \mathbf{c} \in \mathscr{C}, \ \forall i \in I, \ c_{i} = 0\}.$$
+
+#### 2.2 Properties of GRS, alternant and Goppa Codes
+
+Alternant and Goppa codes are subfield subcodes of GRS codes as explained in the introduction. The definition given there relies on the fact that the dual of a GRS code is itself a GRS code as shown by
+
+Proposition 2.2 ([MS86], Theorem 4, p. 304). Let  $GRS_r(x, y)$  be a GRS code of length n. We have for any  $r \in [0, n]$ 
+
+<span id="page-10-0"></span>
+$$\mathbf{GRS}_{r}(\boldsymbol{x}, \boldsymbol{y})^{\perp} = \mathbf{GRS}_{n-r}(\boldsymbol{x}, \boldsymbol{y}^{\perp}),$$
+(6)
+
+where 
+$$y_i^{\perp} = (y_i \prod_{j \neq i} (x_i - x_j))^{-1}, i = 1, ..., n.$$
+
+The dimension of an alternant code of length n, degree r and extension degree m satisfies obviously for any support  $\boldsymbol{x} \in \mathbb{F}_{q^m}^n$ , multiplier  $\boldsymbol{y} \in \left(\mathbb{F}_{q^m}^{\times}\right)^n$ ,
+
+$$\dim \mathscr{A}_r(\boldsymbol{x}, \boldsymbol{y}) \ge n - r \cdot m. \tag{7}$$
+
+**Definition 2.3 (proper alternant/Goppa code).** An alternant code  $\mathscr{A}_r(x, y)$  of length n, degree r and extension degree m is said to be proper if and only if
+
+$$\dim \mathscr{A}_r(\boldsymbol{x},\boldsymbol{y}) = n - r \cdot m.$$
+
+It holds that generic alternant and Goppa codes are proper. In this paper we only consider proper alternant and Goppa codes. In this case, we have
+
+<span id="page-10-2"></span>
+$$(\mathscr{A}_r(\boldsymbol{x},\boldsymbol{y})^{\perp})_{\mathbb{F}_{q^m}} = \bigoplus_{j=0}^{m-1} \mathbf{GRS}_r(\boldsymbol{x}^{q^j},\boldsymbol{y}^{q^j}). \tag{8}$$
+
+This follows on the spot from the fact that  $(\mathscr{A}_r(\boldsymbol{x},\boldsymbol{y})^{\perp})_{\mathbb{F}_{q^m}}$  is the sum of the codes in the right-hand term (see (3)), and that for a linear code over  $\mathbb{F}_q$  we have  $\dim_{\mathbb{F}_q}(\mathscr{C}) = \dim_{\mathbb{F}_{q^m}}(\mathscr{C}_{\mathbb{F}_{q^m}})$ . Then  $\dim\left(\mathscr{A}_r(\boldsymbol{x},\boldsymbol{y})_{\mathbb{F}_{q^m}}^{\perp}\right) = r \cdot m$ , and as  $\dim\left(\mathbf{GRS}_r\left(\boldsymbol{x}^{q^j},\boldsymbol{y}^{q^j}\right)\right) = r$  we deduce that the sum is direct.
+
+# <span id="page-10-3"></span>2.3 The square code distinguisher
+
+<span id="page-10-1"></span>Since our attack applies to high rate Goppa codes, it is worthwhile recalling some facts about them coming from [FGO<sup>+</sup>11]. This original distinguisher essentially identifies a regime of parameters where squares of duals of alternant and Goppa codes have lower dimensions than squares of random codes with identical parameters. This comes from
+
+{11}------------------------------------------------
+
+**Theorem 2.4 ([MT22]).** Let  $\mathscr{C} = \mathscr{A}_r(\boldsymbol{x}, \boldsymbol{y})^{\perp}$  be a proper alternant code of extension degree m. Then
+
+$$\dim \mathscr{C}^{*2} \le \binom{rm+1}{2} - \frac{m}{2}(r-1)\left((2e_{\mathscr{A}}+1)r - 2\frac{q^{e_{\mathscr{A}}+1}-1}{q-1}\right), \tag{9}$$
+
+where
+
+<span id="page-11-1"></span>
+$$e_{\mathscr{A}} \stackrel{\text{def}}{=} \max\{i \in \mathbb{N} \mid r \ge q^i + 1\} = \lfloor \log_q(r - 1) \rfloor. \tag{10}$$
+
+If now  $\mathscr{C} = \mathscr{G}(\boldsymbol{x}, \Gamma)^{\perp}$  is proper, we have
+
+$$\dim \mathscr{C}^{\star 2} \le \binom{rm+1}{2} - \frac{m}{2}(r-1)(r-2), \qquad if \ r < q-1 \tag{11}$$
+
+$$\dim \mathscr{C}^{\star 2} \le \binom{rm+1}{2} - \frac{m}{2}r\left((2e_{\mathscr{G}}+1)r - 2(q-1)q^{e_{\mathscr{G}}-1} - 1\right), \qquad otherwise,$$
+(12)
+
+where
+
+$$e_{\mathscr{G}} \stackrel{\text{def}}{=} \min\{i \in \mathbb{N} \mid r \le (q-1)^2 q^i\} + 1 = \left\lceil \log_q \left( \frac{r}{(q-1)^2} \right) \right\rceil + 1.$$
+ (13)
+
+On the contrary, the square of a random [n, rm]-code has dimension  $\min\{n, \binom{rm+1}{2}\}$  with overwhelming probability [CCMZ15]. As a consequence if the length n is greater than the right-hand side of whichever inequality of Theorem 2.4 applies to  $\mathscr{C}$ , then computing the square code provides a distinguisher. This is the square distinguisher of [FGO+11].
+
+An [n, k]-code  $\mathscr{C}$  having an unusually small square code can be seen as  $\mathscr{C}$  having an unusually large quadratic hull. One can realize this is by considering the evaluation map with respect to some generator matrix  $\mathbf{G} \in \mathbb{F}_q^{k \times n}$  of  $\mathscr{C}$ 
+
+$$e_G: \mathbb{F}_q[X_1, \dots, X_k] \longrightarrow \mathbb{F}_q^n$$
+ (14)
+
+defined as the unique homomorphism of algebras such that  $X_i \mapsto c_i$ , where  $(c_1, \ldots, c_k)$  are the rows of G. We sometimes write  $f(c_1, \ldots, c_k)$  for  $e_G(f)$ . Clearly the image of the space of homogeneous polynomials of degree 2 (aka quadratic forms) under  $e_G$  is exactly  $\mathscr{C}^{*2}$ , and the quadratic hull of  $\mathscr{C}$  can be seen as the kernel of  $e_G$  restricted to this space. More generally, if we denote by  $I(\mathscr{C})$  the entire kernel of  $e_G$ , then one has
+
+$$I(\mathscr{C}) = \bigoplus_{r \ge 0} I_r(\mathscr{C}),$$
+
+where  $I_r(\mathscr{C})$  stands for the kernel of  $e_G$  restricted to the space of homogeneous polynomials of degree r. Throughout the paper we identify the code of quadratic
+
+<span id="page-11-0"></span>There is a slight abuse of notation here, as  $I(\mathscr{C})$  actually depends on the choice of generator matrix G. As noticed earlier and also in [Ran25], we can omit this dependency up to a linear change of variables.
+
+{12}------------------------------------------------
+
+relations, or quadratic hull, with  $I_2(\mathscr{C})$ . Note that the rank-nullity theorem implies
+
+$$\dim I_2(\mathscr{C}) = \binom{k+1}{2} - \dim \mathscr{C}^{\star 2},$$
+
+hence explaining why a smaller square code is equivalent to a larger quadratic hull.
+
+#### <span id="page-12-1"></span>2.4 Determinantal Modeling
+
+There are several ways to explain why duals of alternant and Goppa codes have a rather large quadratic hull. One of them, introduced in [Ran25] and reused in this work, is through a certain determinantal modeling. The point of this approach is that it can be shown that  $I_2(\mathscr{C})$  contains all  $2 \times 2$  minors of a certain  $2 \times f$  matrix  $\Phi$  whose entries are linear forms in the  $X_i$ 's, and where f is an integer that will be detailed thereafter. The key point, both in [Ran25] and in this work, is that this feature somehow survives under shortening.
+
+The exact form of the matrix  $\Phi$  obviously depends on the choice of basis. We specify how to construct  $\Phi$  in the so-called "canonical basis" (we use here the terminology of [CMT23b]) of the alternant code  $\mathscr{C} = (\mathscr{A}_r(\boldsymbol{x}, \boldsymbol{y}))_{\mathbb{F}_{q^m}}$  we are interested in. This basis is given by
+
+<span id="page-12-2"></span>
+$$\mathcal{B} \stackrel{\text{def}}{=} \{ \boldsymbol{y}^{q^u} \boldsymbol{x}^{aq^u} : u \in [0, m-1], a \in [0, r-1] \},$$
+ (15)
+
+i.e. it is nothing but the concatenation of the standard basis of the GRS codes involved in (8). We temporarily re-index the variables  $X_1, \ldots, X_{rm}$  as  $(X_a^{(u)})_{\substack{0 \le a < r \ 0 \le u < m}}$  and the evaluation map is given by mapping  $X_a^{(u)}$  onto  $\mathbf{y}^{q^u} \mathbf{x}^{aq^u}$ .
+
+Alternant case. Clearly we have a bunch of elements of  $\mathscr{C}_{rel}(\mathcal{B})$  given by quadratic relations of the kind for  $a, b, c, d \in [0, r-1]$  and  $u, v \in [0, m-1]$ ,
+
+$$\bm{y}^{q^u}\bm{x}^{aq^u}\bm{y}^{q^v}\bm{x}^{bq^v} - \bm{y}^{q^u}\bm{x}^{cq^u}\bm{y}^{q^v}\bm{x}^{dq^v} = \bm{0},$$
+
+when  $aq^u + bq^v = cq^u + dq^v$ . In the square distinguishable alternant case, it turns out that these relations apparently generate  $\mathscr{C}_{\rm rel}(\mathcal{B})$ , but they are clearly no independent. The approach of [Ran25] is to find a basis of these relations such that the relations can be interpreted as the minors of a certain matrix  $\Phi$ . The basis of the quadratic relations is chosen to be the relations of the form
+
+<span id="page-12-0"></span>
+$$y^{q^{e-u}}x^{aq^{e-u}}y^{q^{e-v}}x^{(b+q^v)q^{e-v}} - y^{q^{e-u}}x^{(a+q^u)q^{e-u}}y^{q^{e-v}}x^{bq^v} = 0, \quad (16)$$
+
+where  $e = e_{\mathscr{A}}$ , where  $e_{\mathscr{A}}$  is defined in (10), where u, v range over [0, e], a ranges over  $[0, r - 1 - q^u]$ , b ranges over  $[0, r - 1 - q^v]$ . These considerations lead to define
+
+{13}------------------------------------------------
+
+$$\boldsymbol{B}_{u} \stackrel{\text{def}}{=} \begin{pmatrix} X_{0}^{(0)} & X_{1}^{(0)} & \cdots & X_{r-1-q^{u}}^{(0)} \\ X_{q^{u}}^{(0)} & X_{q^{u+1}}^{(0)} & \cdots & X_{r-1}^{(0)} \end{pmatrix}$$
+
+$$(17)$$
+
+$$\mathbf{\Phi}_{\mathscr{A}} \stackrel{\text{def}}{=} \left( \mathbf{B}_0^{(e)} \middle| \mathbf{B}_1^{(e-1)} \middle| \cdots \middle| \mathbf{B}_e^{(0)} \right)$$
+ (18)
+
+It is readily seen that all minors  $\begin{vmatrix} X_a^{(e-u)} & X_b^{(e-v)} \\ X_{a+q^u}^{(e-u)} & X_{b+q^v}^{(e-v)} \end{vmatrix}$  of  $\Phi_{\mathscr{A}}$  correspond to the quadratic relations (16). This is [Ran25, Lem. 7]. The number  $f_{\mathscr{A}}$  of columns of  $\Phi_{\mathscr{A}}$  is readily seen to be given by
+
+$$f_{\mathscr{A}} = (e_{\mathscr{A}} + 1)r - \frac{q^{e_{\mathscr{A}} + 1} - 1}{q - 1}.$$
+ (19)
+
+For the rest of the paper, we assume now
+
+**Assumption 1.** We work from now on in characteristic 2. The codes we are interested in are binary. When we take their extension over an extension field, it will be over  $\mathbb{F}_{2^m}$ .
+
+The case of binary (squarefree) Goppa codes. When the Goppa polynomial  $\Gamma$  is squarefree, the binary Goppa code  $\mathscr{G}(\boldsymbol{x},\Gamma)$  can be viewed not only as an alternant code  $\mathscr{A}_r(\boldsymbol{x},\boldsymbol{y})$  where  $r=\deg\Gamma$  and  $\boldsymbol{y}=\frac{1}{\Gamma(\boldsymbol{x})}$  as given by its definition, but also as an alternant code of twice its degree, due to the fact that
+
+$$\mathscr{G}(\boldsymbol{x}, \varGamma) = \mathscr{G}(\boldsymbol{x}, \varGamma^2) = \mathscr{A}_{2r}\left(\boldsymbol{x}, \boldsymbol{y}^2\right).$$
+
+For the first equality see [MS77, p. 342] or [Ran25, Lem. 12]. This allows to define a  $2 \times f_{\mathscr{G}}$  matrix  $\Phi_{\mathscr{G}}$  which is about twice longer and whose  $2 \times 2$  minors all belong to  $I_2(\mathscr{C})$ . More precisely, we use the following equality.
+
+Lemma 2.5 ([Ran25], Proposition 7). Let  $\mathscr{C} \stackrel{\text{def}}{=} \mathscr{G}(\boldsymbol{x}, \Gamma)^{\perp}$  be the dual of a proper binary Goppa code with square-free Goppa polynomial  $\Gamma$ , and let  $\boldsymbol{z} \stackrel{\text{def}}{=} \Gamma(\boldsymbol{x})^{-2}$ . Then
+
+$$\mathscr{C}_{\mathbb{F}_{q^m}} = \bigoplus_{j=0}^{m/2-1} \mathbf{GRS}_{2r} \left( \boldsymbol{x}^{4^j}, \boldsymbol{z}^{4^j} \right),$$
+
+or
+
+$$\mathscr{C}_{\mathbb{F}_{q^m}} = \bigoplus_{j=0}^{(m-1)/2-1} \mathbf{GRS}_{2r}\left(\boldsymbol{x}^{4^j}, \boldsymbol{z}^{4^j}\right) \oplus \mathbf{GRS}_r\left(\boldsymbol{x}^{2^{m-1}}, \boldsymbol{y}^{2^{m-1}}\right),$$
+
+depending on the parity of m.
+
+We may now write variables  $(X_i^{(j)})_{i,j}$  accordingly. We assume m even without loss of generality. Then, much like we did in the alternant case, the basis element
+
+{14}------------------------------------------------
+
+ $(\boldsymbol{z}\boldsymbol{x}^i)^{4^j}$  is associated with a variable  $X_i^{(j)}$ , for all integers  $0 \leq i < 2r$  and  $0 \leq j \leq m/2 - 1$ . Finally, if we write for all  $0 \leq u \leq \hat{e} \stackrel{\text{def}}{=} \lfloor \log_4(2r - 1) \rfloor$ ,
+
+$$\boldsymbol{B}_{u} \stackrel{\text{def}}{=} \begin{pmatrix} X_{0}^{(0)} & X_{1}^{(0)} & \dots & X_{2r-1-4^{u}}^{(0)} \\ X_{4^{u}}^{(0)} & X_{4^{u}+1}^{(0)} & \dots & X_{2r-1}^{(0)} \end{pmatrix}, \tag{20}$$
+
+and
+
+<span id="page-14-1"></span>
+$$\mathbf{\Phi}_{\mathscr{G}} \stackrel{\text{def}}{=} \left( \mathbf{B}_0^{(\hat{e})} \middle| \mathbf{B}_1^{(\hat{e}-1)} \middle| \dots \middle| \mathbf{B}_{\hat{e}}^{(0)} \right), \tag{21}$$
+
+then the  $2 \times 2$  minors of  $\Phi_{\mathscr{G}}$  all belong to  $I_2(\mathscr{C})$  [Ran25, Cor. 5]. We easily see that the matrix  $\Phi_{\mathscr{G}}$  has length
+
+$$f_{\mathscr{G}} \stackrel{\text{def}}{=} (2\hat{e} + 2)r - \frac{4^{\hat{e}+1} - 1}{3}.$$
+ (22)
+
+#### 2.5 The Pfaffian modeling
+
+As explained in the introduction the matrix code of quadratic relations of the dual of an alternant or Goppa code contains many low rank quadratic forms. In particular, many of them happen to have rank 2 when considering codes over fields of characteristic 2. This led the authors of [CMT23b] to model the corresponding MinRank problem – consisting in finding matrices of rank 2 in  $\mathscr{C}_{\text{mat}}$  – using the Pfaffian modeling described thereafter.
+
+The modeling we are about to write here will apply not only to the original Goppa code but also to its shortening. For the sake of generality, we consider a general code  $\mathscr{C}$  of dimension D and fix a basis  $\mathcal{B}$  of the code  $\mathscr{C}$ . We then compute a basis  $(M_1, \dots, M_K)$  of  $\mathscr{C}_{\text{mat}}(\mathcal{B})$ . Here the  $M_i$ 's are  $D \times D$  antisymmetric matrices. Let M be defined by
+
+<span id="page-14-0"></span>
+$$\boldsymbol{M} = \sum_{i=1}^{K} z_i \boldsymbol{M}_i, \tag{23}$$
+
+where the  $z_i$ 's are formal variables. We express that the rank of M is less than or equal to 2 by asking that all  $4 \times 4$  principal minors of M are 0. It is readily seen that if we denote by  $m_{i,j}$  the entry of M, then the  $4 \times 4$  minor associated to the rows and columns  $i, j, k, \ell$  is given by
+
+$$\begin{vmatrix} 0 & m_{i,j} & m_{i,k} & m_{i,\ell} \\ m_{i,j} & 0 & m_{j,k} & m_{j,\ell} \\ m_{i,k} & m_{j,k} & 0 & m_{k,\ell} \\ m_{i,\ell} & m_{j,\ell} & m_{k,\ell} & 0 \end{vmatrix} = (m_{i,j}m_{k,l} + m_{i,k}m_{j,l} + m_{i,l}m_{j,k})^2$$
+(24)
+
+The term  $m_{i,j}m_{k,l} + m_{i,k}m_{j,l} + m_{i,l}m_{j,k}$  is called the Pfaffian corresponding to the principal minor associated to rows and columns  $i, j, k, \ell$ . It will be denoted by  $\mathbf{Pf}(M[i, j, k, \ell])$ . Expressing that M is of rank  $\leq 2$  is equivalent to require that all these Pfaffians are equal to 0, since all odd minors of an antisymmetric matrix
+
+{15}------------------------------------------------
+
+are equal to 0 and all  $4 \times 4$  minors can be expressed as bilinear combinations of the  $4 \times 4$  Pfaffians (this follows from the Pfaffian–Binet–Cauchy formula). This leads to the following set of  $\binom{D}{4}$  quadratic equations in the  $z_i$ 's
+
+Modeling 1 (Pfaffian modeling). The Pfaffian modeling expressing that an antisymmetric matrix
+
+<span id="page-15-0"></span>
+$$M = (m_{i,j})_{\substack{i \in \llbracket 1,D \rrbracket \\ j \in \llbracket 1,D \rrbracket}} = \sum_{i=1}^{K} z_i M_i$$
+
+of size  $D \times D$  belonging to the space generated by K antisymmetric matrices  $M_1, \dots, M_K$  is of rank  $\leq 2$  is given by
+
+Unknowns:  $z_1, \dots, z_K$ 
+
+**Equations:**  $\binom{D}{4}$  quadratic equations of the form
+
+$$m_{i,j}m_{k,l} + m_{i,k}m_{j,l} + m_{i,l}m_{j,k} = 0$$
+
+where the  $m_{i,j}$  are linear forms in the  $z_i$ 's that are specified by (23).
+
+# <span id="page-15-1"></span>3 Shortening before Looking for Rank 2 Matrices in $\mathscr{C}_{\mathrm{mat}}$
+
+The purpose of this section is to show that we can shorten by a large amount the extended dual code of the alternant/Goppa code in which we want to find rank 2 matrices in the associated matrix code of relations. This decreases significantly the number of unknowns in the algebraic attack. The crucial argument is the determinantal modeling put forward in [Ran25] and which is recalled in §2.4. The determinantal modeling is used in [Ran25] to lower bound the Betti numbers involved in the syzygy distinguisher. It is also used in a crucial way to lower bound those Betti numbers when the dual of the alternant or Goppa code gets shortened before applying the syzygy distinguisher.
+
+#### 3.1 The alternant case
+
+Let  $\mathscr{C} = \left( \mathscr{A}_r \left( \boldsymbol{x}, \boldsymbol{y} \right)^\perp \right)_{\mathbb{F}_{q^m}}$  be the extended dual of the alternant code we want to distinguish. Let us assume that we shorten  $\mathscr{C}$  in a set J of s positions and let  $\mathscr{C}_s$  be the resulting code. Without loss of generality, we may assume after permuting the positions that these are the last s positions of the code. We also order the set J and denote for  $j \in [\![1,s]\!]$  by  $\mathscr{C}_j$  the code  $\mathscr{C}$  shortened in the last j positions in J. Let  $\Phi$  be the  $2 \times f_{\mathscr{A}}$  matrix defined in §2.4 whose  $2 \times 2$  minors all belong to  $I_2(\mathscr{C})$ . We denote by k the dimension of  $\mathscr{C}$  and by G be the generator matrix of  $\mathscr{C}$ . We assume that this generator matrix is chosen in such a way that the first k-j rows of G form a basis of  $\mathscr{C}_j$  for every  $j \in J$  and that it is in systematic form in its k last positions. We denote by  $G_j$  the generator matrix
+
+{16}------------------------------------------------
+
+of  $\mathcal{C}_j$  formed by the k-j first rows of G and throwing out the last j columns. For the assumption on the systematic part, this assumption can be done at the cost of permuting the positions, for the rest we implicitly made the following assumption
+
+#### Assumption 2.
+
+$$\dim \mathscr{C}_{\mathfrak{s}} = \dim \mathscr{C} - s.$$
+
+It may happen that the dimension is bigger than this when we have for some  $j \in [0, s-1]$  that  $\mathscr{C}_j = \mathscr{C}_{j+1}$  (where  $\mathscr{C}_0 \stackrel{\text{def}}{=} \mathscr{C}$ ). We may in this case just reason on the subset J' of positions of J which are such that when we order J' again and define  $\mathscr{C}'_j$  as  $\mathscr{C}$  shortened in the last j positions of J' we have for all  $j \in [0, |J'| - 1]$ ,  $\dim \mathscr{C}'_{j+1} = \dim \mathscr{C}'_j - 1$  and  $\dim \mathscr{C}'_{s'} = \dim \mathscr{C} - s'$  where  $s' \stackrel{\text{def}}{=} |J'|$ .
+
+We denote the rows of G by  $c_1, \dots, c_k$  and consider as in §2.3 the evaluation map
+
+$$\boldsymbol{e_G}: \mathcal{R} \rightarrow \mathbb{F}_{q^m}^n \ f \mapsto f(\boldsymbol{c}_1, \cdots, \boldsymbol{c}_k)$$
+
+where  $\mathcal{R} = \mathbb{F}_{q^m}[X_1, \dots, X_k]$  is the polynomial ring of the entries of  $\Phi$ . Recall that  $I_2(\mathscr{C})$  is the kernel of  $e_{\mathbf{G}}$  restricted to the homogeneous polynomials of degree 2 in  $\mathcal{R}$ . We let  $V_{\Phi}$  be the  $\mathbb{F}_{q^m}$ -vector subspace of  $\mathcal{R}^2$  generated by the columns of  $\Phi$ . It is readily seen that (this is just a minor variation on [Ran25, Prop. 4, 1.] whose first item is this proposition in the case s = 1)
+
+<span id="page-16-0"></span>**Proposition 3.1.** For  $j \in [1, s]$  we let  $\mathcal{R}_j = \mathbb{F}_{q^m}[X_1, \dots, X_{k-j}]$ . Let  $V_j \stackrel{\text{def}}{=} V_{\Phi} \cap \mathcal{R}_j^2$ . We let  $\Phi_j$  be a matrix whose columns generate  $V_j$ . All  $2 \times 2$  minors of  $\Phi_j$  belong to  $I_2(\mathscr{C}_j)$ .
+
+Proof. Since  $V_j \subseteq V_{\Phi}$  and by the multilinearity of the determinant, any  $2 \times 2$  minor of  $\Phi_j$  is a linear combination of minors of  $\Phi$ . The resulting polynomial P evaluates to  $\mathbf{0}$  by  $\mathbf{e}_{\mathbf{G}}$ . Since it also belongs to  $\mathcal{R}_j$  by definition of  $V_j$  and is a homogeneous polynomial of degree 2, we have that  $P \in I_2(\mathscr{C}_j)$ .
+
+From now on we make an arbitrary choice for  $\Phi_1, \dots, \Phi_s$ . Basically it is also proved in [Ran25] that (to keep the paper self-contained we also give a proof in Appendix A)
+
+#### Lemma 3.2. We have
+
+$$\dim V_j \ge \dim V_{j-1} - 1, \ \forall j \in [1, s]$$
+ (25)
+
+$$\dim V_j \ge \dim V_{\Phi} - j \tag{26}$$
+
+where  $V_0 \stackrel{\text{def}}{=} V_{\Phi}$ . If we let  $f_j$  be the dimension of  $V_j$  for any  $j \in [1, s]$  then we have that  $f_j \geq f_{\mathscr{A}} - j$ , where  $f_{\mathscr{A}} \stackrel{\text{def}}{=} (e_{\mathscr{A}} + 1)r - \frac{q^{e_{\mathscr{A}} + 1} - 1}{q - 1}$  with  $e_{\mathscr{A}} \stackrel{\text{def}}{=} \lfloor \log_q(r - 1) \rfloor$ .
+
+{17}------------------------------------------------
+
+These lemmas imply that the matrices  $\Phi_j$  contain at least  $f_{\mathscr{A}} - j$  columns, which gives many quadratic relations which are in  $I_2(\mathscr{C}_j)$  by taking all  $2 \times 2$  minors of this matrix. The polar form associated to such a quadratic form is of rank at most 4. It turns out that we can find matrices of rank 2 associated to the determinant of a well-chosen  $2 \times 2$  matrix with entries in  $V_j$  as long as j is sufficiently small. Basically the approach is to show that we can find a  $2 \times 2$  minor of  $\Phi_j$  of the form  $\begin{vmatrix} a & b \\ b & c \end{vmatrix}$ . For this we consider for  $j \in [1, s]$  the two subspaces  $V_j^1$  and  $V_j^2$  of  $\mathcal{R}_j$  as the projection of  $V_j$  on the first entry or on the second entry. In other words if we let for  $i \in \{1, 2\}$ , the projection
+
+$$\pi_i: \mathcal{R} \times \mathcal{R}: \to \mathcal{R}$$
+
+$$(x_1, x_2) \mapsto x_i.$$
+
+We have  $V_j^i = \pi_i(V_j)$ . The crucial lemma is now
+
+<span id="page-17-1"></span>**Lemma 3.3.** Let  $\tilde{e}_{\mathscr{A}} \stackrel{\text{def}}{=} \lfloor \log_q \frac{r}{2} \rfloor$  and  $s_{\mathscr{A}} \stackrel{\text{def}}{=} (\tilde{e}_{\mathscr{A}} + 1)r - 2\frac{q^{\tilde{e}_{\mathscr{A}} + 1} - 1}{q - 1}$ . We have for any  $j \in [0, s_{\mathscr{A}}]$ ,
+
+$$\dim\left(V_j^1 \cap V_j^2\right) \ge s_{\mathscr{A}} - j.$$
+
+This result which is proved in Appendix A shows that we can shorten  $\mathscr C$  up to  $s=s_\mathscr A-1$  positions and derive from the existence of a non-zero element x belonging to both  $V^1_s$  and  $V^2_s$  that one of the two cases happens
+
+– We have a pair of elements in  $V_s$  which are of the form  $\begin{pmatrix} a \\ x \end{pmatrix}$  and  $\begin{pmatrix} x \\ b \end{pmatrix}$ 
+
+$$-\begin{pmatrix} x \\ x \end{pmatrix}$$
+ belongs to  $V_s$ .
+
+The first case implies on the spot that we have a matrix of rank 2 in the matrix code of relationships  $\mathscr{C}_{\mathrm{mat}}(\mathcal{B}_s)$  in characteristic 2 where  $\mathcal{B}_s$  is a basis of  $\mathscr{C}_s$ . It is the polar form of the quadratic relationship associated to the minor  $g \stackrel{\mathrm{def}}{=} \begin{vmatrix} a & x \\ x & b \end{vmatrix}$  belonging to  $I_2(\mathscr{C}_s)$ . Let us rule out now the second case.
+
+<span id="page-17-2"></span>**Lemma 3.4.** We have for any  $s \in [0, s_{\mathscr{A}}]$  that
+
+<span id="page-17-0"></span>
+$$\left\{ x \in \mathcal{R}_s : \begin{pmatrix} x \\ x \end{pmatrix} \in V_s \right\} = \{0\}.$$
+
+This result is proved in Appendix A. With these lemmas at hand, we can now prove our main result of this subsection which is
+
+**Theorem 3.5.** Let  $\tilde{e}_{\mathscr{A}} \stackrel{\text{def}}{=} \lfloor \log_q \frac{r}{2} \rfloor$  and  $s_{\mathscr{A}} \stackrel{\text{def}}{=} (\tilde{e}_{\mathscr{A}} + 1)r - 2\frac{q^{\tilde{e}_{\mathscr{A}} + 1} - 1}{q - 1}$ . Let  $\mathscr{C} = \left(\mathscr{A}_r(\boldsymbol{x}, \boldsymbol{y})^{\perp}\right)_{\mathbb{F}_{q^m}}$  be a proper alternant code where  $\mathbb{F}_{q^m}$  is a finite field of characteristic 2. For any  $s \in [0, s_{\mathscr{A}} - 1]$ , the matrix code of quadratic relations of  $\mathscr{C}_s$  contains a rank 2 matrix, where  $\mathscr{C}_s$  is  $\mathscr{C}$  shortened in s positions.
+
+{18}------------------------------------------------
+
+Proof. We can use Lemma 3.3 to show that for such a value s,  $V_s^1 \cap V_s^2 \neq \{0\}$ . Let  $x \neq 0$  being in this intersection. From Lemma 3.4 we know that there exist two elements in  $V_j$  of the form  $\begin{pmatrix} a \\ x \end{pmatrix}$  and  $\begin{pmatrix} x \\ b \end{pmatrix}$ . The minor  $g \stackrel{\text{def}}{=} \begin{vmatrix} a & x \\ x & b \end{vmatrix}$  belongs to  $I_2(\mathscr{C}_s)$ . Since  $e_{G_s}(g) = a \star b - x \star x$  with  $a \stackrel{\text{def}}{=} e_{G_s}(a)$ ,  $b \stackrel{\text{def}}{=} e_{G_s}(b)$ ,  $x \stackrel{\text{def}}{=} e_{G_s}(x)$ , we deduce that  $\mathscr{C}_{\text{rel}}(\mathcal{B}_s)$  contains the quadratic relation  $a \star b - x \star x$  where  $\mathcal{B}_s$  is the basis of  $\mathscr{C}_s$  formed by the k-s rows of  $G_s$ . This gives a matrix of rank 2 in the matrix code of relationships  $\mathscr{C}_{\text{mat}}(\mathcal{B}_s)$  in characteristic 2.  $\square$ 
+
+This theorem shows that we can shorten  $\mathscr{C}$  in  $s_{\mathscr{A}} - 1$  positions and still have matrices of rank 2 in the matrix code of quadratic relationships of  $\mathscr{C}_s$ . Experimentally, it turns out that this lower bound is tight. We report on Table 3 the values of  $s_{\mathscr{A}}$  for different set of parameters, together with
+
+- the dimension of the ideal  $\mathcal{P}_{\mathscr{A}}$  of the Pfaffian modeling for an alternant code before shortening, *i.e.* taking into acount all quadratic relations in  $I_2(\mathscr{C})$ ;
+- the dimension of the ideal  $\mathcal{P}_{\text{det}}$  of the Pfaffian modeling for rank-2 matrices in the matrix code generated by the matrices of the polar forms of the  $2 \times 2$  minors of  $\Phi$ . As these minors are a subset of  $I_2(\mathscr{C})$ , we expect the dimension of this ideal to be at most equal to that of  $\mathcal{P}_{\mathscr{A}}$ ;
+- <span id="page-18-0"></span>- the number of positions  $s_0$  at which we actually shortened the code in practice before writing the Pfaffian modeling and solving it. We expect this value to be at least  $s_{\mathscr{A}} - 1$ . The following table shows that it was exactly  $s_{\mathscr{A}} - 1$ .
+
+| r | m  | $s_{\mathscr{A}}$ | $\dim \mathcal{P}_{\mathrm{det}}$ | $\dim \mathcal{P}_{\mathscr{A}}$ | $s_0$ |
+|---|----|-------------------|-----------------------------------|----------------------------------|-------|
+| 3 | 10 | 1                 | 1                                 | 1                                | 0     |
+| 4 | 10 | 2                 | 2                                 | 2                                | 1     |
+| 5 | 10 | 4                 | 4                                 | 4                                | 3     |
+| 6 | 11 | 6                 | 6                                 | 6                                | 5     |
+| 8 | 12 | 10                | 10                                | 10                               | 9     |
+| 9 | 12 | 13                | 13                                | 13                               | N/A   |
+
+Table 3: Dimension of the Pfaffian ideal for alternant codes.
+
+Table 3 shows that the dimension of the Pfaffian ideal for alternant codes always coincides with  $s_{\mathscr{A}}$ .
+
+#### 3.2 The binary Goppa case
+
+Much of what is written in the last section also works when  $\mathscr{C} = (\mathscr{G}(\boldsymbol{x}, \Gamma)^{\perp})_{\mathbb{F}_{2^m}}$ . We define the set  $V_j$ 's in a similar way. Lemma 3.3 holds in the same way: it just relies on the existence of a matrix  $\Phi$  for which Proposition 3.1 applies and this is the case for the  $\Phi$  given in (21) in §2.4. The only difference with the previous case is
+
+{19}------------------------------------------------
+
+#### Lemma 3.6.
+
+$$\dim(V_0^1 \cap V_0^2) = s_{\mathscr{G}}$$
+
+$$where \ s_{\mathscr{G}} \stackrel{\text{def}}{=} 2\left((\tilde{e}_{\mathscr{G}} + 1)r - \frac{4^{\tilde{e}_{\mathscr{G}} + 1} - 1}{3}\right)$$
+
+$$\tilde{e}_{\mathscr{G}} \stackrel{\text{def}}{=} |\log_4 r|.$$
+
+*Proof.* The dimensions of the subspaces we are interested in do not depend on the chosen generator matrix. It is convenient here to consider the canonical basis (15). In this basis the matrix  $\Phi$  is given by
+
+$$\mathbf{B}_{u} \stackrel{\text{def}}{=} \begin{pmatrix} X_{0}^{(0)} & X_{1}^{(0)} & \dots & X_{2r-1-4^{u}}^{(0)} \\ X_{4^{u}}^{(0)} & X_{4^{u}+1}^{(0)} & \dots & X_{2r-1}^{(0)} \end{pmatrix} \\
+\mathbf{\Phi} \stackrel{\text{def}}{=} \begin{pmatrix} \mathbf{B}_{0}^{(\hat{e})} \middle| \mathbf{B}_{1}^{(\hat{e}-1)} \middle| \dots \middle| \mathbf{B}_{e}^{(0)} \end{pmatrix} \\
+\text{where } \hat{e} \stackrel{\text{def}}{=} |\log_{4}(2r-1)|.$$
+
+From this form it is readily seen that  $\dim(V_0^1 \cap V_0^2)$  is given by the number N of variables that appear both in the first row and the second row of  $\Phi$ . We clearly have
+
+$$\dim(V_0^1 \cap V_0^2) = N = \sum_{u=0}^{\hat{e}} \max(2r - 2 \cdot 4^u, 0)$$
+
+$$= 2 \sum_{u=0}^{\tilde{e}_{\mathscr{G}}} (r - 4^u)$$
+
+$$= 2 \left( (\tilde{e}_{\mathscr{G}} + 1)r - \frac{4^{\tilde{e}_{\mathscr{G}} + 1} - 1}{3} \right). \tag{27}$$
+
+<span id="page-19-0"></span>The same arguments used for alternant codes apply now, and we derive from it that
+
+**Theorem 3.7.** Let  $\tilde{e}_{\mathscr{G}} \stackrel{\text{def}}{=} \lfloor \log_4 r \rfloor$  and  $s_{\mathscr{G}} \stackrel{\text{def}}{=} 2 \left( (\tilde{e}_{\mathscr{G}} + 1)r - \frac{4^{\tilde{e}_{\mathscr{G}} + 1} - 1}{3} \right)$ . Let  $\mathscr{C} = \left( \mathscr{G}(\boldsymbol{x}, \Gamma)^{\perp} \right)_{\mathbb{F}_2^m}$  where  $\Gamma$  is a square free polynomial in  $\mathbb{F}_{2^m}[X]$  of degree r. For any  $s \in [0, s_{\mathscr{G}} - 1]$ , the matrix code of quadratic relations of  $\mathscr{C}_s$  contains a rank 2 matrix, where  $\mathscr{C}_s$  is  $\mathscr{C}$  shortened in s positions.
+
+We again report in Table 4 the dimension of the Pfaffian ideal  $\mathcal{P}_{\text{det}}$  associated to the  $2 \times 2$  minors of  $\Phi_{\mathscr{G}}$ , and the dimension of the Pfaffian ideal  $\mathcal{P}_{\mathscr{G}}$  when taking into account all relations in  $I_2(\mathscr{C})$ . Some dimensions were however not computable for all sets of parameters.
+
+{20}------------------------------------------------
+
+<span id="page-20-0"></span>
+
+| r              | m  | $s_{\mathscr{G}}$ | $\dim \mathcal{P}_{\mathrm{det}}$ | $\dim \mathcal{P}_{\mathscr{G}}$ | $s_0$     |
+|----------------|----|-------------------|-----------------------------------|----------------------------------|-----------|
+| 2              | 8  | 2                 | 2                                 | 3                                | 1         |
+| 3              | 8  | 4                 | 4                                 | 6                                | 4         |
+| $\overline{4}$ | 8  | 6                 | 6                                 | N/A                              | 7         |
+| 5              | 8  | 10                | 10                                | N/A                              | 11        |
+| 6              | 9  | 14                | 14                                | N/A                              | 15        |
+| 7              | 9  | 18                | N/A                               | N/A                              | 19        |
+| 8              | 11 | 22                | N/A                               | N/A                              | <b>22</b> |
+
+Table 4: Dimension of the Pfaffian ideal for Goppa codes.
+
+On Table 4, bold numbers indicate that we were able to shorten more than the theoretical bound  $s_{\mathscr{G}}-1$  suggests. Contrary to the alternant case, we observe  $\dim \mathcal{P}_{\det} < \dim \mathcal{P}_{\mathscr{G}}$ . Note that  $\dim \mathcal{P}_{\mathscr{G}} = 3$  when r=2 was already explained in details in [Mor25]. The inequality being strict in general comes from the fact that some quadratic forms in  $I_2(\mathscr{C})$  simply cannot be expressed as linear combinations of  $2 \times 2$  minors of  $\Phi_{\mathscr{G}}$  and its conjugates.
+
+#### 4 Squares in the Pfaffian Modeling
+
+If we perform a Gröbner basis computation for the Pfaffian modeling we noticed that there are quadratic polynomials which are squares  $f^2$  in the corresponding ideal. This happens regardless of whether we shorten or not. Obtaining such equations is really helpful. Indeed if we replace  $f^2$  by the linear form f, it does not change the associated variety, but this has the advantage to speed up significantly the computation since we can eliminate one variable with each (independent) linear form and even more importantly this ensures that the computation of the Gröbner basis stays at degree 2. Such squares can be computed directly without performing a Gröbner basis computation by solving a linear system. Indeed, the generators of our Pfaffian ideal are all polynomials with binary coefficients, so detecting degree 2 polynomials which are squares amounts to find quadratic polynomials with only quadratic monomials which are squares, *i.e.* of the form  $x_i^2$ .
+
+Let us explain now why there are squares in the Pfaffian modeling before shortening. We will explain what is going on for a specific example. Let us take  $\mathscr{C} = \left(\mathscr{A}_{\boldsymbol{x}}\left(\boldsymbol{y},r\right)^{\perp}\right)_{F_{q^m}}$  with r=m=4 and q=2 and consider the associated Pfaffian ideal. This code is square-distinguishable and the dimension K of  $I_2(\mathscr{C})$ 
+
+is 36 in this case. The fact that there are squares in the Pfaffian ideal does not depend on the basis chosen for  $\mathscr{C}$ . It will be helpful to consider the canonical basis for  $\mathscr{C}$  which is  $\mathcal{B} = \left\{ \boldsymbol{y}^{q^i} \boldsymbol{x}^{aq^i}, \ i \in [0, m-1], \ a \in [0, r-1] \right\}$ . The code of quadratic relationships  $\mathscr{C}_{\mathrm{rel}} \mathcal{B}$  is generated by all relations of the form
+
+<span id="page-20-1"></span>
+$$(\boldsymbol{y}\boldsymbol{x}^{i})^{q^{u}} \star (\boldsymbol{y}\boldsymbol{x}^{j})^{q^{v}} = (\boldsymbol{y}\boldsymbol{x}^{k})^{q^{u}} \star (\boldsymbol{y}\boldsymbol{x}^{l})^{q^{v}}, \tag{28}$$
+
+{21}------------------------------------------------
+
+where  $0 \le i, j, k, l < r$  and  $0 \le u, v < m$  are integers such that  $iq^u + jq^v = kq^u + lq^v$ . There are 36 independent relationships of this kind. To construct a basis of  $\mathscr{C}_{\text{mat}}(\mathcal{B})$  it will be helpful to choose a basis formed only by rank 2 and 4 matrices that correspond to a subset of quadratic relationships of the form (28). Quadratic relationships of this kind where k = l and u = v have a polar form of rank 2 where the nonzero part of the matrix correspond to rows and columns corresponding to  $\mathbf{y}^{q^u} \mathbf{x}^{iq^u}$  and  $\mathbf{y}^{q^u} \mathbf{x}^{jq^u}$  which is of the form
+
+$$\begin{array}{c|cccc} \boldsymbol{y} \boldsymbol{x}^{iq^u} \boldsymbol{y} \boldsymbol{x}^{kq^u} \boldsymbol{y} \boldsymbol{x}^{iq^u} - \begin{pmatrix} 0 & \boldsymbol{x} & 0 & 1 \ \boldsymbol{y} \boldsymbol{x}^{kq^u} - \boldsymbol{0} & 0 & 0 \ 1 & 0 & 0 & 0 \end{pmatrix}$$
+
+The other quadratic relations have a polar form whose nonzero part is a  $4 \times 4$  matrix of rank 2 given by
+
+$$\begin{array}{c|ccccccccccccccccccccccccccccccccccc$$
+
+We can choose a basis  $\{M_1, \dots, M_{36}\}$  of  $\mathcal{C}_{\text{mat}}\mathcal{B}$  with a maximum number of rank 2 matrices. Let  $M \stackrel{\text{def}}{=} \sum_{i=1}^{36} z_i M_i$ . It is given in Figure 1. We have put in red all variables  $z_i$  which after writing the corresponding Pfaffian modeling are such that their square  $z_i^2$  is in the liner span of these quadratic polynomials. It is readily verified on an example why this is the case. Consider the variable  $z_3$  for instance. Consider the Pfaffian corresponding to the 4 rows and columns containing a  $z_3$  term. It corresponds to the  $4 \times 4$  matrix P which contains the support of the  $M_3$  matrix. This Pfaffian is the square root of the following minor
+
+$$\begin{vmatrix}
+0 & z_1 & 0 & z_3 \\
+z_1 & 0 & z_3 & z_4 \\
+0 & z_3 & 0 & 0 \\
+z_3 & z_4 & 0 & 0
+\end{vmatrix}$$
+
+The corresponding Pfaffian is equal to  $z_1 \times 0 + 0 \times z_4 + z_3^2 = z_3^2$ . We have indicated in red the zeros that are responsible for the fact that this Pfaffian is actually a square.  $M_3$  corresponds to the following quadratic relationship:
+
+$$\mathbf{y} \star \mathbf{y}^2 \mathbf{x}^2 = \mathbf{y} \mathbf{x}^2 \star \mathbf{y}^2.$$
+
+{22}------------------------------------------------
+
+<span id="page-22-0"></span>Fig. 1: Matrix M corresponding to r = m = 4 where the variables in red appear as squares in the Pfaffian modeling.
+
+$$\boldsymbol{M} = \begin{bmatrix} 0 & 0 & z_1 & z_2 & 0 & z_3 & z_4 & z_5 & 0 & 0 & 0 & 0 & 0 & z_6 & z_7 \\ 0 & 0 & z_2 & z_8 & 0 & z_9 & z_{10} & z_{11} & 0 & 0 & 0 & 0 & z_6 & z_7 & z_{12} & z_{13} \\ z_1 & z_2 & 0 & 0 & z_3 & z_4 & z_5 & 0 & 0 & 0 & 0 & 0 & z_{12} & z_{13} & z_{14} & z_{15} \\ z_2 & z_8 & 0 & 0 & z_9 & z_{10} & z_{11} & 0 & 0 & 0 & 0 & 0 & z_{14} & z_{15} & 0 & 0 \\ \hline 0 & 0 & z_3 & z_9 & 0 & 0 & z_{16} & z_{17} & 0 & z_{18} & z_{19} & z_{20} & 0 & 0 & 0 & 0 \\ z_3 & z_9 & z_4 & z_{10} & 0 & 0 & z_{17} & z_{21} & 0 & z_{22} & z_{23} & z_{24} & 0 & 0 & 0 & 0 \\ z_4 & z_{10} & z_5 & z_{11} & z_{16} & z_{17} & 0 & 0 & z_{18} & z_{19} & z_{20} & 0 & 0 & 0 & 0 & 0 \\ \hline z_5 & z_{11} & 0 & 0 & z_{17} & z_{21} & 0 & 0 & z_{22} & z_{23} & z_{24} & 0 & 0 & 0 & 0 & 0 \\ \hline 0 & 0 & 0 & 0 & 0 & 0 & z_{18} & z_{22} & 0 & 0 & z_{25} & z_{26} & 0 & z_{27} & z_{28} & z_{29} \\ \hline 0 & 0 & 0 & 0 & 0 & z_{18} & z_{22} & z_{19} & z_{23} & 0 & 0 & z_{26} & z_{30} & 0 & z_{31} & z_{32} & z_{33} \\ \hline 0 & 0 & 0 & 0 & z_{19} & z_{23} & z_{20} & z_{24} & z_{25} & z_{26} & 0 & 0 & z_{27} & z_{28} & z_{29} & 0 \\ \hline 0 & 0 & 0 & 0 & z_{20} & z_{24} & 0 & 0 & z_{26} & z_{30} & 0 & z_{31} & z_{32} & z_{33} & 0 \\ \hline 0 & z_6 & z_{12} & z_{14} & 0 & 0 & 0 & 0 & 0 & z_{27} & z_{31} & z_{00} & z_{35} & z_{36} \\ \hline z_6 & z_{12} & z_{14} & 0 & 0 & 0 & 0 & 0 & z_{27} & z_{31} & z_{28} & z_{32} & 0 & 0 & z_{35} & z_{36} \\ \hline z_6 & z_{12} & z_{14} & 0 & 0 & 0 & 0 & 0 & z_{28} & z_{32} & z_{29} & z_{33} & z_{34} & z_{35} & 0 & 0 \\ \hline z_7 & z_{13} & z_{15} & 0 & 0 & 0 & 0 & 0 & z_{29} & z_{33} & 0 & 0 & z_{35} & z_{36} & 0 & 0 \\ \hline z_7 & z_{13} & z_{15} & 0 & 0 & 0 & 0 & 0 & z_{29} & z_{33} & 0 & 0 & z_{35} & z_{36} & 0 & 0 \\ \hline z_7 & z_{13} & z_{15} & 0 & 0 & 0 & 0 & 0 & z_{29} & z_{33} & 0 & 0 & z_{35} & z_{36} & 0 & 0 \\ \hline \end{array}$$
+
+It is insightful to give for the corresponding  $4 \times 4$  matrices the index of the basis elements which index the rows and columns of P:
+
+$$\begin{array}{c|cccc} \boldsymbol{y} \boldsymbol{x}^2 \boldsymbol{y}^2 \boldsymbol{x}^2 \boldsymbol{x}^2 \boldsymbol{x}^2 - \begin{pmatrix} 0 & z_1 & 0 & z_3 & z_4 \ z_1 & 0 & z_3 & z_4 \ 0 & z_3 & 0 & 0 \ z_3 & z_4 & 0 & 0 \ \end{pmatrix}$$
+
+The reason why there is a 0 at index  $(y^2, y^2x^2)$  is that there is no quadratic relationship of the form (28) involving the term  $y^2 \star y^2x^2$ . The same explanation holds for the 0 at index  $(y^2, y^2x^2)$ : here there is no quadratic relationship of the form (28) involving the term  $y \star y^2$ . Similar explanations can be given for all the variables that appear in red in Figure 1. For larger values of r, the fact that certain terms do not appear in (28) only explain the vast majority of the squares that appear in the linear span of the Pfaffian modeling but not all of them. In any case counting such Pfaffians gives an easy lower bound on the number of independent squares appearing in the linear span of the Pfaffian modeling.
+
+All this explains the existence of perfect squares in the Pfaffian modeling, at least in the square-distinguishable regime before shortening. It turns out that many perfect squares remain visible after shortening, even in a regime where the shortening is not square distinguishable. This is what we observed in practice, notably when solving TII challenges.
+
+{23}------------------------------------------------
+
+#### 5 The Algorithm of the Attack
+
+Let  $\mathscr{G} = \mathscr{G}(\boldsymbol{x}, \Gamma)$  be a binary Goppa code of extension degree m with square-free Goppa polynomial  $\Gamma$ . We let  $\mathscr{C} = (\mathscr{G}^{\perp})_{\mathbb{F}_{2^m}}$  be the extended dual code over  $\mathbb{F}_{2^m}$ . Throughout this section, we write  $\boldsymbol{y} \stackrel{\text{def}}{=} \Gamma(\boldsymbol{x})^{-1}$ . We describe here how to recover a pair  $(\boldsymbol{x}', \Gamma')$  such that  $\mathscr{G} = \mathscr{G}(\boldsymbol{x}', \Gamma')$  using Algorithm 1. Roughly speaking this algorithm computes  $t = \lceil e_{\mathscr{G}}/3 \rceil$  different shortened codes  $\mathscr{C}_s^1, \dots, \mathscr{C}_s^t$  with respect to s positions each time (where s is well chosen) and for each of those shortened codes  $\mathscr{C}_s^i$  computes a rank 2 matrix belonging to  $\mathscr{C}_{\mathrm{mat}}(\mathcal{B}_s^i)$  (where  $\mathcal{B}_s^i$  is an arbitrary basis of  $\mathscr{C}_s^i$ ). The resulting t rank 2 matrices yield rank 2 matrices in the matrix code of relations of the original code  $\mathscr{C}$ , for free. Due to them being computed from different shortenings, we can treat them as random independent rank 2 matrices in the matrix code of  $\mathscr{C}$ . A generalization of the attack on binary Goppa codes of degree r = 2 obtained in [Mor25] then finishes the job.
+
+#### 5.1 Outline of the attack
+
+The outline of the algorithm is the following one:
+
+#### <span id="page-23-0"></span>Algorithm 1 Attack
+
+- 1:  $\mathcal{E} \leftarrow \emptyset$
+- 2: **for** i = 1 to t **do**
+- 3: Choose a subset  $I_i$  of s positions of [1, n]  $\triangleright n$  is the length of  $\mathscr{C}$
+- 4:  $\mathscr{C}_s^i \leftarrow \mathbf{Sh}_{I_i}(\mathscr{C})$
+- 5:  $\mathcal{M} \leftarrow \text{Rank2Matrix}(\mathscr{C}_s^i) \triangleright \text{Returns a rank 2 matrix in } \mathscr{C}_{\text{mat}}(\mathcal{B}_s^i) \text{ where } \mathcal{B}_s^i \text{ is an arbitrary basis of } \mathscr{C}_s^i$
+- 6:  $\mathcal{E} \leftarrow \mathcal{E} \cup \mathcal{M}$
+- 7: Use the t rank 2 matrices of  $\mathcal{E}$  to reconstruct a basis  $\mathcal{B}$  of some  $\mathbf{GRS}_r\left(\boldsymbol{x}^{2^j},\boldsymbol{y}^{2^j}\right)$  for some j
+- 8: Apply [SS92] or [Mor25] to recover a support  ${\boldsymbol x}$  and a Goppa polynomial  $\Gamma$  from  ${\mathcal B}$
+- 9: return  $(\boldsymbol{x}, \Gamma)$
+
+# 5.2 Finding a rank 2 matrix in $\mathscr{C}_s^i$
+
+We explain here how the function Rank2Matrix( $\mathscr{C}_s^i$ ) works. Note that what we are going to explain also applies to the case where  $\mathscr{G}$  is a binary alternant code. Basically this is done through the following steps:
+
+- Compute a basis  $\mathcal{B}_s^i$  of  $\mathscr{C}_s^i$  together with a basis  $M_1, \ldots, M_K$  of  $\mathscr{C}_{\text{mat}}(\mathcal{B}_s^i)$ , apply Modeling 1 to  $\mathscr{C}_s$  and specialize one variable to 1.
+- Solve the relevant algebraic system by
+  - 1. Computing a Gröbner basis at degree 2 of the relevant system.
+  - 2. Finding squares in the linear span of quadratic equations and replace them by their square root.
+
+{24}------------------------------------------------
+
+- 3. Finding a Gröbner basis at degree 2 of the new system which turns out to be a Gröbner basis of the modified system.
+- 4. Performing a change of order [FGLM93] to get a Gröbner basis for the lexicographical order to output a matrix of rank 2 in  $\mathscr{C}_{\text{mat}}(\mathcal{B}_s^i)$ .
+
+In the alternant case we choose  $s = s_{\mathscr{A}} - 1$  and in the Goppa case s will be just slightly bigger than  $s_{\mathscr{G}} - 1$ . We adjusted this value by letting s grow, starting at  $s_{\mathscr{G}} - 1$  until the Pfaffian modeling for  $\mathscr{C}_s$  has dimension 0 after specialization of one variable to 1.
+
+# <span id="page-24-0"></span>**Algorithm 2** Function returning a rank 2 matrix in $\mathscr{C}_{\mathrm{mat}}(\mathscr{B})$ where $\mathscr{B}$ is a basis of $\mathscr{C}$
+
+- 1: function Rank2matrix( $\mathscr{C}$ )
+- 2: Compute Pfs = { $\mathbf{Pf}(M[i,j,k,l]) \mid 1 \leq i < j < k < l \leq rm-s$ };  $\triangleright M$  is the matrix of Modeling 1 applied to  $\mathscr{C}$ .
+- 3: Compute  $\mathcal{G}_1 = \text{GröbnerBasis}(\text{Pfs}, 2)$ ;  $\triangleright$  This just consists in echelonizing the quadratic system, obtaining linear equations and eliminate as many variables as we have obtained linear equations and then echelonize the obtained quadratic system again.
+- 4: Compute  $\mathscr{S}$  a basis of  $\{f \in \langle \mathcal{G}_1 \rangle_{\mathbb{F}_2} \mid \exists g, \ f = g^2\};$
+- 5:  $\mathscr{L} \leftarrow \{\sqrt{f} \mid f \in \mathscr{S}\};$
+- 6: Compute  $\mathscr{G}_2 = \text{GR\"obnerBasis}(\mathscr{L} \cup \mathscr{G}_1, 2)$ ;  $\triangleright$  We eliminate  $|\mathscr{L}|$  variables by using the linear equations of  $\mathscr{L}$  and echelonize the system.
+- 7:  $\mathscr{G}_{lex} \leftarrow Gr\ddot{o}bner basis in lexicographical order obtained by <math>\mathscr{G}_2$ ;
+- 8:  $\mathbf{B} \leftarrow \text{Solve}(\mathcal{G}_{\text{lex}});$
+- 9: return B
+
+A few remarks can be made here.
+
+- Remark 5.1. In all our experiments, Algorithm 2 did not return only one rank 2 matrix, but m. These m matrices were however all the same up to some conjugation operation as we explain in Appendix C. We thus need (and must) keep only one of these m matrices.
+  - The total number of Pfaffians is equal to  $\binom{rm-s}{4}$ . We aim at attacking high-rate Goppa codes, especially square-distinguishable Goppa codes. Such codes are such that the dimension K of  $I_2(\mathscr{C}_s)$  remains relatively small, leading to
+
+<span id="page-24-2"></span><span id="page-24-1"></span>
+$$\binom{rm-s}{4} \ge \binom{K+1}{2}. \tag{29}$$
+
+ $\triangleright$ 
+
+This inequality allows us to avoid computing all Pfaffians.
+
+– Due to the specialization, Step 3 already produces a certain number  $n_1$  of linear equations. The Gröbner basis computation at this step uses these linear forms to eliminate variables. As a result, the number of quadratic equations produced at this step cannot exceed  $\binom{K-n_1+1}{2}$ .
+
+{25}------------------------------------------------
+
+- Step 4 allows to find  $n_c$  additional linear equations. Experimentally, the quantities  $m, K, n_1, n_c$  always satisfy the equation
+
+<span id="page-25-0"></span>
+$$n_1 + n_c = K - m. (30)$$
+
+Incorporating the new linear equations, we experimentally obtain a radical ideal generated at degree 2. This is why we stop at Step 6: we expect  $\mathcal{G}_2$  to be a Gröbner basis of the radical of the specialized Pfaffian modeling.
+
+**Proposition 5.2.** Assume that Algorithm 2 indeed returns m solutions, as noticed in Remark 5.1. Also, assume we are in the regime where Inequality (29) holds. Then the complexity of Algorithm 2 is upper-bounded by
+
+<span id="page-25-1"></span>
+$$\kappa = \mathcal{O}\left(\binom{rm-s}{4}^{\omega}\right),\tag{31}$$
+
+where  $\omega$  is the exponent of linear algebra.
+
+*Proof.* To begin with, note that since the FGLM algorithm here has complexity  $\mathcal{O}\left(m^3(K-n_1-n_c)\right)$  (which is  $\mathcal{O}\left(m^4\right)$  if we further assume (30)). The bottleneck of Algorithm 2 therefore lies at Step 3, which amounts to echelonizing the Macaulay matrix representing the Pfaffians, deducing linear equations, and use the linear equations to eliminate variables. Again, the bottleneck here is the echelonization. The Macaulay matrix has (at most)  $\binom{rm-s}{4}$  rows, which exceeds the number of columns by (29).
+
+As we explained in Remark 5.1, we do not necessarily need to compute all the Pfaffians when (29) holds. The rank of the Macaulay matrix cannot exceed the number of columns, which is  $\binom{K+1}{2}$ . Therefore, we should in theory be able to pick  $\binom{K+1}{2}$  subsets  $\{i,j,k,l\} \subset \llbracket 1,rm-s \rrbracket$  so that the corresponding Pfaffians generate the vector space spanned by all Pfaffians, leading to a complexity of
+
+<span id="page-25-2"></span>
+$$\mathcal{O}\left(\binom{K+1}{2}^{\omega}\right) \tag{32}$$
+
+which is significantly less. It is unclear however how we can choose these subsets and ensure that the Pfaffians defined by these subsets are enough. In practice, we use another heuristic to avoid computing all the Pfaffians that is given in Appendix B. We give below the computation time it took us in practice to compute the first Macaulay matrix (Step 3 of Algorithm 2) and echelonize it, for r = 5 and several values of m, and with  $n = 2^m$ .
+
+{26}------------------------------------------------
+
+| m  | K   | $\binom{rm-s}{4}$ | # Pfaffians | $T_{\rm write}$ (s) | $T_{\text{Gauss}}$ (s) |
+|----|-----|-------------------|-------------|---------------------|------------------------|
+| 8  | 190 | 23751             | 18000       | 2.8                 | 1.1                    |
+| 9  | 201 | 46376             | 27000       | 3.3                 | 2.1                    |
+| 10 | 216 | 82251             | 42000       | 6.58                | 5.2                    |
+| 11 | 231 | 135751            | 63000       | 8.2                 | 9.1                    |
+| 12 | 246 | 211876            | 77000       | 15.7                | 17.1                   |
+| 13 | 261 | 316251            | 105000      | 27.7                | 29.9                   |
+
+Table 5: Time  $T_{\text{write}}$  to compute the Pfaffians in seconds and time  $T_{\text{Gauss}}$  (in seconds) to echelonize the resulting Macaulay matrix, for full-length dual Goppa codes of degree r=5. We also report the total number of Pfaffians  $i.e. \binom{rm-s}{4}$ , and the number of Pfaffians that we computed in practice (# Pfaffians) – essentially those corresponding to Heuristic 2 –. Each time, the Pfaffians that we computed were enough to solve the system.
+
+We see that the number of variables K in the Pfaffian modeling is asymptotically proportional to m, so we expect the Gaussian elimination time to be proportional to a power of m. The pessimistic complexity (31) suggests that the exponent is less than  $4\omega \leq 12$ , while the theoretical optimum (32) suggests it should be around  $2\omega$ . In practice, a simple linear regression between m and  $T_{\rm Gauss}$  gives an exponent of 6.8945 with confidence  $R^2 = 0.9973$ . This is significantly higher than  $2\omega$ , but this might be explained by the fact that we compute significantly more Pfaffians than  $\binom{K+1}{2}$ , leading to a Macaulay matrix with many more rows than columns. The reason why we do this instead of computing around  $\binom{K+1}{2}$  random Pfaffians (which would indeed be enough) is that the first Pfaffians that we compute, i.e. those outside the dense block, are sparse. We have seen in practice that computing random Pfaffians increases  $T_{\rm write}$  so much that our strategy is the fastest for solving the TII instances reported on Table 1. For the CFS parameters on Table 2 however, choosing random Pfaffians might be a winning strategy due to the very large number of rows given by our heuristic.
+
+#### <span id="page-26-0"></span>5.3 Finishing the attack with enough rank 2 matrices in $\mathscr{C}_{\mathrm{mat}}$
+
+Computing a fundamental triple  $(\boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w})$  of vectors. Rank 2 matrices in the matrix code of relations of the shortened codes  $\mathscr{C}_s^i$  we immediately deduce rank 2 matrices in the matrix code of relations of the original code. For each such matrix  $\boldsymbol{B}$  of rank 2, we compute a pair  $(\boldsymbol{\mu}, \boldsymbol{\nu})$  of vectors that span the rowspace of  $\boldsymbol{B}$ . We are going to deduce from this a triple  $(\boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w})$  of elements of  $\mathscr{C}$  which live in a much smaller space related to the GRS code we want to retrieve: they will live namely in  $\bigoplus_{j=0}^{e_{\mathscr{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right)$  (or a Frobenius conjugate of this code). Here is how we proceed. We first compute a basis  $\mathcal{B}$  of  $\mathscr{C}$  which is of the form
+
+<span id="page-26-1"></span>
+$$\mathcal{B} = (\boldsymbol{b}_0, \dots, \boldsymbol{b}_{r-1}, \boldsymbol{b}_0^2, \dots, \boldsymbol{b}_{r-1}^2, \dots, \boldsymbol{b}_0^{2^{m-1}}, \dots, \boldsymbol{b}_{r-1}^{2^{m-1}}), \tag{33}$$
+
+{27}------------------------------------------------
+
+and define  $H_{\mathcal{B}}$  as the matrix whose rows are the elements of  $\mathcal{B}$  in that order. We then define
+
+$$\begin{aligned} \boldsymbol{u} & \stackrel{\text{def}}{=} \boldsymbol{\mu} \boldsymbol{H}_{\mathcal{B}} \in \mathscr{C} \ \boldsymbol{v} & \stackrel{\text{def}}{=} \boldsymbol{\nu} \boldsymbol{H}_{\mathcal{B}} \in \mathscr{C}. \end{aligned}$$
+
+We also compute a vector  $\boldsymbol{w} \in \mathscr{C}$  such that
+
+<span id="page-27-0"></span>
+$$u \star v = w^2$$
+.
+
+In other words  $\boldsymbol{w} = (\boldsymbol{u} \star \boldsymbol{v})^{\frac{1}{2}}$ . It turns that these vectors live in a much smaller space than the whole code  $\mathscr{C}$  as explained above. We observed this experimentally and proved it for  $\boldsymbol{u}$  and  $\boldsymbol{v}$  under some mild assumption
+
+**Proposition 5.3.** Under Assumption 3, we have for some  $a \in [0, m-1]$ :
+
+$$\boldsymbol{u},\boldsymbol{v}\in\bigoplus_{j=a}^{a+e_{\mathscr{G}}-1}\mathbf{GRS}_{r}\left(\boldsymbol{x}^{2^{j}},\boldsymbol{y}^{2^{j}}\right).$$
+
+For a proof see Appendix C. We experimentally also find that  $\boldsymbol{w}$  lives in the same space as  $\boldsymbol{u}$  and  $\boldsymbol{v}$ . From now on we call FundamentalTriple( $\boldsymbol{B}$ ) the function that outputs such a triple  $(\boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w})$ .
+
+Alignment of Fundamental triples. With the previous procedure we obtain many triples  $(\boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i)$  which live in subspaces of the form  $\bigoplus_{j=a_i}^{a_i+e_{\mathcal{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right)$ . We say that two triples  $(\boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i)$  and  $(\boldsymbol{u}_j, \boldsymbol{v}_j, \boldsymbol{w}_j)$  are aligned when  $a_i = a_j$ . Notice that there exists necessarily for two such triples an integer  $b \in [0, m-1]$  such that  $(\boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i)$  and  $(\boldsymbol{u}_j^{2^b}, \boldsymbol{v}_j^{2^b}, \boldsymbol{w}_j^{2^b})$  are aligned. This integer b can be found with the following heuristic
+
+<span id="page-27-1"></span>Heuristic 1. Let  $(\boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w})$  and  $(\boldsymbol{u}', \boldsymbol{v}', \boldsymbol{w}')$  be two triples obtained as explained above, each of them living respectively in  $\bigoplus_{j=a}^{a+e_{\mathcal{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right)$  and in  $\bigoplus_{j=a'}^{a'+e_{\mathcal{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right)$ . For  $b \in [0, m-1]$  define the linear code  $\mathscr{V}_b \stackrel{\text{def}}{=} \left\langle \boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w}, \boldsymbol{u'}^{2^b}, \boldsymbol{v'}^{2^b}, \boldsymbol{w'}^{2^b} \right\rangle_{\mathbb{F}_{2^m}}$ . We assume that  $\dim \mathscr{V}_i = 6$  all the time, otherwise we can merely check this dimension to verify alignment. Finally, define the function  $f: \{0, \ldots, m-1\} \to \mathbb{N}$  as  $f(b) \stackrel{\text{def}}{=} \dim \mathscr{V}_b^{\star 2}$ . Then
+
+- f is not a constant function;
+- f is minimal at  $b_0$  such that  $(\boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i)$  and  $(\boldsymbol{u}_j^{2^{b_0}}, \boldsymbol{v}_j^{2^{b_0}}, \boldsymbol{w}_j^{2^{b_0}})$  are aligned;
+- f is maximal at  $b_0 + \lfloor m/2 \rfloor \mod m$ .
+
+We observed this experimentally and some justification is given in the appendix. From now on we denote by ALIGNEMENT( $(\boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w}), (\boldsymbol{u}', \boldsymbol{v}', \boldsymbol{w}')$ ) the function which outputs such an integer  $b_0$ .
+
+{28}------------------------------------------------
+
+Recovering a GRS code. By finding  $\lceil e_{\mathscr{G}}/3 \rceil$  triples we can reconstruct a large subcode of (some conjugate of)  $\mathscr{D} \stackrel{\text{def}}{=} \bigoplus_{j=0}^{e_{\mathscr{G}}-1} \mathbf{GRS}_r \left( \boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j} \right)$ . We may even assume that the triples generate this code entirely, up to conjugation. In fact, the only parameter for which we could not reconstruct this code entirely was r=5, for which Assumption 3 is refined. We explain in Appendix E how to recover a support and Goppa polynomial in this case anyway, leading to a correct attack on TII challenges 83 and 89.
+
+From now on we assume that  $\mathscr{D}$  is reconstructed. We are going to recover (up to Frobenius conjugation) the GRS code  $\mathbf{GRS}_r\left(x^{2^{e_{\mathscr{G}}-1}},y^{2^{e_{\mathscr{G}}-1}}\right)$  by using the following proposition.
+
+**Proposition 5.4.** Define  $\mathscr{D}_0 \stackrel{\text{def}}{=} \mathscr{D}$  and  $\mathscr{D}_{i+1} \stackrel{\text{def}}{=} \mathscr{D}_i \cap \mathscr{D}_i^{(2)}$  for all  $0 \leq i < e_{\mathscr{G}} - 1$ . Then we have
+
+$$\forall 0 \leq i < e_{\mathscr{G}}, \ \mathscr{D}_i = \bigoplus_{j=i}^{e_{\mathscr{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right).$$
+
+*Proof.* We proceed through induction. The desired equality is true for i=0 by definition. Let us assume it is true for some  $0 \le i < e_{\mathscr{G}} - 1$ , and let  $\boldsymbol{u} \in \mathscr{D}_i \cap \mathscr{D}_i^{(2)}$ . We may write  $\boldsymbol{u} = \sum_{j=i}^{e_{\mathscr{G}}-1} \boldsymbol{y}^{2^j} f_j(\boldsymbol{x})^{2^j}$ , with polynomials  $f_j \in \mathbb{F}_{2^m}[X]_{\le r}$  being unique. On the other hand, we know that  $\boldsymbol{u} \in \mathscr{D}_i^{(2)}$ , which means that there are unique polynomials  $g_j$  such that
+
+$$\bm{u} = \left(\sum_{j=i}^{e_\mathscr{G}-1} \bm{y}^{2^j} g_j(\bm{x})^{2^j}\right)^2 = \sum_{j=i+1}^{e_\mathscr{G}} \bm{y}^{2^j} g_{j-1}(\bm{x})^{2^j}.$$
+
+The uniqueness of the writing of  $\boldsymbol{u}$  as an element of  $\mathscr{C}_{\mathbb{F}_{2^m}} = \bigoplus_{j=0}^{m-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right)$  implies that we have  $f_j = g_{j-1}$  for all  $j \geq i+1$  and  $f_i = 0$ , hence we have indeed  $\boldsymbol{u} \in \bigoplus_{j=i+1}^{e_{\mathscr{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j}, \boldsymbol{y}^{2^j}\right)$ . The converse inclusion is easily verified.  $\square$ 
+
+In particular, we get access to  $\mathscr{D}_{e_{\mathscr{G}}-1} = \mathbf{GRS}_r\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-1}}, \boldsymbol{y}^{2^{e_{\mathscr{G}}-1}}\right)$ . It only remains to apply the Sidelnikov-Shestakov attack to recover a valid pair  $\boldsymbol{x}', \boldsymbol{y}'$  such that  $\mathscr{C} = \mathscr{A}_r\left(\boldsymbol{x}', \boldsymbol{y}'\right)^{\perp}$ . We obtain a Goppa polynomial  $\Gamma'$  by using the method described in [Mor25, §3]. The whole attack is then given by the following algorithm.
+
+The complexity of Algorithm 3 is that of linear algebra over matrices of size  $rm \times rm$ , repeated at most  $mt = \mathcal{O}(m \log r)$  times. This is by far negligible compared to the complexity of Algorithm 2. We conclude
+
+**Theorem 5.5.** Under our heuristic experimentally supported, we retrieve the private structure of a square distinguishable binary Goppa code of degree r and extension degree m by running  $t = \lceil e_{\mathscr{G}}/3 \rceil$  times Algorithm 2 and then Algorithm 3, for a total complexity of
+
+$$\kappa_{tot} = \mathcal{O}\left(\binom{rm - s_{\mathscr{G}} + 1}{4}\right)^{\omega} \log r. \tag{34}$$
+
+{29}------------------------------------------------
+
+<span id="page-29-0"></span>**Algorithm 3** Recovering a support and a Goppa polynomial from  $t > e_{\mathscr{G}}/3$  matrices of rank 2 in  $\mathscr{C}_{\text{mat}}(\mathcal{B})$  where  $\mathcal{B}$  is a given basis of  $\mathscr{C}$ .
+
+```
+1: Input: B_1, \ldots, B_t of rank 2 in \mathscr{C}_{\text{mat}}(\mathcal{B}) where \mathcal{B} is a basis of \mathscr{C} in the form of (33).
+  2: Output: \mathbf{x}', \Gamma' such that \mathscr{C} = \mathscr{G}(\mathbf{x}', \Gamma')^{\perp}.
+  3: (\boldsymbol{u}_1, \boldsymbol{v}_1, \boldsymbol{w}_1) \leftarrow \text{FundamentalTriple}(\boldsymbol{B}_1);
+  4: for i = 2, ..., t do
+                 (\boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i) \leftarrow \text{FundamentalTriple}(\boldsymbol{B}_i);
+  5:
+                 b \leftarrow \text{Alignement}((\boldsymbol{u}_1, \boldsymbol{v}_1, \boldsymbol{w}_1), \boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i));
+  6:
+                 (\boldsymbol{u}_i,\boldsymbol{v}_i,\boldsymbol{w}_i) \leftarrow (\boldsymbol{u}_i^{2^b},\boldsymbol{v}_i^{2^b},\boldsymbol{w}_i^{2^b});
+  7:
+  8: \mathscr{D} \leftarrow \langle \boldsymbol{u}_i, \boldsymbol{v}_i, \boldsymbol{w}_i \mid 1 \leq i \leq t \rangle_{\mathbb{F}_{2^m}};
+  9: for i = 1, ..., e_{\mathscr{G}} - 1 do
+                  \mathscr{D} \leftarrow \mathscr{D} \cap \mathscr{D}^{(2)};
+10:
+11: Use [Mor25, §3] to recover \boldsymbol{x}', \Gamma' from \mathscr{D} = \mathbf{GRS}_r\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-1}}, \boldsymbol{y}^{2^{e_{\mathscr{G}}-1}}\right) (up to con-
+         jugation).
+```
+
+# 6 Concluding Remarks
+
+With the notable exception of the very peculiar case when the Goppa polynomial is of degree 2 [Mor25], this is the first time that there is a key attack on the McEliece scheme based on binary Goppa codes. It applies to square-distinguishable binary Goppa codes, meaning very high rate Goppa codes. It gives in this case an attack of polynomial complexity. In particular it applies to the CFS signature scheme [CFS01]. It breaks this 25 years old signature scheme. We also applied it to codes of smaller rate which are not square-distinguishable such as the TII challenges we broke. Arguably however, the codes of this kind were close to be square-distinguishable.
+
+This shows that the MinRank modeling with Pfaffians does not only lead to distinguisher attacks, it may also lead to actual attacks. We prove in this case some fundamental results about what happens in this case when we shorten the dual code before applying our attack to it and give in the alternant case a tight bound about the number of positions that we can shorten and still keep rank 2 matrices in the matrix code of quadratic relationships. Moreover we also observed that there are squares in the associated polynomial at degree 2. They can easily be obtained by solving a linear system and are instrumental for keeping the computations of the Gröbner basis at degree 2 in this case. Here we have only some partial understanding of the dimension of the vector space formed by these squares (and this particularly if we shorten the code). In any case, the Pfaffian modeling of [CMT23b] raises very intriguing questions on understanding the subspace of squares which are in the corresponding ideal. It suggests that there are many interesting algebraic phenomena in the Pfaffian modeling which would be interesting to understand in order to push further the attack proposed here way beyond the square-distinguishability regime.
+
+{30}------------------------------------------------
+
+# References
+
+- <span id="page-30-4"></span>ABC<sup>+</sup>22. Martin Albrecht, Daniel J. Bernstein, Tung Chou, Carlos Cid, Jan Gilcher, Tanja Lange, Varun Maram, Ingo von Maurich, Rafael Mizoczki, Ruben Niederhagen, Edoardo Persichetti, Kenneth Paterson, Christiane Peters, Peter Schwabe, Nicolas Sendrier, Jakub Szefer, Cen Jung Tjhai, Martin Tomlinson, and Wang Wen. Classic McEliece (merger of Classic McEliece and NTS-KEM). <https://classic.mceliece.org>, November 2022. Fourth round finalist of the NIST post-quantum cryptography call.
+- <span id="page-30-7"></span>BBB<sup>+</sup>17. Gustavo Banegas, Paulo S.L.M Barreto, Brice Odilon Boidje, Pierre-Louis Cayrel, Gilbert Ndollane Dione, Kris Gaj, Cheikh Thiécoumba Gueye, Richard Haeussler, Jean Belo Klamti, Ousmane N'diaye, Duc Tri Nguyen, Edoardo Persichetti, and Jefferson E. Ricardini. DAGS : Key encapsulation for dyadic GS codes. [https:](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/DAGS.zip) [//csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/DAGS.zip) [documents/round-1/submissions/DAGS.zip](https://csrc.nist.gov/CSRC/media/Projects/Post-Quantum-Cryptography/documents/round-1/submissions/DAGS.zip), November 2017. First round submission to the NIST post-quantum cryptography call.
+- <span id="page-30-10"></span>BC18. Élise Barelli and Alain Couvreur. An efficient structural attack on NIST submission DAGS. In Thomas Peyrin and Steven Galbraith, editors, Advances in Cryptology - ASIACRYPT'18, volume 11272 of LNCS, pages 93– 118. Springer, December 2018.
+- <span id="page-30-5"></span>BCGO09. Thierry P. Berger, Pierre-Louis Cayrel, Philippe Gaborit, and Ayoub Otmani. Reducing key length of the McEliece cryptosystem. In Bart Preneel, editor, Progress in Cryptology - AFRICACRYPT 2009, volume 5580 of LNCS, pages 77–97, Gammarth, Tunisia, June 21-25 2009.
+- <span id="page-30-3"></span>Ber10. Daniel J. Bernstein. Grover vs. McEliece. In Nicolas Sendrier, editor, Post-Quantum Cryptography 2010, volume 6061 of LNCS, pages 73–80. Springer, 2010.
+- <span id="page-30-0"></span>BJMM12. Anja Becker, Antoine Joux, Alexander May, and Alexander Meurer. Decoding random binary linear codes in 2 n/<sup>20</sup>: How 1 + 1 = 0 improves information set decoding. In Advances in Cryptology - EUROCRYPT 2012, LNCS. Springer, 2012.
+- <span id="page-30-11"></span>BL04. Thierry P. Berger and Pierre Loidreau. Designing an efficient and secure public-key cryptosystem based on reducible rank codes. In Progress in Cryptology - INDOCRYPT 2004, volume 3348 of LNCS, pages 218–229, 2004.
+- <span id="page-30-6"></span>BLM11. Paulo Barreto, Richard Lindner, and Rafael Misoczki. Monoidic codes in cryptography. In Post-Quantum Cryptography 2011, volume 7071 of LNCS, pages 179–199. Springer, 2011.
+- <span id="page-30-2"></span>BLP08. Daniel J. Bernstein, Tanja Lange, and Christiane Peters. Attacking and defending the McEliece cryptosystem. In Post-Quantum Cryptography 2008, volume 5299 of LNCS, pages 31–46, 2008.
+- <span id="page-30-8"></span>BLP10. Daniel J. Bernstein, Tanja Lange, and Christiane Peters. Wild McEliece. In Alex Biryukov, Guang Gong, and Douglas R. Stinson, editors, Selected Areas in Cryptography, volume 6544 of LNCS, pages 143–158, 2010.
+- <span id="page-30-9"></span>BLP11. Daniel J. Bernstein, Tanja Lange, and Christiane Peters. Wild McEliece Incognito. In Bo-Yin Yang, editor, Post-Quantum Cryptography 2011, volume 7071 of LNCS, pages 244–254. Springer Berlin Heidelberg, 2011.
+- <span id="page-30-1"></span>BM17. Leif Both and Alexander May. Optimizing BJMM with Nearest Neighbors: Full Decoding in 2 2/21n and McEliece Security. In WCC Workshop on Coding and Cryptography, September 2017.
+
+{31}------------------------------------------------
+
+- <span id="page-31-2"></span>BMT24. Magali Bardet, Rocco Mora, and Jean-Pierre Tillich. Polynomial time keyrecovery attack on high rate random alternant codes. IEEE Trans. Inform. Theory, 70(6):4492–4511, 2024.
+- <span id="page-31-4"></span>BMvT78. Elwyn Berlekamp, Robert McEliece, and Henk van Tilborg. On the inherent intractability of certain coding problems. IEEE Trans. Inform. Theory, 24(3):384–386, May 1978.
+- <span id="page-31-10"></span>CBB<sup>+</sup>17. Alain Couvreur, Magali Bardet, Élise Barelli, Olivier Blazy, Rodolfo Canto Torres, Phillipe Gaborit, Ayoub Otmani, Nicolas Sendrier, and Jean-Pierre Tillich. BIG QUAKE. <https://bigquake.inria.fr>, November 2017. NIST Round 1 submission for Post-Quantum Cryptography.
+- <span id="page-31-6"></span>CC98. Anne Canteaut and Florent Chabaud. A new algorithm for finding minimum-weight words in a linear code: Application to McEliece's cryptosystem and to narrow-sense BCH codes of length 511. IEEE Trans. Inform. Theory, 44(1):367–378, 1998.
+- <span id="page-31-11"></span>CCMZ15. Igniacio Cascudo, Ronald Cramer, Diego Mirandola, and Gilles Zémor. Squares of random linear codes. IEEE Trans. Inform. Theory, 61(3):1159– 1173, 3 2015.
+- <span id="page-31-7"></span>CDMT22. Kevin Carrier, Thomas Debris-Alazard, Charles Meyer-Hilfiger, and Jean-Pierre Tillich. Statistical decoding 2.0: Reducing decoding to LPN. In Advances in Cryptology - ASIACRYPT 2022, LNCS. Springer, 2022.
+- <span id="page-31-8"></span>CDMT24. Kévin Carrier, Thomas Debris-Alazard, Charles Meyer-Hilfiger, and Jean-Pierre Tillich. Reduction from sparse LPN to LPN, dual attack 3.0. In Marc Joye and Gregor Leander, editors, Advances in Cryptology - EU-ROCRYPT 2024 - 43rd Annual International Conference on the Theory and Applications of Cryptographic Techniques, Zurich, Switzerland, May 26-30, 2024, Proceedings, Part VI, volume 14656 of LNCS, pages 286– 315. Springer, 2024. Artifact available at [https://artifacts.iacr.org/](https://artifacts.iacr.org/eurocrypt/2024/a10/) [eurocrypt/2024/a10/](https://artifacts.iacr.org/eurocrypt/2024/a10/).
+- <span id="page-31-0"></span>CFS01. Nicolas Courtois, Matthieu Finiasz, and Nicolas Sendrier. How to achieve a McEliece-based digital signature scheme. In Advances in Cryptology - ASIACRYPT 2001, volume 2248 of LNCS, pages 157–174, Gold Coast, Australia, 2001. Springer.
+- <span id="page-31-12"></span>CGG<sup>+</sup>14. Alain Couvreur, Philippe Gaborit, Valérie Gauthier-Umaña, Ayoub Otmani, and Jean-Pierre Tillich. Distinguisher-based attacks on public-key cryptosystems using Reed-Solomon codes. Des. Codes Cryptogr., 73(2):641– 666, 2014.
+- <span id="page-31-3"></span>CMT23a. Alain Couvreur, Rocco Mora, and Jean-Pierre Tillich. A new approach based on quadratic forms to attack the McEliece cryptosystem. In Jian Guo and Ron Steinfeld, editors, Advances in Cryptology - ASIACRYPT 2023 - 29th International Conference on the Theory and Application of Cryptology and Information Security, Guangzhou, China, December 4-8, 2023, Proceedings, Part IV, volume 14441 of LNCS, pages 3–38. Springer, 2023.
+- <span id="page-31-5"></span>CMT23b. Alain Couvreur, Rocco Mora, and Jean-Pierre Tillich. A new approach based on quadratic forms to attack the McEliece cryptosystem. arXiv preprint arXiv:2306.10294, 2023.
+- <span id="page-31-1"></span>COT14. Alain Couvreur, Ayoub Otmani, and Jean-Pierre Tillich. New identities relating wild Goppa codes. Finite Fields Appl., 29:178–197, 2014.
+- <span id="page-31-9"></span>DEEK24. Léo Ducas, Andre Esser, Simona Etinski, and Elena Kirshanova. Asymptotics and improvements of sieving for codes. In Marc Joye and Gregor
+
+{32}------------------------------------------------
+
+- Leander, editors, Advances in Cryptology EUROCRYPT 2024 43rd Annual International Conference on the Theory and Applications of Cryptographic Techniques, Zurich, Switzerland, May 26-30, 2024, Proceedings, Part VI, volume 14656 of Lecture Notes in Computer Science, pages 151– 180. Springer, 2024.
+- <span id="page-32-8"></span>DMR11. Hang Dinh, Cris Moore, and Alexander Russell. The McEliece cryptosystem resists quantum Fourier sampling attacks. In Advances in Cryptology - CRYPTO 2011, volume 6841 of LNCS, pages 761–779. Springer, 2011.
+- <span id="page-32-5"></span>Dum89. Il'ya Dumer. Two decoding algorithms for linear codes. Probl. Inf. Transm., 25(1):17–23, 1989.
+- <span id="page-32-6"></span>Ess22. Andre Esser. Revisiting nearest-neighbor-based information set decoding. Cryptology ePrint Archive, Paper 2022/1328, 2022. [https://eprint.iacr.](https://eprint.iacr.org/2022/1328) [org/2022/1328](https://eprint.iacr.org/2022/1328).
+- <span id="page-32-7"></span>EZ23. Andre Esser and Floyd Zweydinger. New time-memory trade-offs for subset sum - improving ISD in theory and practice. In Carmit Hazay and Martijn Stam, editors, Advances in Cryptology - EUROCRYPT 2023 - 42nd Annual International Conference on the Theory and Applications of Cryptographic Techniques, Lyon, France, April 23-27, 2023, Proceedings, Part V, volume 14008 of Lecture Notes in Computer Science, pages 360–390. Springer, 2023.
+- <span id="page-32-12"></span>FGLM93. Jean-Charles Faugère, Patrizia M. Gianni, Daniel Lazard, and Teo Mora. Efficient computation of zero-dimensional gröbner bases by change of ordering. J. Symbolic Comput., 16(4):329–344, 1993.
+- <span id="page-32-0"></span>FGO<sup>+</sup>11. Jean-Charles Faugère, Valérie Gauthier, Ayoub Otmani, Ludovic Perret, and Jean-Pierre Tillich. A distinguisher for high rate McEliece cryptosystems. In Proc. IEEE Inf. Theory Workshop- ITW 2011, pages 282–286, Paraty, Brasil, October 2011.
+- <span id="page-32-11"></span>FGO<sup>+</sup>13. Jean-Charles Faugère, Valérie Gauthier, Ayoub Otmani, Ludovic Perret, and Jean-Pierre Tillich. A distinguisher for high rate McEliece cryptosystems. IEEE Trans. Inform. Theory, 59(10):6830–6844, October 2013.
+- <span id="page-32-10"></span>Fin03. Matthieu Finiasz. Words of minimal weight and weight distribution of binary Goppa codes. In Proceedings of the 2003 IEEE International Symposium on Information Theory. IEEE, 2003.
+- <span id="page-32-2"></span>FOPT10. Jean-Charles Faugère, Ayoub Otmani, Ludovic Perret, and Jean-Pierre Tillich. Algebraic cryptanalysis of McEliece variants with compact keys. In Advances in Cryptology - EUROCRYPT 2010, volume 6110 of LNCS, pages 279–298, 2010.
+- <span id="page-32-3"></span>FPdP14. Jean-Charles Faugère, Ludovic Perret, and Frédéric de Portzamparc. Algebraic attack against variants of McEliece with Goppa polynomial of a special form. In Advances in Cryptology - ASIACRYPT 2014, volume 8873 of LNCS, pages 21–41, Kaoshiung, Taiwan, R.O.C., December 2014. Springer.
+- <span id="page-32-1"></span>Gib91. J. K. Gibson. Equivalent Goppa codes and trapdoors to McEliece's public key cryptosystem. In Donald Davies, editor, Advances in Cryptology - EU-ROCRYPT 1991, volume 547 of LNCS, pages 517–521. Springer Berlin / Heidelberg, 1991.
+- <span id="page-32-9"></span>KT17. Ghazal Kachigar and Jean-Pierre Tillich. Quantum information set decoding algorithms. In Post-Quantum Cryptography 2017, volume 10346 of LNCS, pages 69–89, Utrecht, The Netherlands, June 2017. Springer.
+- <span id="page-32-4"></span>LB88. Pil J. Lee and Ernest F. Brickell. An observation on the security of McEliece's public-key cryptosystem. In Advances in Cryptology - EURO-CRYPT'88, volume 330 of LNCS, pages 275–280. Springer, 1988.
+
+{33}------------------------------------------------
+
+- <span id="page-33-6"></span>Lem25. Axel Lemoine. The tangent space attack. Cryptology ePrint Archive, Paper 2025/763, 2025.
+- <span id="page-33-9"></span>LL97. Françoise Levy-dit-Vehel and Simon Litsyn. Parameters of Goppa codes revisited. IEEE Trans. Inform. Theory, 43(6):1811–1819, November 1997.
+- <span id="page-33-15"></span>LMT25. Axel Lemoine, Rocco Mora, and Jean-Pierre Tillich. Understanding the new distinguisher of alternant codes at degree 2. IACR Cryptol. ePrint Arch., page 531, 2025.
+- <span id="page-33-10"></span>MB09. Rafael Misoczki and Paulo Barreto. Compact McEliece keys from Goppa codes. In Selected Areas in Cryptography, Calgary, Canada, August 13-14 2009.
+- <span id="page-33-2"></span>McE78. Robert J. McEliece. A Public-Key System Based on Algebraic Coding Theory, pages 114–116. Jet Propulsion Lab, 1978. DSN Progress Report 42-44.
+- <span id="page-33-7"></span>MMT11. Alexander May, Alexander Meurer, and Enrico Thomae. Decoding random linear codes in O(2<sup>0</sup>.054<sup>n</sup> ). In Dong Hoon Lee and Xiaoyun Wang, editors, Advances in Cryptology - ASIACRYPT 2011, volume 7073 of LNCS, pages 107–124. Springer, 2011.
+- <span id="page-33-8"></span>MO15. Alexander May and Ilya Ozerov. On computing nearest neighbors with applications to decoding of binary linear codes. In E. Oswald and M. Fischlin, editors, Advances in Cryptology - EUROCRYPT 2015, volume 9056 of LNCS, pages 203–228. Springer, 2015.
+- <span id="page-33-0"></span>Mor25. Rocco Mora. On the matrix code of quadratic relationships for a goppa code. Adv. Math. Commun., 19(3):829–852, 2025.
+- <span id="page-33-13"></span>MP12. Irene Márquez-Corbella and Ruud Pellikaan. Error-correcting pairs for a public-key cryptosystem, 2012.
+- <span id="page-33-17"></span>MS77. F. Jessie MacWilliams and N. J. A. Sloane. The Theory of Error-Correcting Codes. North-Holland, Amsterdam, 1977.
+- <span id="page-33-16"></span>MS86. Florence J. MacWilliams and Neil J. A. Sloane. The Theory of Error-Correcting Codes. North–Holland, Amsterdam, fifth edition, 1986.
+- <span id="page-33-14"></span>MT22. Rocco Mora and Jean-Pierre Tillich. On the dimension and structure of the square of the dual of a Goppa code. In WCC 2022 - Workshop on Coding Theory and Cryptography, 2022.
+- <span id="page-33-11"></span>Nie86. Harald Niederreiter. Knapsack-type cryptosystems and algebraic coding theory. Problems of Control and Information Theory, 15(2):159–166, 1986.
+- <span id="page-33-5"></span>Pan25. Lorenz Panny. On breaking McEliece keys using brute force. Cryptology ePrint Archive, Paper 2025/632, 2025.
+- <span id="page-33-1"></span>Ran25. Hugues Randriambololona. The syzygy distinguisher. In Serge Fehr and Pierre-Alain Fouque, editors, Advances in Cryptology - EUROCRYPT 2025 - 44th Annual International Conference on the Theory and Applications of Cryptographic Techniques, Madrid, Spain, May 4-8, 2025, Proceedings, Part VI, volume 15606 of Lecture Notes in Computer Science, pages 324–354. Springer, 2025.
+- <span id="page-33-3"></span>RSA78. Ronald L. Rivest, Adi Shamir, and Leonard M. Adleman. A method for obtaining digital signatures and public-key cryptosystems. Commun. ACM, 21(2):120–126, 1978.
+- <span id="page-33-4"></span>Sen00. Nicolas Sendrier. Finding the permutation between equivalent linear codes: The support splitting algorithm. IEEE Trans. Inform. Theory, 46(4):1193– 1203, 2000.
+- <span id="page-33-12"></span>SS92. Vladimir Michilovich Sidelnikov and S.O. Shestakov. On the insecurity of cryptosystems based on generalized Reed-Solomon codes. Discrete Math. Appl., 1(4):439–444, 1992.
+
+{34}------------------------------------------------
+
+- <span id="page-34-0"></span>Ste88. Jacques Stern. A method for finding codewords of small weight. In G. D. Cohen and J. Wolfmann, editors, Coding Theory and Applications, volume 388 of LNCS, pages 106–113. Springer, 1988.
+- <span id="page-34-1"></span>Tra24. Bénédikt Minh Dang Tran. Post-Quantum Code-Based Cryptography. PhD thesis, EPFL, Lausanne, 2024.
+- <span id="page-34-3"></span>Wie10. Christian Wieschebrink. Cryptanalysis of the Niederreiter public key scheme based on GRS subcodes. In Post-Quantum Cryptography 2010, volume 6061 of LNCS, pages 61–72. Springer, 2010.
+- <span id="page-34-2"></span>Wie25. Andreas Wiemers. A note on the Goppa code distinguishing problem. Cryptology ePrint Archive, Paper 2025/1661, 2025.
+
+{35}------------------------------------------------
+
+#### <span id="page-35-0"></span>A Proofs of the Lemmas needed in §3
+
+<span id="page-35-1"></span>We are going to prove here lemmas used to prove Theorem 3.7. We first need a result which is also proved in [Ran25], namely that (see the proof of Proposition 4 in [Ran25])
+
+**Lemma A.1.** Let  $p_j = (\underbrace{0, \cdots, 0}_{k-j \text{ terms}}, 1)^{\mathsf{T}} \in \mathbb{F}_{q^m}^{k-j+1}$ . We consider the evaluation
+
+map  $e_j : \mathcal{R}_{j-1} \mapsto \mathbb{F}_{q^m}$  at  $p_j$  which maps f to its evaluation  $f(p_j)$ . It extends naturally coordinatewise as  $e_j : \mathcal{R}_{j-1}^2 \to \mathbb{F}_{q^m}^2$ . We have for any  $j \in [1, s]$ 
+
+$$\dim\left(\boldsymbol{e}_{j}(V_{j-1})\right) \leq 1.$$
+
+We give a proof for the sake of self-containedness, although a proof of this statement is given in the proof of [Ran25, Prop. 4].
+
+*Proof.* By an immediate proof by induction we have for any  $j \in [1, s]$  that  $V_j = V_{j-1} \cap \mathcal{R}_{j-1}^2$  and
+
+<span id="page-35-2"></span>
+$$V_j = \ker(\boldsymbol{e}_j : V_{j-1} \to \mathbb{F}_{a^m}^2). \tag{35}$$
+
+Since the  $2 \times 2$  minors of  $\Phi_{j-1}$  are in  $I_2(\mathscr{C}_{j-1})$ , they all vanish when evaluated on  $c_1, \dots, c_{k-j+1}$ . In particular the last coordinate of the corresponding vector is equal to 0. This coordinate corresponds to the last column of  $G_{j-1}$ , which is nothing but  $p_j$ . This shows that such minors vanish when evaluated on  $p_j$ . This immediately implies that dim  $(e_j(V_{j-1})) \leq 1$ .
+
+From this it immediately follows the lemma we gave in §3
+
+Lemma 3.2. We have
+
+$$\dim V_i \ge \dim V_{i-1} - 1, \ \forall j \in \llbracket 1, s \rrbracket \tag{25}$$
+
+$$\dim V_j \ge \dim V_{\Phi} - j \tag{26}$$
+
+where  $V_0 \stackrel{\text{def}}{=} V_{\Phi}$ . If we let  $f_j$  be the dimension of  $V_j$  for any  $j \in [1, s]$  then we have that  $f_j \geq f_{\mathscr{A}} - j$ , where  $f_{\mathscr{A}} \stackrel{\text{def}}{=} (e_{\mathscr{A}} + 1)r - \frac{q^{e_{\mathscr{A}} + 1} - 1}{q - 1}$  with  $e_{\mathscr{A}} \stackrel{\text{def}}{=} \lfloor \log_q(r - 1) \rfloor$ .
+
+*Proof.* For any j in [1, s], we have
+
+$$\dim \boldsymbol{e}_j(V_{j-1}) + \dim \ker(\boldsymbol{e}_j: V_{j-1} \to \mathbb{F}_{q^m}^2) = \dim V_{j-1}.$$
+
+Since on one hand, dim  $(e_j(V_{j-1})) \le 1$  by Lemma A.1 and dim  $\ker(e_j : V_{j-1} \to \mathbb{F}_{q^m}^2) = \dim V_j$  by (35), we deduce that for any j in [1, s]
+
+$$\dim V_i \ge \dim V_{i-1} - 1.$$
+
+The remaining statements follow directly from this and from the fact that  $V_0 = \dim V_{\Phi} = f_{\mathscr{A}}$ . The last equality is a direct consequence that all the entries of the first row of  $\Phi$  involve different variables. This shows that the dimension of  $V_{\Phi}$  is nothing but the number of columns of  $\Phi$  which is readily seen to be equal to  $f_{\mathscr{A}}$ .
+
+{36}------------------------------------------------
+
+Let us prove now the crucial Lemma 3.3 that we recall here
+
+**Lemma 3.3.** Let  $\tilde{e}_{\mathscr{A}} \stackrel{\text{def}}{=} \lfloor \log_q \frac{r}{2} \rfloor$  and  $s_{\mathscr{A}} \stackrel{\text{def}}{=} (\tilde{e}_{\mathscr{A}} + 1)r - 2\frac{q^{\tilde{e}_{\mathscr{A}} + 1} - 1}{q - 1}$ . We have for any  $j \in [0, s_{\mathscr{A}}]$ ,
+
+ $\dim \left(V_i^1 \cap V_i^2\right) \ge s_{\mathscr{A}} - j.$ 
+
+To prove this lemma we first prove that it is is true for j = 0.
+
+#### Lemma A.2.
+
+$$\dim(V_0^1 \cap V_0^2) = s_{\mathscr{A}}.$$
+
+*Proof.* The dimensions of the subspaces we are interested in do not depend on the chosen generator matrix. It is convenient here to consider the canonical basis (15). In this basis the matrix  $\Phi$  is given by
+
+$$\bm{B}_u \stackrel{\text{def}}{=} \begin{pmatrix} X_0^{(0)} & X_1^{(0)} & \cdots & X_{r-1-q^u}^{(0)} \ X_{q^u}^{(0)} & X_{q^u+1}^{(0)} & \cdots & X_{r-1}^{(0)} \end{pmatrix} \ \bm{\Phi} \stackrel{\text{def}}{=} \big( \bm{B}_0^{(e)} \big| \bm{B}_1^{(e-1)} \big| \cdots \big| \bm{B}_e^{(0)} \big) \end{pmatrix}$$
+
+where  $e = e_{\mathscr{A}}$  (as defined in (10)).
+
+From this form it is readily seen that  $\dim(V_0^1 \cap V_0^2)$  is given by the number N of variables that appear both in the first row and the second row of  $\Phi$ . We clearly have
+
+$$\dim(V_0^1 \cap V_0^2) = N = \sum_{u=0}^e \max(r - 2q^u, 0)$$
+
+$$= \sum_{u=0}^{\tilde{e}_{\mathscr{A}}} (r - 2q^u)$$
+
+$$= (\tilde{e}_{\mathscr{A}} + 1)r - 2\frac{q^{\tilde{e}_{\mathscr{A}} + 1} - 1}{q - 1}.$$
+(36)
+
+Lemma 3.3 is clearly a direct consequence of this lemma and the induction inequality given below.
+
+**Lemma A.3.** For all  $j \in [1, s_{\mathscr{A}}]$  we have
+
+<span id="page-36-0"></span>
+$$\dim (V_j^1 \cap V_j^2) \ge \dim (V_{j-1}^1 \cap V_{j-1}^2) - 1. \tag{37}$$
+
+*Proof.* To verify this lemma, let us use Lemma A.1 which says that dim  $(e_j(V_{j-1})) \le 1$ . This implies that one the following points holds
+
+(i) there exists an element 
+$$\lambda \in \mathbb{F}_{q^m}^*$$
+ such that  $e_j(V_{j-1}) = \left\{ \begin{pmatrix} x \\ \lambda x \end{pmatrix}, x \in \mathbb{F}_{q^m} \right\}$  or
+
+(ii) 
+$$\mathbf{e}_{j}(V_{j-1}) = \left\{ \begin{pmatrix} x \\ 0 \end{pmatrix}, x \in \mathbb{F}_{q^{m}} \right\}$$
+ or
+
+{37}------------------------------------------------
+
+(iii) 
+$$\mathbf{e}_{j}(V_{j-1}) = \left\{ \begin{pmatrix} 0 \\ x \end{pmatrix}, x \in \mathbb{F}_{q^{m}} \right\}$$
+ or (iv)  $\mathbf{e}_{i}(V_{j-1}) = \{0\}.$ 
+
+Case (i): Let us assume that (i) holds. Consider now the restriction of  $e_j$  to  $V_{j-1}^1 \cap V_{j-1}^2$ . Let
+
+$$W \stackrel{\text{def}}{=} \ker(\boldsymbol{e}_j : V_{j-1}^1 \cap V_{j-1}^2 \to \mathbb{F}_{q^m}).$$
+
+Let  $w \in W$ . By definition of W, all three following properties hold
+
+- (a)  $e_i(w) = 0$ .
+- (b) there exists v such that  $\begin{pmatrix} w \\ v \end{pmatrix}$  is in  $V_{j-1}$  (c) there exists x such that  $\begin{pmatrix} x \\ w \end{pmatrix}$  is in  $V_{j-1}$
+
+From (i) and (a)  $e_j(w) = 0$ , we know that we have at the same time  $e_j(v) =$  $e_j(x) = 0$ . This implies that  $\begin{pmatrix} w \\ v \end{pmatrix}$  and  $\begin{pmatrix} x \\ w \end{pmatrix}$  are both in  $V_j$ , which in turn implies that w is in  $V_j^1$  and  $V_j^2$ . In other words, we have proved that  $W \subseteq V_j^1 \cap V_j^2$  and since dim  $W \ge \dim \left(V_{j-1}^1 \cap V_{j-1}^2\right) - 1$ , this shows that (37) holds.
+
+Case (ii): Consider that (ii) holds. It will be helpful to consider for an element  $v_2$  in  $\pi_2(V_{j-1})$  the affine set
+
+$$\mathcal{A}(v_2) = \pi_1 \left( \pi_2^{-1}(v_2) \right) = \left\{ x \in \mathcal{R}_{j-1} : \begin{pmatrix} x \\ v_2 \end{pmatrix} \in V_{j-1} \right\}.$$
+
+If we let  $W = \mathcal{A}(0) = \left\{ x \in \mathcal{R}_{j-1} : \begin{pmatrix} x \\ 0 \end{pmatrix} \in V_{j-1} \right\}$ , then  $\mathcal{A}(v_2)$  is a coset of W. There are two cases to consider.
+
+**Subcase**  $e_j(W) = \mathbb{F}_{q^m}$ . In this case, we claim that  $V_j^1 \cap V_j^2 = V_{j-1}^1 \cap V_{j-1}^2$ . Indeed let w be in  $V_{j-1}^1 \cap V_{j-1}^2$ . There exist in this case v and x such that both  $\begin{pmatrix} w \\ v \end{pmatrix}$  and  $\begin{pmatrix} x \\ w \end{pmatrix}$  belong to  $V_{j-1}$ . From the form of  $\mathbf{e}_j(V_{j-1})$  and the fact that  $\begin{pmatrix} x \\ w \end{pmatrix}$  belongs to  $V_{j-1}$  this implies that  $\mathbf{e}_j(w) = 0$ . Since  $\mathbf{e}_j(v) = 0$  because v is  $V_j^2$ , this implies that  $\begin{pmatrix} w \\ v \end{pmatrix}$  is in  $V_j$  and therefore w is in  $V_j^1$ . From the fact that
+
+ $e_j(W) = \mathbb{F}_{q^m}$ , there exists y in W such that  $e_j(y) = e_j(x)$ . Since  $\begin{pmatrix} x - y \\ w \end{pmatrix}$  also belongs to  $V_{j-1}$  by definition of W and since  $e_j(x-y)=0$  we also have that w belongs to  $V_j^2$ . This implies  $w \in V_j^1 \cap V_j^2$  and shows that  $V_j^1 \cap V_j^2 = V_{j-1}^1 \cap V_{j-1}^2$ . Subcase  $e_j(W) = \{0\}$ . Consider the linear map
+
+$$\phi: \pi_2(V_{j-1}) \to \mathcal{R}_{j-1}/W$$
+
+which maps an element  $u \in \pi_2(V_{j-1})$  to the coset u' + W which is such that  $(u'+W)\times\{u\}\subseteq V_{j-1}$ . Note that  $e_j$  is well defined on  $\mathcal{R}_{j-1}/W$  because  $e_j(W)=$ 
+
+{38}------------------------------------------------
+
+ $\{0\}$ . Let  $L: \pi_2(V_{j-1}) \to \mathbb{F}_{q^m}$  be the linear map  $L = e_j \circ \phi$ . Consider the kernel of its restriction to  $V_{j-1}^1 \cap V_{j-1}^2$ ,  $U \stackrel{\text{def}}{=} \ker(L: V_{j-1}^1 \cap V_{j-1}^2 \to \mathbb{F}_{q^m})$ . We have
+
+<span id="page-38-0"></span>
+$$\dim U \ge \dim \left( V_{i-1}^1 \cap V_{i-1}^2 \right) - 1. \tag{38}$$
+
+Let u be in U. Since  $U \subseteq V_{j-1}^1 \cap V_{j-1}^2$  there exist v and x such that both  $\begin{pmatrix} u \\ v \end{pmatrix}$  and  $\begin{pmatrix} x \\ u \end{pmatrix}$  belong to  $V_{j-1}$ . From the form of  $e_j(V_{j-1})$  and the fact that  $\begin{pmatrix} x \\ u \end{pmatrix}$  belongs to  $V_{j-1}$  this implies that  $e_j(u) = 0$ . From this, we deduce that  $\begin{pmatrix} u \\ v \end{pmatrix}$  is in  $V_j$  and that  $u \in V_j^1$ . Moreover by definition of U, we also have  $e_j(x) = 0$ . From this we deduce that  $\begin{pmatrix} x \\ u \end{pmatrix}$  is in  $V_j$  and therefore u is also in  $V_j^2$ . Putting both facts together, we get that  $u \in V_j^1 \cap V_j^2$ . In other words,  $U \subseteq V_j^1 \cap V_j^2$ . This together with (38) shows (37).
+
+Case (iii): (37) is proved similarly to Case (ii).
+
+Case (iv): In this case  $V_j = V_{j-1}$  and we immediately deduce that
+
+$$\dim (V_j^1 \cap V_j^2) = \dim (V_{j-1}^1 \cap V_{j-1}^2).$$
+
+Let us recall Lemma 3.4 that we also prove here
+
+**Lemma 3.4.** We have for any  $s \in [0, s_{\mathscr{A}}]$  that
+
+$$\left\{ x \in \mathcal{R}_s : \begin{pmatrix} x \\ x \end{pmatrix} \in V_s \right\} = \{0\}.$$
+
+*Proof.* We just have to prove this result for  $V_0 = V_{\Phi}$ . This result does not depend on the basis chosen for  $\mathscr{C}$ . We choose in this case the canonical basis where the matrix  $\Phi$  takes the following form
+
+$$\boldsymbol{B}_{u} \stackrel{\text{def}}{=} \begin{pmatrix} X_{0}^{(0)} & X_{1}^{(0)} & \cdots & X_{r-1-q^{u}}^{(0)} \\ X_{q^{u}}^{(0)} & X_{q^{u}+1}^{(0)} & \cdots & X_{r-1}^{(0)} \end{pmatrix}$$
+$$\boldsymbol{\Phi} \stackrel{\text{def}}{=} \begin{pmatrix} \boldsymbol{B}_{0}^{(e)} \middle| \boldsymbol{B}_{1}^{(e-1)} \middle| \cdots \middle| \boldsymbol{B}_{e}^{(0)} \end{pmatrix}$$
+where  $e \stackrel{\text{def}}{=} e_{\mathscr{A}}$  (see (10))
+
+Obviously since the variables involved in each block  $\boldsymbol{B}_{u}^{(e-u)}$  are distinct it is sufficient to prove that for all u in [0, e] we have
+
+$$\left\{ x \in \mathcal{R}_s : \begin{pmatrix} x \\ x \end{pmatrix} \in V_{\mathbf{\Phi}}(u) \right\} = \{0\},$$
+
+{39}------------------------------------------------
+
+where  $V_{\Phi}(u)$  is the column space of  $\mathbf{B}_u$ . To simplify notation let us drop the superscript (0) in  $X_a^{(0)}$ . Assume that there exists x in  $\mathcal{R}$  and  $\lambda_0, \dots, \lambda_{r-1-q^u}$  in  $\mathbb{F}_{q^m}$  such that
+
+$$\sum_{i=0}^{r-1-q^u} \lambda_i \begin{pmatrix} X_i \\ X_{i+q^u} \end{pmatrix} = \begin{pmatrix} x \\ x \end{pmatrix}$$
+ (39)
+
+This implies
+
+$$\sum_{i=0}^{r-1-q^u} \lambda_i X_i = \sum_{i=0}^{r-1-q^u} \lambda_i X_{i+q^u},$$
+
+which in turn implies that
+
+<span id="page-39-2"></span>
+$$\lambda_i = 0 \text{ where } i \in [0, q^u - 1] \cup [r - q^u, r - 1]$$
+ (40)
+
+$$\lambda_i = \lambda_{i+q^u} \text{ where } i \in [0, r-1-2q^u]. \tag{41}$$
+
+(40) and the shift invariance property (41) clearly imply that  $\lambda_i = 0$  when  $u \in [q^u, 2q^u - 1]$ . By induction we obtain that we should have  $\lambda_i = 0$  for any  $i \in [0, r - 1]$ .
+
+#### <span id="page-39-1"></span>B A Heuristic for Computing less Pfaffians
+
+We give here a heuristic for reducing the number of Pfaffians that are needed. When we compute a basis of the matrix code  $\mathscr{C}_{\text{mat}}$ , we obtain matrices of the following shape
+
+<span id="page-39-3"></span>
+$$\begin{pmatrix} 1 \\ 1 \\ C \end{pmatrix}, \tag{42}$$
+
+where C is a dense  $i_0 \times i_0$  block whose size  $i_0$  is the same for all basis elements and which is always located in the last  $i_0$  row and column positions. There are only two 1's outside the block C of size  $i_0 \times i_0$  and the rest of the values are equal to 0. This shape naturally comes from the fact that we see the space  $(c_{ij})_{i \leq j} \in \mathbb{F}_q^{k(k+1)/2}$  such that  $\sum_{i \leq j} c_{ij} X_i X_j \in I_2(\mathscr{C}_s)$  as a linear code of length k(k+1)/2. The shape (42) then comes from the fact that we compute a basis of this code in systematic form, and then compute the matrices of the polar forms associated to the elements of this basis. This shape is also visible in the generic matrix M of the Pfaffian modeling: the coefficients of M that are outside this block area consist of single variables, while the coefficients in the dense area are dense linear forms.
+
+<span id="page-39-0"></span>**Heuristic 2.** The Pfaffians obtained by taking a subset  $\{i, j, k, l\}$  of rows and columns inside the dense area are linear combinations of the Pfaffians obtained by taking i outside the dense area.
+
+{40}------------------------------------------------
+
+If the dense area is of size i0, then Heuristic [2](#page-39-0) implies that we only need to compute
+
+$$\sum_{i=1}^{i_0-1} \binom{rm-s-i}{3}$$
+
+Pfaffians, instead of rm−s 4 . This is what we did to solve TII challenges 83, 89, 125, 166 and 210.
+
+# <span id="page-40-0"></span>C The Shape of Rank 2 Matrices
+
+We are going to prove Proposition [5.3](#page-27-0) here and also give some additional explanation about the shape of rank 2 matrices in the matrix code of relationships. We will need again to introduce the canonical basis A of C ,
+
+$$\mathcal{A} = (\bm{y}, \bm{x}\bm{y}, \dots, \bm{x}^{r-1}\bm{y}, \dots, \bm{y}^{2^{m-1}}, (\bm{x}\bm{y})^{2^{m-1}}, \dots, (\bm{x}^{r-1}\bm{y})^{2^{m-1}}),$$
+
+where y = Γ(x) −1 . We define the matrix H<sup>A</sup> whose rows are the elements of A in that order. Let B = (b1, . . . , brm) be the public basis of C . As both H<sup>A</sup> and H<sup>B</sup> generate the same code C , there exists a transition matrix P ∈ GLrm(F2<sup>m</sup>) such that H<sup>B</sup> = PHA. Finally, we define
+
+$$\boldsymbol{S} \stackrel{\text{def}}{=} \begin{pmatrix} \boldsymbol{I}_r & & & \ & \ddots & & \ & & \boldsymbol{I}_r \ \boldsymbol{I}_r & & \end{pmatrix}$$
+
+the matrix of the r-th cyclic shift. We recall the following result.
+
+Proposition C.1 ([\[CMT23b\]](#page-31-5), Proposition 22). The matrix codes Cmat(A) and Cmat(B) are invariant under the linear operation
+
+$$\sigma: \boldsymbol{M} \longmapsto \boldsymbol{S}^{\top} \boldsymbol{M}^{(2)} \boldsymbol{S}.$$
+
+Note that σ is rank-preserving. Therefore, the varieties given by matrices of rank at most 2 in Cmat(A) and Cmat(B) are also globally invariant under σ. This explains why Algorithm [2](#page-24-0) returns m matrices of rank 2 instead of only one: it returns a whole σ-orbit (B, σ(B), . . . , σm−<sup>1</sup> (B)). Note that σ <sup>m</sup> is the identity map.
+
+The canonical basis is very useful, for rank 2 matrices with respect to this basis have a very special shape. We give the following as an assumption that has been verified through extensive computations.
+
+Assumption 3. Let A ∈ Cmat(A) be a matrix of rank 2. Up to changing A with σ j (A) for some j, we have that A is of the form
+
+<span id="page-40-1"></span>
+$$\mathbf{A} = \begin{pmatrix} \mathbf{A}_0 & \mathbf{0} \\ \mathbf{0} & \mathbf{0} \end{pmatrix}, \tag{43}$$
+
+with A<sup>0</sup> a skew-symmetric matrix of size e<sup>G</sup> r × e<sup>G</sup> r.
+
+{41}------------------------------------------------
+
+Remark C.2. When  $\mathscr{C}$  is a dual alternant code whose support and multiplier are chosen independently at random, we experimentally observe that something similar can be said, with the matrix  $A_0$  having size  $e_{\mathscr{A}}r \times e_{\mathscr{A}}r$  instead of  $e_{\mathscr{C}}r \times e_{\mathscr{C}}r$ .
+
+This enables us to prove Proposition 5.3. Let us first recall it here.
+
+**Proposition 5.3.** Under Assumption 3, we have for some  $a \in [0, m-1]$ :
+
+$$\boldsymbol{u},\boldsymbol{v}\in\bigoplus_{j=a}^{a+e_{\mathscr{G}}-1}\mathbf{GRS}_{r}\left(\boldsymbol{x}^{2^{j}},\boldsymbol{y}^{2^{j}}\right).$$
+
+*Proof.* We have  $\boldsymbol{u} = \boldsymbol{\mu}\boldsymbol{H}_{\mathcal{B}} = \boldsymbol{\mu}\boldsymbol{P}\boldsymbol{H}_{\mathcal{A}}$  and  $\boldsymbol{v} = \boldsymbol{\nu}\boldsymbol{H}_{\mathcal{B}} = \boldsymbol{\nu}\boldsymbol{P}\boldsymbol{H}_{\mathcal{A}}$ . Define  $\boldsymbol{A} = \boldsymbol{P}^{\top}\boldsymbol{B}\boldsymbol{P} \in \mathscr{C}_{\mathrm{mat}}(\mathcal{A})$ . Since  $\boldsymbol{\mu}$  and  $\boldsymbol{\nu}$  are chosen in the row span of  $\boldsymbol{B}$ , necessarily  $\boldsymbol{\mu}\boldsymbol{P}$  and  $\boldsymbol{\nu}\boldsymbol{P}$  are in the row span of  $\boldsymbol{A}$ . Indeed, if  $\boldsymbol{\alpha} \in \mathbb{F}_{2^m}^{rm}$  is a vector such that  $\boldsymbol{\alpha}\boldsymbol{B} = \boldsymbol{\mu}$ , then
+
+$$\alpha(P^{\intercal})^{-1}A = \alpha BP = \mu P$$
+
+which proves that  $\mu P$  is in the row span of A. The same reasoning holds for  $\nu P$ . Now, under Assumption 3, this implies that  $\mu P$  and  $\nu P$  belong to the image of the diagonal block  $A_0$ , which we assume to be the upper-left block without loss of generality. As a result, one has  $\mu P$ ,  $\mu P \in \mathbb{F}_{2^m}^{e g r} \times \{0\}^{(m-e g)r}$ , from which we immediately deduce that u and v belong to the desired code.
+
+# D Justification for the Algorithm Finding the Alignment between Triples
+
+Heuristic 1 has enabled us to successfully reconstruct the desired code  $\bigoplus_{j=a}^{a+e_{\mathscr{G}}-1} \mathbf{GRS}_r\left(\boldsymbol{x}^{2^j},\boldsymbol{y}^{2^j}\right)$  for all our implementations. To better understand its behaviour, we report on Table 6 the values that we observed for f when r=5 and m=8. The exact same values were observed for  $3 \le r \le 7$ .
+
+| i       | 0  | 1  | 2  | 3  | 4   | 5  | 6  | 7  |
+|---------|----|----|----|----|-----|----|----|----|
+| f(i)    | 19 | 19 | 19 | 17 | 15  | 17 | 19 | 19 |
+| Aligned | No | No | No | No | Yes | No | No | No |
+
+<span id="page-41-0"></span>Table 6: An example of the function f when r = 5 and m = 8.
+
+The maximum of f is 19, which is  $\binom{6+1}{2} - 2$ . This means that the quadratic hull of  $\mathscr{V}_i = \left\langle \boldsymbol{u}, \boldsymbol{v}, \boldsymbol{w}, \boldsymbol{u'}^{2^i}, \boldsymbol{v'}^{2^i}, \boldsymbol{w'}^{2^i} \right\rangle_{\mathbb{F}_q}$  contains only two relations, namely
+
+$$u \star v = w^2$$
+
+{42}------------------------------------------------
+
+and
+
+$$u'^{2^i} \star v'^{2^i} = w'^{2^i}.$$
+
+This is what we expect when i is equal to  $b_0 + \lfloor m/2 \rfloor$ , where  $b_0$  is defined as the unique value (mod m) such that the triples are aligned. On the contrary, when  $i = b_0$ , all six vectors belong to  $\bigoplus_{j=a}^{a+e_{\mathcal{G}}-1} \mathbf{GRS}_r\left(\mathbf{x}^{2^j}, \mathbf{y}^{2^j}\right)$ , whose quadratic hull is much larger (this is due to the shape of quadratic relations in  $\mathscr{C}_{\mathrm{rel}}(\mathcal{A})$  described in [FGO+11]). This implies that the six vectors are much likelier to satisfy additional quadratic relations, thus decreasing the value of f. This is how we find the value  $b_0$  such that the two triples  $(\mathbf{u}, \mathbf{v}, \mathbf{w})$  and  $(\mathbf{u}'^{2^{b_0}}, \mathbf{v}'^{2^{b_0}}, \mathbf{w}'^{2^{b_0}})$  are aligned. Note that this reasoning also holds when r = 2, where it is worthwhile noticing that the minimum of f becomes 7. This new value for the minimum of f has a simple explanation: the corresponding code  $\mathscr{V}_{b_0}$ , provably, turns out to be a GRS code of dimension 4.
+
+#### <span id="page-42-0"></span>E The issue when r=5
+
+Our algorithm for r = 5 always found rank-2 matrices satisfying Assumption 3, with an additional annoying property: some rows and columns were always equal to 0. More precisely, we found that the diagonal block  $A_0$  of a rank-2 matrix A in the canonical basis had the following shape
+
+$$A_0 = \begin{pmatrix} 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0 & 0$$
+
+where the character \* denotes any element of  $\mathbb{F}_{2^m}$ . This block  $A_0$  not being entirely dense implied the vectors  $u_i, v_i, w_i$  belonging to a proper subcode of  $\mathscr{D}$ . We could still define the  $\mathscr{D}'_i$ s, but this led to  $\mathscr{D}_{e_{\mathscr{G}}-1}$  being a 2-codimensional
+
+{43}------------------------------------------------
+
+subcode of  $\mathbf{GRS}_r\left(\boldsymbol{x}^{2^{e_g-1}},\boldsymbol{y}^{2^{e_g-1}}\right)$ . We have no explanation for the origin of this issue yet. However, we did find a way to recover a GRS code with support  $\boldsymbol{x}$ . The idea is to consider  $\mathcal{D}_{e_g-2}$ , which is a subcode of
+
+$$\mathbf{GRS}_r\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-2}},\boldsymbol{y}^{2^{e_{\mathscr{G}}-2}}\right)\oplus\mathbf{GRS}_r\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-1}},\boldsymbol{y}^{2^{e_{\mathscr{G}}-1}}\right)=\mathbf{GRS}_{2r}\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-2}},\boldsymbol{y}^{2^{e_{\mathscr{G}}-1}}\right),$$
+
+the equality coming from [Ran25, Lemma 12]. We always found that the codimension of  $\mathcal{D}_{e_{\mathscr{G}}-2}$  in this GRS code was equal to 2. Our hope was that this codimension was small enough compared to 2r for  $\mathcal{D}_{e_{\mathscr{G}}-2}^{\star 2}$  to generate all of
+
+$$\mathbf{GRS}_{2r}\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-1}},\boldsymbol{y}^{2^{e_{\mathscr{G}}-1}}\right)^{\star 2}=\mathbf{GRS}_{4r-1}\left(\boldsymbol{x}^{2^{e_{\mathscr{G}}-1}},\boldsymbol{y}^{2^{e_{\mathscr{G}}}}\right).$$
+
+This was indeed the case in all our experiments. In particular, it enabled us to recover a valid pair of support and Goppa polynomial for the key recovery TII challenges 83 (which had already been solved by [Pan25]) and 89. Instances 125, 166 and 210 had parameters r = 7, m = 9 and did not require any trick: the algorithm described in the previous section worked well.

--- a/data/markdown/eprint/2026_430/2026_430_meta.json
+++ b/data/markdown/eprint/2026_430/2026_430_meta.json
@@ -1,0 +1,13 @@
+{
+  "eprint": {
+    "title": "",
+    "authors": [],
+    "abstract": "",
+    "keywords": [],
+    "category": "",
+    "publication_info": "",
+    "last_updated": "",
+    "license": "",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2026_430/conversion_info.json
+++ b/data/markdown/eprint/2026_430/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "modal-marker",
+  "converted_at": "2026-04-25T20:02:03.830999+00:00",
+  "elapsed_seconds": 293.83,
+  "pdf_sha256": "d785c07bd7baadae6617cf4b3affca880b960aabe16347a126c56d1c6d90c3c1",
+  "source_pdf": "2026_430.pdf",
+  "output_path": "2026_430/2026_430.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "modal",
+    "os": "Linux",
+    "os_version": "4.4.0",
+    "arch": "x86_64",
+    "python_version": "3.12.10",
+    "cpu_count": 17,
+    "provider": "modal",
+    "gpu_count": 1,
+    "gpu_name": "NVIDIA A100-SXM4-40GB",
+    "gpu_vram_mb": 40441,
+    "cuda_version": "12.8"
+  },
+  "estimated_cost_usd": 0.089913
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2026/430

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit a16329b)
Website: https://papyrus.badaas.eu