### PR TITLE
Add markdown for 2026/270

### DIFF
--- a/data/markdown/eprint/2026_270/2026_270.md
+++ b/data/markdown/eprint/2026_270/2026_270.md
@@ -1,0 +1,658 @@
+
+
+{0}------------------------------------------------
+
+# Pseudorandomness of Knapsacks over a Number Ring
+
+Biswajit Mandal<sup>1</sup> and Shashank Singh<sup>1</sup>
+
+1 Indian Institute of Science Education and Research, Bhopal biswajit22@iiserb.ac.in, shashank@iiserb.ac.in
+
+#### Abstract
+
+In this work, we study the pseudorandomness of the bounded Knapsack function family defined over a number ring R. We establish that if the Knapsack function family is one-way and certain related folded Knapsack function families are pseudorandom, then the original Knapsack is pseudorandom. This can be seen as a generalisation of the work of Micciancio and Mol presented at the CRYPTO-2011, for the case of Knapsack function families defined over arbitrary number ring.
+
+Keywords: Pseudorandom, Oneway, Knapsack, Unpredictability
+
+## 1 Introduction
+
+The relationship between onewayness and pseudorandomness of the Knapsack function is studied only in restricted settings, namely, over Z<sup>N</sup> [\[IN96\]](#page-18-0) and for arbitrary Abelian groups [\[MM11\]](#page-19-0). In all these studies, the support of the input distributions is a subset of Z. To the best of our knowledge, no such characterisation for the Knapsack function defined over a general number ring exists. Such a study may facilitate a sample preserving search-to-decision reduction for Module Learning With Errors (MLWE) problem. We propose a resolution of this problem by constructing a two-level implication. We first show that onewayness implies unpredictability for a Knapsack function family K whose inputs are drawn from R. This formalises the intuition that if a function is hard to invert, then predicting even a single bit or a linear combination of its inputs is also hard. Second, we prove that unpredictability implies pseudorandomness for knapsack families over Rq, under the condition that all folded Knapsack variants K<sup>a</sup> associated to polynomial-norm ideals a | qR are pseudorandom. Our proof generalises the Fourier-analysis technique of Micciancio and Mol [\[MM11\]](#page-19-0) to the number rings and modules, introducing several new analytic tools to handle trace forms and generalised character sums over quotient group R/a for ideal a ⊆ R. Together, these results yields our main Theorem [3.1,](#page-12-0) which states that the Knapsack family K is pseudorandom under the assumption of onewayness, without any specific ring structure or splitting requirements of modulus.
+
+## 2 Preliminaries
+
+We use the standard notations Z, N, Q, R and C to represent the sets of integers, natural numbers, rational numbers, real numbers, and complex numbers, respectively. For any integer s > 0, the set containing first s positive numbers less than or equal to s is denoted as [s] i.e., [s] = {1, . . . , s}. For a positive integer η > 0, the collection of all polynomials with coefficients in {0, 1, . . . , η − 1} 
+
+{1}------------------------------------------------
+
+is denoted as  $S_{\eta}$  i.e.,  $S_{\eta} = \{a(x) \in \mathbb{Z}[X] : 0 \le a_i < \eta \ \forall \ i \le \deg(a)\}$ . We denote the  $\infty$ -norm on  $\mathbb{C}^d$  by  $\|\cdot\|_{\infty}$  and define as  $\|\mathbf{x}\|_{\infty} = \max_{i \in [d]} |x_i|$  for all  $\mathbf{x} = (x_1, \dots, x_d)^{\mathsf{t}} \in \mathbb{C}^d$ . The collection of all square matrices of size n over a nonempty set F is denoted as  $M_n(F)$ .
+
+**The Space** H: For positive integers  $s_1, s_2$  and n, consider a subspace  $H \subseteq \mathbb{R}^{s_1} \times \mathbb{C}^{2s_2}$  defined as follows:
+
+$$H := \{ \mathbf{x} \in \mathbb{R}^{s_1} \times \mathbb{C}^{2s_2} \colon x_{s_1 + s_2 + j} = \overline{x_{s_1 + j}} \ \forall \ j \in [s_2] \} \subseteq \mathbb{C}^n.$$
+
+It is easy to see that H is isomorphic to  $\mathbb{R}^n$  as an inner product space with the induced inner product of  $\mathbb{C}^n$ . For the proof one can consider the orthonormal basis  $\{\mathbf{h_i}\}_{i\in[n]}$  given below. For  $j \in [s_1]$ , consider  $\mathbf{h}_j = \mathbf{e}_j \in \mathbb{C}^n$  and for  $s_1 < j \le s_1 + s_2$ , consider  $\mathbf{h}_j = \frac{1}{\sqrt{2}} (\mathbf{e}_j + \mathbf{e}_{j+s_2})$  and  $\mathbf{h}_{j+s_2} = \frac{\sqrt{-1}}{\sqrt{2}} (\mathbf{e}_j - \mathbf{e}_{j+s_2})$ , where  $\{\mathbf{e}_j : j \in [n]\} \subset \mathbb{C}^n$  is the standard orthonormal basis of  $\mathbb{C}^n$ . Note that the complex conjugation operation (which maps H to itself) acts on the set  $\{\mathbf{h}_i\}_{i\in[n]}$  by flipping the sign of all coordinates with indices in the range  $\{s_1 + s_2 + 1, \dots, n\}$ .
+
+### 2.1 Probabilities and Asymptotics
+
+We follow the standard asymptotic notations, i.e.,  $O(\cdot)$ ,  $o(\cdot)$ ,  $o(\cdot)$ ,  $o(\cdot)$ , and  $o(\cdot)$ , throughout this article. For a positive integer n, the expression  $n^{O(1)}$  denotes an arbitrary polynomial bound of n whereas  $n^{-\omega(1)}$  denotes a negligible function in n. For a probability distribution  $\chi$  over a nonempty set X, we write  $x \leftarrow \chi$  to mean that x is sampled according to the distribution  $\chi$ . We define the support of the distribution  $\chi$  as  $\sup(\chi) := \{x \in X \mid \Pr[x \leftarrow \chi] > 0\}$ . The notation  $\mathcal{U}(X)$  represents uniform distribution on X, occasionally we write  $x \overset{\$}{\leftarrow} X$  also to indicate that x is chosen uniformly at random from X. The statistical distance between two distributions  $\chi_1$  and  $\chi_2$  over a set S is defined as
+
+$$\Delta(\chi_1, \chi_2) = \frac{1}{2} \sum_{x \in S} |\chi_1(x) - \chi_2(x)|.$$
+
+The two distribution  $\chi_1$  and  $\chi_2$  are said to be statistically close if  $\Delta(\chi_1,\chi_2) = n^{-\omega(1)}$ .
+
+#### <span id="page-1-0"></span>2.2 Function Families
+
+Let X and Y be two nonempty sets. A function family denoted as  $(F,\chi)$  is a collection  $F = \{f_{\lambda} \colon X \to Y \mid \lambda \in I\}$  of functions indexed on I from X to the range Y, where  $\chi$  is a distribution on X. The distribution associated with function family  $(F,\chi)$  is defined as follows:
+
+$$\mathcal{F}(F,\chi) \coloneqq \{(f,f(x)) \mid f \leftarrow \mathcal{U}(F), x \leftarrow \chi\}.$$
+
+ $(t, \epsilon)$  invertible: Let  $\epsilon, t$  be two positive real numbers. A function family  $(F, \chi)$  is said to be  $(t, \epsilon)$ -invertible if there is a probabilistic algorithm  $\mathcal{I}$ , running in time at most t, such that
+
+$$\Pr_{(f,x)\leftarrow(F,\chi)}\left[\mathcal{I}(f,f(x))=x\right] \ge \epsilon. \tag{1}$$
+
+Such an  $\mathcal{I}$  is called a  $(t, \epsilon)$ -inverter for F.
+
+{2}------------------------------------------------
+
+ $\epsilon$  oneway: A function family  $(\mathcal{F}, \chi)$  is called  $\epsilon$  oneway if for all probabilistic polynomial time (PPT) algorithms  $\mathcal{A}$ ,
+
+$$\Pr_{(f,y)\leftarrow\mathcal{F}(F,\chi)}\left[f(\mathcal{A}(f,f(x))) = y\right] \le \epsilon. \tag{2}$$
+
+ $\epsilon$  indistinguishable: Two distributions  $\mathcal{D}_1$  and  $\mathcal{D}_2$  are  $\epsilon$ -indistinguishable if for all PPT algorithms  $\mathcal{A}$ ,  $\mathrm{Adv}_{\mathcal{A}}(\mathcal{D}_1, \mathcal{D}_2) \leq \epsilon$ , where the advantage  $\mathrm{Adv}_{\mathcal{A}}(\mathcal{D}_1, \mathcal{D}_2)$  is defined as follows:
+
+$$\operatorname{Adv}_{\mathcal{A}}(\mathcal{D}_{1}, \mathcal{D}_{2}) = \left| \Pr_{x \leftarrow \mathcal{D}_{1}} \left[ \mathcal{A}(x) = 1 \right] - \Pr_{y \leftarrow \mathcal{D}_{2}} \left[ \mathcal{A}(y) = 1 \right] \right|. \tag{3}$$
+
+ $\epsilon$  **pseudorandom:** The distribution  $\mathcal{F}(F,\chi)$  is  $\epsilon$ -pseudorandom if for all PPT algorithm  $\mathcal{A}$ ,  $\mathrm{Adv}_{\mathcal{A}}(\mathcal{F},\mathcal{U}) \leq \epsilon$ , i.e.,
+
+$$\left| \Pr_{(f,f(x)) \leftarrow \mathcal{F}(F,\chi)} \left[ \mathcal{A}(f,f(x)) = 1 \right] - \Pr_{(f,y) \leftarrow \mathcal{U}(F,Y)} \left[ \mathcal{A}(f,y) = 1 \right] \right| \le \epsilon. \tag{4}$$
+
+### 2.3 Algebraic Number Theory
+
+A complex number  $\xi \in \mathbb{C}$  is called an algebraic number if it is a root of a non-zero polynomial with rational coefficients, i.e.,  $f(\xi) = 0$  for some  $f(x) \in \mathbb{Q}[x] \setminus \{0\}$ . The minimal polynomial of  $\xi$ , denoted by  $f(x) \in \mathbb{Q}[X]$ , is the unique monic irreducible polynomial of minimal degree n such that  $f(\xi) = 0$ . An algebraic integer is an algebraic number that is a root of a monic polynomial with integer coefficients. A number field  $K = \mathbb{Q}(\xi)$  of degree  $n = [K : \mathbb{Q}]$  is a finite field extension of  $\mathbb{Q}$  obtained by adjoining an algebraic number  $\xi$  whose minimal polynomial has degree n. The tensor product  $K_{\mathbb{R}} = K \otimes_{\mathbb{Q}} \mathbb{R}$  represents the canonical embedding of K into  $\mathbb{R}$ . The set of algebraic integers in K forms a ring, denoted by R, called the ring of integers of K. In general,  $\mathbb{Z}[\xi] \subseteq R$ , with equality holding only for certain fields, for example, cyclotomic extension  $K = \mathbb{Q}(\xi)$  and quadratic extension  $K = \mathbb{Q}(\xi)$  for some  $\xi = \sqrt{d}$ , where d is square free and  $d \neq 1 \mod 4$ .
+
+#### 2.4 Embeddings and Geometry of Numbers
+
+Coefficient embedding: A number field  $K = \mathbb{Q}(\xi)$  of degree n can be represented as a vector space of dimension n over the rational field  $\mathbb{Q}$  with its basis  $\{1, \xi, \dots, \xi^{n-1}\}$ . That is, any element x in K can be written as  $x = x_0 + x_1 \xi + \dots + x_{n-1} \xi^{n-1}$  for some  $x_j \in \mathbb{Q}$ . The coefficient embedding of the number field K is a mapping from K to  $\mathbb{Q}^n$ . It is denoted as  $\tau$  and it maps each  $x \in K$  to a column vector  $(x_0, \dots, x_{n-1})^{\mathsf{t}}$  in  $\mathbb{Q}^n$ .
+
+Canonical embedding: A number field  $K = \mathbb{Q}(\xi)$  of degree n has exactly n injective field homomorphisms  $\sigma_i \colon K \to \mathbb{C}$  fixing  $\mathbb{Q}$ , i.e.,  $\sigma_i(x) = x$  for all  $x \in \mathbb{Q}$ . The injective homomorphisms are called embeddings of the number field K into the complex field. Each embedding maps  $\xi$  to its conjugates. An embedding whose image lies in  $\mathbb{R}$  is called a real embedding, and otherwise it is called a complex embedding. As the complex roots of f(x) come in pairs (complex conjugate), there are an even number, say  $2s_2$ , of complex embeddings. Assuming  $s_1$  number of real embeddings, we have  $n = s_1 + 2s_2$  embeddings with  $\sigma_{s_1+s_2+j} = \overline{\sigma_{s_1+j}}$  for  $j \in \{1, 2, \ldots, s_2\}$ . The canonical embedding  $\sigma \colon K \to \mathbb{R}^{s_1} \times \mathbb{C}^{2s_2}$  is a field homomorphism that is defined as  $\sigma(x) = (\sigma_1(x), \sigma_2(x), \ldots, \sigma_n(x))$  for all  $x \in K$ , where multiplication and addition in  $\mathbb{R}^{s_1} \times \mathbb{C}^{2s_2}$  are both component-wise. Let  $\omega_1, \omega_2, \ldots, \omega_n$  be n elements of K. Then the discriminant of K is
+
+{3}------------------------------------------------
+
+Disc $(\omega_1, \omega_2, \ldots, \omega_n) = \det(\mathbf{D}_K((\omega_1, \omega_2, \ldots, \omega_n)))^2$ , where  $\mathbf{D}_K(\omega_1, \omega_2, \ldots, \omega_n) = [\sigma_i(\omega_j)]_{i,j \in [n]}$ . In particular, for the power basis  $\{1, \xi, \ldots, \xi^{n-1}\}$ , we write  $\mathbf{D}_K$  for the corresponding matrix. Every element  $x \in K$  can be written as  $x = x_0 + x_1 \xi + \cdots + x_{n-1} \xi^{n-1}$  for some  $x_i \in \mathbb{Q}$  with respect to the power basis. Therefore, for every  $x \in K$ ,  $\sigma(x) = x_0 \sigma(1) + x_1 \sigma(\xi) + \cdots + x_{n-1} \sigma(\xi^{n-1})$ , equivalently  $\sigma(x) = \mathbf{D}_K \cdot \tau(x)$ .
+
+Next, we introduce a notion of the size of an algebraic number. Let  $x \in K$ , we define infinity norm  $\|x\|_{\infty}$  of x by  $\|x\|_{\infty} := \|\tau(x)\|_{\infty}$ . This can be extended to the vectors  $\mathbf{x} \in K^d$  as follows:  $\|\mathbf{x}\|_{\infty} = \max_{i \in [d]} \|\tau(x_i)\|_{\infty}$ . We have a standard notion of  $\ell_{\infty}$  norm of matrices  $\mathbf{A} = (a_{ij})$  in  $M_n(\mathbb{C})$ , defined as
+
+$$\|\mathbf{A}\|_{\infty} = \max_{1 \le i \le n} \left[ \sum_{i=1}^{n} |a_{ij}| \right].$$
+
+Using it, we denote  $d_K = \|\mathbf{D}_K\|_{\infty}$ . The canonical embedding  $\sigma$  maps K into H, so for any  $x \in K$ 
+
+$$\|\sigma(x)\|_{\infty} \le \|\mathbf{D}_K\|_{\infty} \|\tau(x)\|_{\infty} \le d_K \|x\|_{\infty}.$$
+
+Two fundamental quantities associated with an algebraic number  $\alpha$  in K are the *trace* and the *norm*. The *trace* of  $\alpha \in K$ , denoted as  $\mathrm{Tr}_{K/\mathbb{Q}}(\alpha)$ , is defined by
+
+$$\operatorname{Tr}_{K/\mathbb{Q}}(\alpha) = \sum_{j=1}^{n} \sigma_j(\alpha),$$
+
+and the *norm* of  $\alpha$ , denoted as  $N_{K/\mathbb{Q}}(\alpha)$ , is defined by
+
+$$N_{K/\mathbb{Q}}(\alpha) = \prod_{j=1}^{n} \sigma_j(\alpha).$$
+
+#### 2.4.1 Modules, Ideals and Units
+
+Let K be a number field of degree n with its ring of integers R and let  $d \in \mathbb{N}$ . A subset  $\mathcal{M} \subseteq$  $K^d$  is called an R-module of rank d if it is closed under additions by elements of M and under multiplications by elements of R and  $\mathcal{M}$ . The module  $\mathcal{M}$  is said to be finitely generated if there is a finite family  $\{b_i\}\subseteq \mathcal{M}$  such that  $\mathcal{M}=\sum_i R\cdot b_i$ . A set  $\mathfrak{a}\subseteq R$  is called fractional ideal of R if  $\mathfrak{a}$  is an R-module contained in K such that there is an integer  $m \in \mathbb{Z}$  with  $m\mathfrak{a} \subseteq R$ . An ideal  $\mathfrak{a} \subseteq R$  is a non-zero additive subgroup of R that is closed under multiplication by R. In particular, every ideal is a module of rank 1, and it is also a fractional ideal in R for m=1. If  $\mathfrak{a}$  and  $\mathfrak{b}$ be two fractional ideals of R, then the product  $\mathfrak{ab} := \left\{ \sum_{i=1}^{\ell} a_i b_i : a_i \in \mathfrak{a}, b_i \in \mathfrak{b} \text{ and } \ell \in \mathbb{N} \right\}$  and sum  $\mathfrak{a} + \mathfrak{b} := \{a_i + b_i : a_i \in \mathfrak{a} \text{ and } b_i \in \mathfrak{b}\}, \text{ both are fractional ideals of } R. \text{ A non-zero fractional ideal}$  $\mathfrak{a}$  of R is said to be invertible if there exists a fractional ideal  $\mathfrak{b}$  of R such that  $\mathfrak{ab} = R$  and  $\mathfrak{b}$  is called inverse of  $\mathfrak{a}$ . For every non-zero fractional ideal  $\mathfrak{a}$  of R, there is a unique inverse of it, and furthermore, it can be specified as  $\mathfrak{a}^{-1} = \{x \in K \mid x\mathfrak{a} \subseteq R\}$ . A fractional ideal  $\mathfrak{a}$  of R is said to be finitely generated if there exists  $a_1, \ldots, a_n$  in  $\mathfrak{a}$  such that  $\mathfrak{a} = Ra_1 + \ldots + Ra_n$ . We also express it by writing  $\mathfrak{a} = \langle a_1, \ldots, a_n \rangle$ . If a fractional ideal  $\mathfrak{a}$  of R is generated by a single element  $a \in R$ , we call it principal fractional ideal of R. Since R is Dedekind domain, every non-zero proper ideal  $\mathfrak a$  of R can be uniquely written as a product of distinct prime ideals powers i.e., there are unique prime ideals  $\mathfrak{p}_1,\ldots,\mathfrak{p}_r$  of R and positive integers  $e_1,\ldots,e_r$  such that  $\mathfrak{a}=\mathfrak{p}_1^{e_1}\mathfrak{p}_2^{e_2}\ldots\mathfrak{p}_r^{e_r}$ . A rational prime p is said to be unramified in K if no prime ideal appears more than one time in the prime ideal factorisation of pR i.e.,  $e_i = 1$  for all i. The set  $I_K$  of all non-zero fractional ideals of Dedekind
+
+{4}------------------------------------------------
+
+domain R forms a group under the multiplication of ideals.
+
+Let  $\mathfrak{a}, \mathfrak{b} \in I_K$ . We say that  $\mathfrak{a}$  divides  $\mathfrak{b}$  if there is an ideal  $\mathfrak{c}$  of R such that  $\mathfrak{b} = \mathfrak{a}\mathfrak{c}$  and denote it by the notation  $\mathfrak{a} \mid \mathfrak{b}$ . Note that ideal  $\mathfrak{a} \mid \mathfrak{b}$ , then  $\mathfrak{b} \subseteq \mathfrak{a}$ . An ideal  $\mathfrak{d} \in I_K$  is said to be the GCD of the ideal  $\mathfrak{a}$  and  $\mathfrak{b} \in I_K$  if  $\mathfrak{d}$  is a common divisor of both the ideals, and if there is an ideal  $\mathfrak{d}'$  of R such that  $\mathfrak{d}' \mid \mathfrak{a}$  and  $\mathfrak{d}' \mid \mathfrak{b}$  then  $\mathfrak{d}' \mid \mathfrak{d}$ . It is easy to verify that  $\gcd(\mathfrak{a},\mathfrak{b}) = \mathfrak{a} + \mathfrak{b}$ . The  $\mathfrak{a}$  and  $\mathfrak{b}$  are relatively prime if their GCD is identity in the group  $I_K$ , i.e.,  $\gcd(\mathfrak{a},\mathfrak{b}) = R$ . For relatively prime ideals  $\mathfrak{a}$  and  $\mathfrak{b}$ ,  $\mathfrak{a}\mathfrak{b} = \mathfrak{a} \cap \mathfrak{b}$ . In a Dedekind domain and hence in the ring R, any non-zero ideal  $\mathfrak{a}$  can be generated by at most two elements of R, and one of the two generators can be chosen suitably. For more details on algebraic number theory concepts, we refer to the book [Ste12] and paper [LPR13].
+
+<span id="page-4-0"></span>**Lemma 2.1** (Generators of ideal). Let  $K = \mathbb{Q}(\xi)$  be a number field of degree n with ring of integer R. Every non zero ideal  $\mathfrak{a}$  of R can be generated by at most two elements.
+
+Proof. The integral ideal  $\mathfrak{a}$  of R is non-zero; there is a non zero element  $a \in \mathfrak{a}$ . If the ideal  $\mathfrak{a}$  is a principal ideal, then the proof is trivial. So, consider  $\mathfrak{a}$  is not a principal ideal. Since the non-zero element a belongs to ideal  $\mathfrak{a}$ , we can write  $aR = \mathfrak{p}_1^{f_1} \cdots \mathfrak{p}_r^{f_r}$  and  $\mathfrak{i} = \mathfrak{p}_1^{g_1} \cdots \mathfrak{p}_r^{g_r}$  uniquely and for each  $i \in [r]$ ,  $g_i \leq f_i$  because  $\mathfrak{i} \subseteq qR$ . For each  $i \in [r]$ , consider element  $b_i \in \mathfrak{p}_1^{g_1+1} \cdots \mathfrak{p}_i^{g_i} \cdots \mathfrak{p}_r^{g_r+1} \setminus \mathfrak{p}_1^{g_i+1} \cdots \mathfrak{p}_i^{g_i+1} \cdots \mathfrak{p}_r^{g_i+1} \subset \mathfrak{i}$  for each  $i \in [r]$ . Then, for all  $i \in [r]$ ,  $b_i \in \mathfrak{p}_j^{g_j+1} \ \forall j \neq i$  but  $b_i \notin \mathfrak{p}_i^{g_i+1}$ . Otherwise,  $b_i \in \mathfrak{p}_i^{g_i+1} \cap \left(\mathfrak{p}_1^{g_1+1} \cdots \mathfrak{p}_i^{g_i} \cdots \mathfrak{p}_r^{g_r+1}\right) = \mathfrak{p}_1^{g_1+1} \ldots \mathfrak{p}_r^{g_r+1}$ , which contradicts the choice of  $b_i$ . Hence  $b = b_1 + \cdots + b_r \notin \mathfrak{p}_i^{g_i+1}$  for all  $i \in [r]$  but in ideal  $\mathfrak{i}$  the principal ideal bR can be factorized uniquely as  $bR = \mathfrak{p}_1^{h_1} \cdots \mathfrak{p}_r^{h_r}$ . The ideal  $\langle a, b \rangle$  can be written as aR + bR, consequently  $\langle a, b \rangle = \mathfrak{p}_1^{m_1} \cdots \mathfrak{p}_r^{m_r}$  for some  $m_i = \min(f_i, h_i)$ . Since ideal  $\langle a, b \rangle$  is contained in  $\mathfrak{a}$ ,  $m_i \geq g_i$  for all  $i \in [r]$  and  $b \notin \mathfrak{p}_i^{g_i+1}$  for all  $i \in [r]$  implies  $\langle a, b \rangle \not\subset \mathfrak{p}_i^{g_i+1} \subset \mathfrak{p}_i^{g_i}$  as a result  $g_i \geq m_i$  for all  $i \in [r]$ . Hence we have  $m_i = g_i$  for all  $i \in [r]$ . Thus we proved  $\mathfrak{a} = \langle a, b \rangle$ .
+
+For a non-zero ideal  $\mathfrak{a}$  of R and  $a, b \in R$ , we say that a is congruent to b modulo  $\mathfrak{a}$  if  $a - b \in \mathfrak{a}$  i.e.,  $\mathfrak{a} \mid (a - b)R$  and we denote it as  $a \equiv b \mod \mathfrak{a}$ . Next, we state the Chinese Remainder Theorem on the number ring R.
+
+**Theorem 2.1** (Chinese Remainder Theorem). Assume,  $\mathfrak{a}_1, \ldots, \mathfrak{a}_r$  are mutually coprime ideals of R, i.e.,  $\mathfrak{a}_i + \mathfrak{a}_j = R$  for any  $i \neq j$ . Then the natural homomorphism  $R \longrightarrow \bigoplus_{i=1}^r R/\mathfrak{a}_i$  induces an isomorphism
+
+$$R/\left(\prod_{i=1}^r \mathfrak{a}_i\right) \longrightarrow \bigoplus_{i=1}^r \left(R/\mathfrak{a}_i\right)$$
+
+Thus for given  $a_i \in \mathfrak{a}_i \ \forall \ i \in [r]$ , there is  $a \in R$  such that  $a \equiv a_i \mod \mathfrak{a}_i$  for all  $i \in [r]$ .
+
+**Norm of Ideal:** For any non-zero ideal  $\mathfrak{a}$  in R, the norm of  $\mathfrak{a}$  is defined as  $N(\mathfrak{a}) := |R/\mathfrak{a}|$ . It satisfies two important properties. The first property is multiplicativity i.e.,  $N(\mathfrak{a}\mathfrak{b}) = N(\mathfrak{a})N(\mathfrak{b})$  for any two non-zero ideals  $\mathfrak{a}$  and  $\mathfrak{b}$  of R. The second property of the norm of ideals ensures the existence of a finite number of ideals  $\mathfrak{a}$  of R satisfying  $N(\mathfrak{a}) \leq c$ , for a given positive integer c. We use the notation  $N_{\mathfrak{a}}$  for the ideal norm  $N(\mathfrak{a})$  for simplicity, particularly in longer calculations.
+
+**Euler's totient:** Here we recall the generalised Euler's totient function over the number ring R. For non zero ideals  $\mathfrak{m}$  and  $\mathfrak{n}$  of R, consider the set
+
+$$A_{\mathfrak{m}}(\mathfrak{n}) \coloneqq \{ \mathfrak{i} \in I_K \mid \gcd(\mathfrak{i}, \mathfrak{n}) = \mathfrak{m} \text{ and } 1 \leq \mathrm{N}(\mathfrak{i}) < \mathrm{N}(\mathfrak{n}) \}.$$
+
+{5}------------------------------------------------
+
+We denote the cardinality of the set  $A_{\mathfrak{m}}(\mathfrak{n})$  as  $\Phi_{\mathfrak{m}}(\mathfrak{n})$ . Notice that  $\Phi_{\mathfrak{m}}(\mathfrak{n}) \geq 1$  if and only if  $\mathfrak{m}$  divides  $\mathfrak{n}$ , i.e.,  $\mathfrak{n} \subseteq \mathfrak{m}$ . If  $\mathfrak{m} = R$ , we simply denote it as  $\Phi(\mathfrak{n})$ . This function  $\Phi(\mathfrak{n})$  is called the generalised Euler's totient function, and it is expressed as
+
+<span id="page-5-0"></span>
+$$\Phi(\mathfrak{n}) = N(\mathfrak{n}) \prod_{\mathfrak{p} \mid \mathfrak{a}} \left( 1 - \frac{1}{N(\mathfrak{p})} \right), \tag{5}$$
+
+where the product extends over all prime ideals  $\mathfrak{p}$  dividing a non-zero ideal  $\mathfrak{n}$ . For more details on the generalised Euler's totient function, we refer to the article [Mig14].
+
+<span id="page-5-1"></span>**Lemma 2.2.** Let  $\mathfrak{n} \neq R$  be a non-zero ideal of the number ring R. Then for any ideal  $\mathfrak{d}$  dividing  $\mathfrak{n}$ , we have  $\Phi_{\mathfrak{d}}(\mathfrak{n}) \leq N(\mathfrak{n})/N(\mathfrak{d})$ . The equality holds only when  $\mathfrak{n}\mathfrak{d}^{-1} = R$ .
+
+*Proof.* Let  $\mathfrak{d} \in I_K$  be an ideal dividing  $\mathfrak{n}$ . By definition, the set  $A_{\mathfrak{d}}(\mathfrak{n})$  is non-empty. For every ideal  $\mathfrak{a} \in A_{\mathfrak{d}}(\mathfrak{n})$ , there exists an ideal  $\mathfrak{c} \in I_K$  such that  $\mathfrak{a} = \mathfrak{c}\mathfrak{d}$ . This implies that  $\gcd(\mathfrak{c}, \mathfrak{n}\mathfrak{d}^{-1}) = R$ . Conversely, any ideal  $\mathfrak{c}$  satisfying this condition gives rise to an ideal  $\mathfrak{a} = \mathfrak{c}\mathfrak{d}$  in  $A_{\mathfrak{d}}(\mathfrak{n})$ . Hence,
+
+$$A_{\mathfrak{d}}(\mathfrak{n}) = \left\{ \mathfrak{cd} \in I_K \ \middle| \ \gcd(\mathfrak{c}, \mathfrak{nd}^{-1}) = R, \ 1 \leq \mathrm{N}(\mathfrak{c}) < \frac{\mathrm{N}(\mathfrak{n})}{\mathrm{N}(\mathfrak{d})} \right\}.$$
+
+By the above correspondence, we obtain  $A_{\mathfrak{d}}(\mathfrak{n}) = A_R(\mathfrak{n}\mathfrak{d}^{-1})$ , and therefore  $\Phi_{\mathfrak{d}}(\mathfrak{n}) = \Phi(\mathfrak{n}\mathfrak{d}^{-1})$ . Using Equation (5), we have
+
+$$\Phi(\mathfrak{n}\mathfrak{d}^{-1}) = \frac{N(\mathfrak{n})}{N(\mathfrak{d})} \prod_{\mathfrak{p} \mid (\mathfrak{n}\mathfrak{d}^{-1})} \left(1 - \frac{1}{N(\mathfrak{p})}\right) \leq \frac{N(\mathfrak{n})}{N(\mathfrak{d})},$$
+
+where equality holds only when  $\mathfrak{nd}^{-1} = R$ . This proves the lemma.
+
+<span id="page-5-2"></span>**Lemma 2.3** (Adapted from [MM11, Lemma 3.8]). For any non-zero ideal  $\mathfrak{a}$  of the number ring R,
+
+$$\sum_{\substack{\mathfrak{d} \mid \mathfrak{a} \\ \mathfrak{d} \neq \mathfrak{a}}} N(\mathfrak{d})^2 \le \left(\frac{\pi^2}{6} - 1\right) N(\mathfrak{a})^2.$$
+
+*Proof.* Any non-zero ideal  $\mathfrak{a}$  of R can be uniquely factorized as  $\mathfrak{a} = \mathfrak{p}_1^{e_1} \cdots \mathfrak{p}_r^{e_r}$ . For any proper divisor  $\mathfrak{d}$  of  $\mathfrak{a}$ , N( $\mathfrak{d}$ ) divides N( $\mathfrak{a}$ ). Hence, by Lemma 3.8 in the paper [MM11], inequality follows.
+
+<span id="page-5-3"></span>**Lemma 2.4.** Let  $K = \mathbb{Q}(\xi)$  be a number field of degree n with ring of integers R. For any prime ideal  $\mathfrak{p}$  of R there is a rational prime p and monic irreducible polynomial g(x) in  $F_p[x]$  such that  $\mathfrak{p} = (p, g(x))$  and  $N(\mathfrak{p}) = p^{\deg g}$ . Moreover, the quotient ring  $R/\mathfrak{p}$  has  $p^{\deg(g)}$  elements and their representatives can be taken as all polynomials of degree at most  $\deg(g) - 1$  with coefficients less than q.
+
+Proof. Let  $\mathfrak{p} \subset R$  be prime ideal. Since number ring R is Dedekind domain,  $\mathfrak{p}$  is maximal ideal in R. As a result, the quotient ring  $R/\mathfrak{p}$  is field of order  $p^r$  for some prime p and positive integer r. Lagrange's theorem implies  $N(\mathfrak{p})(1+\mathfrak{p})=\mathfrak{p}$ , so  $N(\mathfrak{p})\in\mathfrak{p}$ . Consequently  $p\in\mathfrak{p}$ , because  $\mathfrak{p}$  is a prime ideal of R. One can efficiently compute (e.g., algorithm in [QFCZ12]) a minimal polynomial  $g(x)\in\mathbb{Z}[X]$  such that  $g(\xi)=0$  and can factor it over  $F_p[X]$  into irreducible factors i.e.,  $g\equiv\prod g_i(x)^{e_i}\mod p$ . Then by Dedekind-Kumar theorem,  $pR=\prod\mathfrak{p}_i^{e_i}$ , where each  $\mathfrak{p}_i=\langle p,g_i(\xi)\rangle$  is prime ideal with norm  $p^{\deg(g_i)}$ . Since  $p\in\mathfrak{p}$ , the principle ideal pR is contained in  $\mathfrak{p}$  which implies
+
+{6}------------------------------------------------
+
+ $\mathfrak{p}_i \subseteq \mathfrak{p}$  for some i, because  $\mathfrak{p}$  is an prime ideal of R. since every non-zero prime ideal is maximal,  $\mathfrak{p} = \mathfrak{p}_i$  for some i. Thus proved  $\mathfrak{p} = (p, g_i(\xi))$  and  $N(\mathfrak{p}) = p^{\deg(g_i)}$ .
+
+<span id="page-6-0"></span>**Lemma 2.5.** Let K be a number field of degree n and R be its ring of integers. For a positive number q and non zero  $\mathbf{w} = (w_1, \ldots, w_d)^{\mathsf{t}}$  in  $R^d$ , for  $d \geq 1$ , the distribution  $\{\langle \mathbf{a}, \mathbf{w} \rangle \bmod qR : \mathbf{a} \leftarrow \mathcal{U}(R_q^d)\}$  is uniform over  $\mathfrak{d} \bmod qR$ , where  $\mathfrak{d} = \gcd(\langle w_1, \cdots, w_m \rangle, qR)$  in R and sometimes we write it as  $\gcd_{qR}(\mathbf{w})$ .
+
+*Proof.* To prove the lemma, we consider the set  $\mathfrak{I}_{\mathbf{w}} = \{ \langle \mathbf{a}, \mathbf{w} \rangle \mod qR \colon \mathbf{a} \in R_q^d \}$ . This is precisely the image of  $R_q^d$  under the linear map
+
+$$\varphi_{\mathbf{w}} \colon R_q^d \to R_q \text{ defined by } \mathbf{a} \longmapsto \langle \mathbf{a}, \mathbf{w} \rangle \mod qR.$$
+
+The image of any submodule of  $R_q^d$  under the map  $\varphi_{\mathbf{w}}$  is an ideal in  $R_q$ . So  $\mathfrak{J}_{\mathbf{w}}$  is also an ideal in  $R_q$ , which is generated by  $\langle w_1, \ldots, w_d \rangle$  mod qR. Without the loss of generality, one can consider it as ideal  $\mathfrak{d} = \gcd(\langle w_1, \ldots, w_d \rangle, qR)$ . By the first isomorphism theorem,  $R_q^d/\ker(\varphi_{\mathbf{w}})$  is isomorphic to  $\mathfrak{J}_{\mathbf{w}}$ . Hence for each element b in  $\mathfrak{J}_{\mathbf{w}}$ , there is a unique coset  $\mathbf{a} + \ker(\varphi_{\mathbf{w}}) \subset R_q^d$  mapping to b. Since each coset has size  $|\ker(\varphi_{\mathbf{w}})|$ , the probability of sampling b under the uniform choice of  $\mathbf{a} \in R_q^d$  is  $\Pr[b] = |\ker(\varphi_{\mathbf{w}})|/|R_q^d|$ . Therefore, the distribution  $\{\langle \mathbf{a}, \mathbf{w} \rangle \mod qR \in R_q : \mathbf{a} \leftarrow \mathcal{U}(R_q^d)\}$  is uniform over  $\mathfrak{d} \mod qR$ .
+
+### 2.5 Knapsack Functions Family
+
+Let q and d be two positive integers. Let K be a number field of degree n and R be its ring of integers. For input distribution  $\chi$  on  $R^d$ , the Knapsack function family over the polynomial ring  $R_q$  is defined as
+
+$$\mathcal{K}(n,q,d,\chi) \coloneqq \{f_{\mathbf{a}} \colon \operatorname{supp}(\chi) \to R_q \mid \mathbf{a} \in R_q^d\},$$
+
+where
+
+$$f_{\mathbf{a}}(\mathbf{x}) = \langle \mathbf{a}, \mathbf{x} \rangle \bmod qR \ \forall \ \mathbf{x} \in R_q^d.$$
+
+When  $R_q$ ,  $\chi$  and n are clear from the context, we will simply write  $\mathcal{K}$ . For any ideal  $\mathfrak{d}$  of R, the image of  $\mathfrak{d}$  under the canonical map  $\pi_{qR} \colon R \to R_q$  forms an ideal of  $R_q$ . To simplify, we use the notation  $\tilde{\mathfrak{d}} := \pi_{qR}(\mathfrak{d}) \equiv \mathfrak{d} \mod qR$ . For any ideal  $\mathfrak{d}$  of R, we often consider folded version of knapsack functions family  $\mathcal{K}_{\mathfrak{d}}(n,q,d,\chi)$  defined over the quotient group  $R_q/\tilde{\mathfrak{d}}$  and we denote it as  $\mathcal{K}_{\mathfrak{d}}$  to keep it simple.
+
+We further define a distribution
+
+$$\mathcal{F}_{\mathfrak{d}}(\mathcal{K}) = \{ (\mathbf{a}, y + h) \mid (\mathbf{a}, y) \leftarrow \mathcal{F}(\mathcal{K}), h \leftarrow \mathcal{U}(\tilde{\mathfrak{d}}) \}, \tag{6}$$
+
+for some ideal  $\mathfrak{d}$  of R. Note that,
+
+$$\mathcal{F}_{qR}(\mathcal{K}) = \mathcal{F}(\mathcal{K}) \quad \text{and} \quad \mathcal{F}_{R}(\mathcal{K}) = \mathcal{U}(R_q^d \times R_q).$$
+ (7)
+
+**Lemma 2.6** (Adapted from-[MM11, Lemma 2.2]). Let K be a number field of degree n and R be its ring of integers. Then for any ideal  $\mathfrak{d}$  of R,  $\Delta(\mathcal{F}_{\mathfrak{d}}(\mathcal{K}),\mathcal{U}) = \Delta(\mathcal{F}(\mathcal{K}_{\mathfrak{d}}),\mathcal{U})$ . Moreover,  $\mathcal{F}_{\mathfrak{d}}(\mathcal{K})$  is pseudorandom if and only if  $\mathcal{F}(\mathcal{K}_{\mathfrak{d}})$  is pseudorandom.
+
+*Proof.* Define the natural projection
+
+$$f: R_q^d \times R_q \to (R_q/\tilde{\mathfrak{d}})^d \times R_q/\tilde{\mathfrak{d}}, \qquad (\mathbf{a}, b) \mapsto (\bar{\mathbf{a}}, \bar{b}),$$
+
+{7}------------------------------------------------
+
+where reduction is taken modulo  $\tilde{\mathfrak{d}}$  componentwise.
+
+The map f is surjective. For any  $(\bar{\mathbf{a}}, \bar{b})$  in the codomain, its preimage is
+
+$$f^{-1}(\bar{\mathbf{a}}, \bar{b}) = \{(\mathbf{a}', b') \in R_q^d \times R_q : \mathbf{a}' \equiv \mathbf{a} \bmod \tilde{\mathfrak{d}}, \ b' \equiv b \bmod \tilde{\mathfrak{d}}\},$$
+
+which has cardinality  $|\tilde{\mathfrak{d}}|^{d+1}$ . Therefore, f maps the uniform distribution on  $R_q^d \times R_q$  to the uniform distribution on  $(R_q/\tilde{\mathfrak{d}})^d \times R_q/\tilde{\mathfrak{d}}$ .
+
+Moreover, if  $(\bar{\mathbf{a}}, \bar{b}) \leftarrow \mathcal{F}(\hat{\mathcal{K}})$  and  $y \leftarrow \mathcal{U}(\tilde{\mathfrak{d}})$ , then  $(\bar{\mathbf{a}}, b + y)$  is mapped by f to  $(\bar{\mathbf{a}}, \bar{b})$ , which follows the distribution  $\mathcal{F}(\mathcal{K}_{\mathfrak{d}})$ . By the data-processing inequality,
+
+$$\Delta(\mathcal{F}(\mathcal{K}_{\mathfrak{d}}), \mathcal{U}) = \Delta(f(\mathcal{F}_{\mathfrak{d}}(\mathcal{K})), f(\mathcal{U})) \leq \Delta(\mathcal{F}_{\mathfrak{d}}(\mathcal{K}), \mathcal{U}).$$
+
+We now prove the reverse inequality. Define the random lifting transformation
+
+$$g: (R_q/\tilde{\mathfrak{d}})^d \times R_q/\tilde{\mathfrak{d}} \to R_q^d \times R_q, \qquad (\bar{\mathbf{a}}, \bar{b}) \mapsto (\bar{\mathbf{a}} + \mathbf{a}', \bar{b} + b'),$$
+
+where  $(\mathbf{a}', b') \leftarrow \mathcal{U}(\tilde{\mathfrak{d}}^d \times \tilde{\mathfrak{d}})$ . For every  $(\mathbf{a}, b) \in R_q^d \times R_q$ , there exists a unique coset representative  $(\bar{\mathbf{a}}, \bar{b})$  such that  $\bar{\mathbf{a}} \equiv \mathbf{a} \mod \tilde{\mathfrak{d}}$  and  $\bar{b} \equiv b \mod \tilde{\mathfrak{d}}$ . Conditioned on this coset, the probability that  $(\bar{\mathbf{a}} + \mathbf{a}', \bar{b} + b') = (\mathbf{a}, b)$  is  $|\tilde{\mathfrak{d}}|^{-(d+1)}$ . Hence, for each uniform sample  $(\bar{\mathbf{a}}, \bar{b}) \in (R_q/\tilde{\mathfrak{d}})^d \times R_q/\tilde{\mathfrak{d}}$ ,
+
+$$\Pr[g(\bar{\mathbf{a}}, \bar{b}) = (\mathbf{a}, b)] = \frac{1}{|R_q/\tilde{\mathfrak{d}}|^{d+1}} \cdot \frac{1}{|\tilde{\mathfrak{d}}|^{d+1}} = \frac{1}{|R_q|^{d+1}},$$
+
+and thus  $g(\mathcal{U})$  is uniform over  $R_q^d \times R_q$ .
+
+Now assume  $(\bar{\mathbf{a}}, \bar{b}) \leftarrow \mathcal{F}(\mathcal{K}_{\mathfrak{d}})$ , so that  $\bar{b} = \langle \bar{\mathbf{a}}, \mathbf{x} \rangle$  for some  $\mathbf{x} \in \text{supp}(\chi)$ . Let  $(\mathbf{a}', b') \leftarrow \mathcal{U}(\tilde{\mathfrak{d}}^d \times \tilde{\mathfrak{d}})$  and define  $\mathbf{a} = \bar{\mathbf{a}} + \mathbf{a}'$  and  $h = b' - \langle \mathbf{a}', \mathbf{x} \rangle \mod qR$ . Then  $\mathbf{a}$  is uniformly distributed over  $R_q^d$ . We claim that h is uniformly distributed over  $\tilde{\mathfrak{d}}$ . Indeed, for any  $z \in \tilde{\mathfrak{d}}$ ,
+
+$$\Pr[h=z] = \sum_{a \in \tilde{\mathfrak{d}}} \Pr[\langle \mathbf{a}', \mathbf{x} \rangle = a] \Pr[b' - a = z] = \frac{1}{|\tilde{\mathfrak{d}}|} \sum_{a \in \tilde{\mathfrak{d}}} \Pr[\langle \mathbf{a}', \mathbf{x} \rangle = a] = \frac{1}{|\tilde{\mathfrak{d}}|}.$$
+
+Thus, h is uniform over  $\tilde{\mathfrak{d}}$ , and  $b = \bar{b} + b' = \langle \mathbf{a}, \mathbf{x} \rangle + h$  follows the distribution  $\mathcal{F}_{\mathfrak{d}}(\mathcal{K})$ . Applying the data-processing inequality again, we get,
+
+$$\Delta(\mathcal{F}_{\mathfrak{d}}(\mathcal{K}),\mathcal{U}) = \Delta(g(\mathcal{F}(\mathcal{K}_{\mathfrak{d}})),g(\mathcal{U})) \leq \Delta(\mathcal{F}(\mathcal{K}_{\mathfrak{d}}),\mathcal{U}).$$
+
+Combining both directions yields
+
+$$\Delta(\mathcal{F}_{\mathfrak{d}}(\mathcal{K}),\mathcal{U}) = \Delta(\mathcal{F}(\mathcal{K}_{\mathfrak{d}}),\mathcal{U}).$$
+
+Since both f and g are efficiently computable, any distinguisher for one distribution can be transformed into a distinguisher for the other, and vice versa.  $\Box$ 
+
+### 2.6 Fourier Analysis and Learning
+
+Fourier analysis plays an important role in lattice-based cryptography, particularly in the study of Gaussian distribution for worst-case to average-case reduction [MR04]. It is used in establishing the average-case hardness of the LWE from worst-case lattice assumptions [Reg09, Pei08]. In this work, we employ Fourier-analytic techniques in a context closer to their uses in the learning theory and in the analysis of Boolean and algebraic functions (see [KM93, MOS03]). More specifically, we
+
+{8}------------------------------------------------
+
+use Fourier analysis as a tool to study the structure and distinguishability of distributions arising from the Knapsack families. Our work closely resembles the work of Micciancio and Mol [MM11]. We extend their result to obtain a sample preserving search to decision reduction for the module LWE. Before discussing our actual work, we briefly recall the essential notions of the Fourier transformation over finite abelian groups, required in our setting. For more comprehensive discussion, we refer the reader to the standard references such as [Aka08] and [Con25].
+
+### 2.6.1 Characters of Finite Abelian Group
+
+A character of a finite abelian group  $(G,\cdot)$  is homomorphism  $\chi\colon G\to S^1$ , where  $S^1\coloneqq\{z\in\mathbb{C}\colon |z|=1\}$  is group with respect to complex multiplication. For a character  $\chi$  of the group G, the conjugate character  $\overline{\chi}\colon G\to S^1$  is defined as  $\overline{\chi}(g)\coloneqq\overline{\chi(g)}$  for all g in G as  $\overline{\chi}(g)=\chi(g)^{-1}=\chi(g^{-1})$ . The dual group of a finite abelian group G is the set  $\widehat{G}$  consisting of all characters  $\chi\colon G\to S^1$  with point-wise multiplication of functions as  $(\chi_1\chi_2)(g)=\chi_1(g)\chi_2(g)$  for all g in G. It is isomorphic to the group G. The set  $L(G)=\{f\colon G\to\mathbb{C}\}$  is a  $\mathbb{C}$ -vector space of functions. Any function  $f\in L(G)$  can be expressed as
+
+$$f = \sum_{g \in G} f(g)\delta_g$$
+ where  $\delta_g(x) = \begin{cases} 1 & \text{if } x = g, \\ 0 & \text{otherwise.} \end{cases}$ 
+
+The set  $\{\delta_g\}_{g\in G}$  forms a basis of L(G), so the dimension of vector space L(G) is equal to order of G, i.e., |G|. The Lemma 2.7 states the classical orthogonality relation for characters of finite abelian groups G. Every nontrivial character has a total sum of zero when evaluated over all elements of the group.
+
+<span id="page-8-0"></span>**Lemma 2.7** ([Con25, Theorem 4.1]). Let G be a finite abelian group. Then for a character  $\chi \in \widehat{G}$ 
+
+$$\sum_{g \in G} \chi(g) = \begin{cases} 1 & \text{if } \chi = 1_G \\ 0 & \text{if } \chi \neq 1_G \end{cases}$$
+
+From the above Lemma 2.7, one can obtain an orthogonality relation, given in the following Corollary 2.1.
+
+<span id="page-8-1"></span>Corollary 2.1. For any characters  $\chi_1$  and  $\chi_2$  in  $\widehat{G}$  and g in G,
+
+$$\sum_{g \in G} \chi_1(g)\bar{\chi_2}(g) = \begin{cases} |G| & \text{if } \chi_1 = \chi_2 \\ 0 & \text{if } \chi_1 \neq \chi_2 \end{cases}$$
+ (8)
+
+and for any  $g_1$  and  $g_2$  in G
+
+<span id="page-8-2"></span>
+$$\sum_{\chi \in \widehat{G}} \chi(g_1)\bar{\chi}(g_2) = \begin{cases} |G| & \text{if } g_1 = g_2\\ 0 & \text{if } g_1 \neq g_2 \end{cases}$$
+ (9)
+
+From the second equation (Equation 9) of the Corollary 2.1, the delta functions can be expressed as
+
+$$\sum_{\chi \in \widehat{G}} \chi(g)\bar{\chi}(x) = |G|\delta_g(x) \implies \delta_g(x) = \frac{1}{|G|} \sum_{\chi \in \widehat{G}} \bar{\chi}(g)\chi(x).$$
+
+{9}------------------------------------------------
+
+Now substituting the value of  $\delta_g$  in the expression  $f(x) = \sum_{g \in G} f(g) \delta_g(x)$ , we have
+
+$$f(x) = \sum_{g \in G} f(g) \left( \frac{1}{|G|} \sum_{\chi \in \widehat{G}} \bar{\chi}(g) \chi(x) \right) = \sum_{\chi \in \widehat{G}} \sum_{g \in G} \frac{1}{|G|} f(g) \bar{\chi}(g) \chi(x) = \sum_{\chi \in \widehat{G}} c_{\chi} \chi(x)$$
+
+where  $c_{\chi} = \sum_{g \in G} f(g)\bar{\chi}(g)$ . This implies that  $\widehat{G}$  generates the vector space L(G). Since dimension of L(G) is |G|, which is same as  $|\widehat{G}|$ , it is a basis for L(G). The vector space L(G) is an inner product space with respect to the Hermitian inner product defined as
+
+$$\langle f_1, f_2 \rangle = \frac{1}{|G|} \sum_{g \in G} f_1(g) \overline{f_2(g)} = \underset{g \leftarrow \mathcal{U}(G)}{\mathbb{E}} \left[ f_1(g) \overline{f_2(g)} \right]. \tag{10}$$
+
+The corresponding  $\ell_2$  and  $\ell_\infty$  norms of f in L(G) are defined as
+
+$$||f||_2 = \sqrt{\langle f, f \rangle} \text{ and } ||f||_\infty = \max_{g \in G} |f(g)|.$$
+ (11)
+
+**Definition 2.1** (Fourier Transform). If f be a function in L(G), then its Fourier transform is a function  $FT: L(G) \to L(G)$  defined as  $FT(f) = \hat{f}$ , where
+
+$$\hat{f}(g) \coloneqq \langle f, \chi_g \rangle \ \forall \ g \in G.$$
+
+The significance of representing a function  $f \in L(G)$  in the Fourier basis lies in its Fourier coefficient  $\hat{f}(g)$ . Each Fourier coefficient  $\hat{f}(g)$  quantifies the extent to which f correlates with the character  $\chi_g$ . The energy of the Fourier coefficient g is defined as  $|\hat{f}(g)|^2$  and the total energy of f is  $\sum_{g \in G} |\hat{f}(g)|^2$ . The total energy  $\sum_{g \in G} |\hat{f}(g)|^2$  is equal to the norm  $||f||_2^2$  (Parseval's Identity).
+
+**Definition 2.2** ( $\tau$ -Heavy Fourier Coefficients). Let f be a function in L(G),  $f = \sum_{g \in G} \hat{f}(g) \chi_g$  and let  $\tau$  be a positive real number. The coefficient  $\hat{f}(g)$  is  $\tau$ -heavy if  $|\hat{f}(g)|^2 \geq \tau$ . The set of all  $\tau$ -heavy Fourier coefficients of f is  $\text{Heavy}_{\tau}(f) \coloneqq \{g \in G : |\hat{f}(g)|^2 \geq \tau\}$ . The word  $\tau$ -significant Fourier coefficient is synonymously used for the  $\tau$ -heavy Fourier coefficient.
+
+In the year 2008, Akavia proposed an algorithm [Aka08], to learn those characters that are close to f in terms of  $\ell_2$  norm. Akavia proved that if the query access of the function f is given, it is possible to find all  $g \in G$  such that  $|\hat{f}(g)|^2$  is significantly large.
+
+<span id="page-9-0"></span>**Theorem 2.2** (Significant Fourier Transform [Aka08, Theorem 3.3]). There is a probabilistic algorithm (SFT), which on input a threshold value  $\tau > 0$  and oracle access to a function  $f: G \to \mathbb{C}$  outputs a list of size at most  $2\|f\|_2^2/\tau$  of all  $\tau$ -heavy Fourier coefficients of f in polynomial time in  $\log |G|, 1/\tau, \|f\|_{\infty}$  with probability at least 2/3.
+
+Characters in finite abelian group  $R/\mathfrak{a}$ : Let R be the ring of integers of a number field K of degree n. For any non-zero ideal  $\mathfrak{a} \subseteq R$ , the quotient  $R/\mathfrak{a}$ , is a finite ring. We denote it as  $R_{\mathfrak{a}}$  for simplicity and when  $\mathfrak{a}$  is a principal ideal generated by an element  $a \in R$ , we write this quotient simply as  $R_a$ . Specifically, for any ideal  $\mathfrak{a}$ ,  $R_{\mathfrak{a}}$  forms a finite abelian group under ring addition. In our work, we require an explicit description of the characters of  $R_{\mathfrak{a}}$ . This is achieved in the following Lemma 2.8 below. For every non-zero proper ideal  $\mathfrak{a}$  of R, its norm satisfies  $(N(\mathfrak{a})) \subseteq \mathfrak{a}$ , and hence  $N(\mathfrak{a}) \in \mathfrak{a} \cap \mathbb{Z}$ . In particular, for any prime ideal  $\mathfrak{p}$ , there exists exactly one rational prime
+
+{10}------------------------------------------------
+
+p such that  $\mathfrak{p} \cap \mathbb{Z} = (p)$ . These algebraic properties facilitate the construction of characters over the finite quotient ring  $R_{\mathfrak{a}}$ .
+
+<span id="page-10-0"></span>**Lemma 2.8.** Let K be a number field of degree n with ring of integers R, and let  $\mathfrak{l} \subseteq R$  be an non-zero proper ideal. Then there is a positive integer  $\ell > 1$  such that for every  $\mathbf{a} \in R^d_{\mathfrak{l}}$  with  $d \geq 1$ , the map
+
+$$\chi_{\mathbf{a}}(\mathbf{x}) = \exp\left(\frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(\langle \mathbf{a}, \mathbf{x} \rangle \bmod \mathfrak{l})\right), \quad \mathbf{x} \in R_{\mathfrak{l}}^{d}$$
+(12)
+
+is a character of the finite abelian group  $R^d_{\mathfrak{l}}$ . Here  $\langle \cdot, \cdot \rangle$  mod  $\mathfrak{l}$  denotes the R-linear inner product modulo  $\mathfrak{l}$ , and  $\operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}: R_{\mathfrak{l}} \to \mathbb{Z}_{\ell}$  is the reduction of the field trace  $\operatorname{Tr}_{K/\mathbb{Q}}$  modulo  $\ell$ . When we consider an element  $a \in R_{\mathfrak{l}}$ , it means  $a \in R$  is representative of the coset  $a + \mathfrak{l} \in R_{\mathfrak{l}}$ . In particular, for any  $a \in R_{\mathfrak{l}}$ , the function
+
+$$\chi_a(x) = \exp\left(\frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(ax)\right), \text{ where } x \in R_{\mathfrak{l}},$$
+(13)
+
+is a character of the group  $R_{l}$ .
+
+For a function family  $(F, \chi)$  with input distribution supported on  $\operatorname{supp}(\chi) \subset R^d$ , two major properties, namely the onewayness and pseudorandomness, are widely studied. These notions are defined in the Section 2.2. Additionally, a third notion, called *predictability*, was originally proposed by Mol and Micciancio in their work [MM11], where the input distribution  $\chi$  was defined over  $\mathbb{Z}$ . We introduce a structured variant of this notion for function families over the ring of integers R by learning the characters over the finite abelian group of the form  $R^d_{\mathfrak{a}}$  for some ideal  $\mathfrak{a}$  of R. A probabilistic polynomial-time (PPT) algorithm  $\mathcal{P}$  that predicts the inner product  $\langle \mathbf{x}, \mathbf{r} \rangle$  mod  $\mathfrak{l}$ , where  $\mathbf{r} \leftarrow \mathcal{U}(R^d_{\mathfrak{l}})$  is an auxiliary input, is referred to as an  $\mathfrak{l}$ -predictor. The formal definition is given in the Definition 2.3, followed by two additional notions to quantify its quality: *accuracy* and *bias*. The former measures the success probability of the predictor, whereas the latter is a measure that depends on Fourier analytic methods for its evaluation.
+
+<span id="page-10-1"></span>**Definition 2.3** (1-predictor). Let R be number ring of the number field K of degree n and for any integer  $d \geq 1$ , consider any function family  $(F, \chi)$  with input distribution  $\chi$  over  $R^d$ . For a non-zero ideal  $\mathfrak{l} \subseteq R$ , an  $\mathfrak{l}$ -predictor  $\mathcal{P}$  is a PPT algorithm runs on input  $(f, y, \mathbf{r}) \in F \times Y \times R^d_{\mathfrak{l}}$  and returns a guess  $\mathcal{P}(f, y, \mathbf{r})$  in  $R_{\mathfrak{l}}$  for  $\langle \mathbf{r}, \mathbf{x} \rangle$  mod  $\mathfrak{l}$ . The error distribution of the  $\mathfrak{l}$ -predictor  $\mathcal{P}$  is defined as
+
+$$\mathcal{E}_{\mathfrak{l}}(\mathcal{P}) \coloneqq \left\{ \langle \mathbf{r}, \mathbf{x} \rangle - \mathcal{P}(f, f(\mathbf{x}), \mathbf{r}) \bmod \mathfrak{l} \mid f \leftarrow \mathcal{U}(F), \mathbf{x} \leftarrow \chi \ and \ \mathbf{r} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^d) \right\}. \tag{14}$$
+
+An  $\mathfrak{l}$ -predictor is said to be  $(t,\epsilon)$ -accurate if  $\Pr\left[0\leftarrow\mathcal{E}_{\mathfrak{l}}(\mathcal{P})\right]\geq \frac{1}{N(\mathfrak{l})}+\epsilon$ . The bias of an  $\mathfrak{l}$ -predictor  $\mathcal{P}$  is defined by the absolute value of the following expectation
+
+$$\underset{e \leftarrow \mathcal{E}_{\mathfrak{l}}(\mathcal{P})}{\mathbb{E}} \left[ \exp \left( -\frac{2\pi i}{\ell} \mathrm{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(e) \right) \right] = \underset{e \leftarrow \mathcal{E}_{\mathfrak{l}}(\mathcal{P})}{\mathbb{E}} \left[ \omega_{\ell}^{-\mathrm{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(e)} \right],$$
+
+where  $\omega_{\ell}$  is  $\ell$ -th primitive root of unity. An  $\mathfrak{l}$ -predictor is said to be  $(t, \epsilon)$ -biased if its bias is  $\epsilon$  and its running time is at most t. A family F that admits a  $(t, \epsilon)$ -accurate or  $(t, \epsilon)$ -biased  $\mathfrak{l}$ -predictor is called  $(t, \epsilon)$ -accurate or  $(t, \epsilon)$ -biased.
+
+The following Lemma 2.9 shows that for any prime ideal  $\mathfrak{p}$  of a number ring R, every  $\epsilon$ -accurate  $\mathfrak{p}$ -predictor is also  $\epsilon$ -biased. In other words, it suffices to bound the success probability of an  $\mathfrak{p}$ -predictor in order to achieve  $\epsilon$ -bias, when  $\mathfrak{p}$  is a prime.
+
+{11}------------------------------------------------
+
+<span id="page-11-0"></span>**Lemma 2.9.** Let R be the number ring of the number field K of degree n. Let  $(F,\chi)$  be a family function with input distribution  $\chi$  on  $R^d$ . For any prime ideal  $\mathfrak{p}$  of R, if  $(F,\chi)$  admits an  $(t,\epsilon)$ -accurate  $\mathfrak{p}$ -predictor, then  $(F,\chi)$  admits an  $(t,\epsilon)$ -biased  $\mathfrak{p}$ -predictor.
+
+Proof. Let  $\mathcal{P}$  be the  $(t, \epsilon)$ -accurate  $\mathfrak{p}$ -predictor for the function family  $(F, \chi)$ . We construct an  $(t, \epsilon)$ -biased  $\mathcal{P}'$ -predictor. The predictor  $\mathcal{P}'$  takes a random input  $(f, f(\mathbf{x}))$  from the distribution  $\mathcal{F}(F)$  and a hint  $\mathbf{r}$  uniformly at random from  $R^d_{\mathfrak{p}}$ . It predicts  $\langle \mathbf{r}, \mathbf{x} \rangle$  mod  $\mathfrak{p}$  by executing the following steps: select a random non-zero sample  $y \leftarrow \mathcal{U}(R^*_{\mathfrak{p}})$ , run the existing  $\mathfrak{p}$ -predictor on the input  $(f, f(\mathbf{x}), y\mathbf{r})$ , and output  $y^{-1}\mathcal{P}(f, f(\mathbf{x}), y\mathbf{r}) \in R_{\mathfrak{p}}$ . The error distribution of  $\mathcal{P}'$  is defined as
+
+$$\mathcal{E}_{\mathfrak{p}}(\mathcal{P}') = \left\{ \mathcal{P}'(f, f(\mathbf{x}), \mathbf{r}) - \langle \mathbf{r}, \mathbf{x} \rangle \bmod \mathfrak{p} \mid (f, f(\mathbf{x})) \leftarrow \mathcal{F}(F, \chi) \text{ and } \mathbf{r} \leftarrow \mathcal{U}(R^d_{\mathfrak{p}}) \right\},$$
+
+which is equivalent to  $\{\mathcal{P}(f, f(\mathbf{x}), y\mathbf{r}) - y\langle \mathbf{r}, \mathbf{x}\rangle \bmod \mathfrak{p} \mid (f, f(\mathbf{x})) \leftarrow \mathcal{F}(F, \chi) \text{ and } \mathbf{r} \leftarrow \mathcal{U}(R_{\mathfrak{p}}^d)\}$ . For the prime ideal  $\mathfrak{p}$ , let p be the unique positive integer such that  $\mathfrak{p} \cap \mathbb{Z} = p\mathbb{Z}$ . The bias of  $\mathcal{P}'$  is then defined as
+
+<span id="page-11-1"></span>
+$$\mathbb{E}_{e \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}')} \left[ \omega_p^{-\operatorname{Tr}_{R_{\mathfrak{p}}/\mathbb{Z}_p}(e)} \right] = \sum_{e \in R_{\mathfrak{p}}} \operatorname{Pr} \left[ e \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}') \right] \omega_p^{-\operatorname{Tr}_{R_{\mathfrak{p}}/\mathbb{Z}_p}(e)}. \tag{15}$$
+
+For  $e \in R_{\mathfrak{p}}$ , and considering the uniform randomness of  $y \in R_{\mathfrak{p}}^*$ , the probability of error e is
+
+$$\Pr\left[e \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}')\right] = \Pr\left[e = \langle \mathbf{r}, \mathbf{x} \rangle - \mathcal{P}(f, f(\mathbf{x}), y\mathbf{r})y^{-1} \bmod qR\right]$$
+$$= \Pr\left[ye = \langle y\mathbf{r}, \mathbf{x} \rangle - \mathcal{P}(f, f(\mathbf{x}), y\mathbf{r}) \bmod qR\right]$$
+
+In particular, for the case e=0 in  $R_{\mathfrak{p}}$ , we can apply the accuracy bound of the  $\mathfrak{p}$ -predictor to conclude:
+
+$$\Pr\left[0 \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}')\right] = \Pr\left[\langle y\mathbf{r}, \mathbf{x} \rangle = \mathcal{P}(f, f(\mathbf{x}), y\mathbf{r}) \bmod qR\right] = \left(\frac{1}{\mathrm{N}(\mathfrak{p})} + \epsilon\right)$$
+
+For the remaining cases, i.e., when  $e \in R_{\mathfrak{p}}^*$ , we compute the probability:
+
+$$\Pr\left[e \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}')\right] = \Pr\left[y = (\langle y\mathbf{r}, \mathbf{x} \rangle - \mathcal{P}(f, f(\mathbf{x}), y\mathbf{r}))e^{-1} \bmod qR\right]$$
+
+$$= \frac{1}{N(\mathfrak{p}) - 1} \left\{1 - \Pr\left[\langle y\mathbf{r}, \mathbf{x} \rangle = \mathcal{P}(f, f(\mathbf{x}), y\mathbf{r}) \bmod qR\right]\right\}$$
+
+$$= \frac{1}{N(\mathfrak{p}) - 1} \left\{1 - \left(\frac{1}{N(\mathfrak{p})} + \epsilon\right)\right\} = \frac{1}{N(\mathfrak{p})} - \frac{\epsilon}{N(\mathfrak{p}) - 1}.$$
+
+Incorporating both obtained probability values into Equation 15, we obtain the bias:
+
+$$\mathbb{E}_{e \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}')} \left[ \omega_{p}^{-\operatorname{Tr}_{R_{\mathfrak{p}}/\mathbb{Z}_{p}}(e)} \right] = \left( \frac{1}{\mathrm{N}(\mathfrak{p})} + \epsilon \right) + \sum_{e \in R_{\mathfrak{p}}^{*}} \left( \frac{1}{\mathrm{N}(\mathfrak{p})} - \frac{\epsilon}{\mathrm{N}(\mathfrak{p}) - 1} \right) \omega_{p}^{-\operatorname{Tr}_{R_{\mathfrak{p}}/\mathbb{Z}_{p}}(e)} \\
+= \left( \frac{1}{\mathrm{N}(\mathfrak{p})} + \epsilon \right) + \left( \frac{1}{\mathrm{N}(\mathfrak{p})} - \frac{\epsilon}{\mathrm{N}(\mathfrak{p}) - 1} \right) \sum_{e \in R_{\mathfrak{p}}^{*}} \omega_{p}^{-\operatorname{Tr}_{(R/\mathfrak{p})/\mathbb{Z}_{p}}(e)}.$$
+
+The character sum identity given by Lemma 2.7 states that  $\sum_{e \in R_{\mathfrak{p}}} \omega_p^{-\operatorname{Tr}_{R_{\mathfrak{p}}/\mathbb{Z}_p}(e)} = 0$ . Using this, we find the magnitude of the bias:
+
+$$\left| \underset{e \leftarrow \mathcal{E}_{\mathfrak{p}}(\mathcal{P}')}{\mathbb{E}} \left[ \omega_p^{-\operatorname{Tr}_{R_{\mathfrak{p}}/\mathbb{Z}_p}(e)} \right] \right| = \left| \frac{\epsilon \mathrm{N}(\mathfrak{p})}{\mathrm{N}(\mathfrak{p}) - 1} \right| \ge \epsilon$$
+
+{12}------------------------------------------------
+
+Thus, for any prime ideal p of R, it is proved that if (F, χ) admits an (t, ϵ)-accurate p-predictor, then (F, χ) admits an (t, ϵ)-biased p-predictor.
+
+## 3 Pseudorandomness of Knapsack Functions
+
+In this section, we formalise the relationship between the search and decision variants of the bounded Knapsack family. This yields a parameter-preserving hardness implication from search MLWE to decision MLWE, including preservation of the number of samples. In the classical setting [\[MM11\]](#page-19-0), the pseudorandomness of a polynomial number of folded Knapsack instances K<sup>d</sup> for d < s (s is bound of secret) suffices to guarantee the pseudorandomness of the underlying Knapsack family K. In the module setting, however, these pseudorandomness assumptions alone are insufficient due to inherent structural limitations, as discussed in Subsection [3.2.](#page-14-0) Accordingly, our analysis additionally assumes the existence of at least one ideal d with polynomially bounded norm for which the folded family K<sup>d</sup> is distinguishable with noticeable advantage.
+
+<span id="page-12-0"></span>Theorem 3.1. Let K be a number field of degree n with ring of integers R. Let χ be a distribution supported on S d <sup>η</sup> ⊂ R<sup>d</sup> for some d ≥ 1 and parameter η = poly(n), and let q be a positive integer with associated quotient ring Rq. Consider the knapsack function family K(n, q, d, χ).
+
+Assume that K(n, q, d, χ) is one-way, and that for every ideal d dividing qR with N(d) < η, the folded family K<sup>d</sup> is pseudorandom. Furthermore, suppose that there exists an ideal d dividing qR such that η ≤ N(d) ≤ b(n) and K<sup>d</sup> is δ ′ -distinguishable, where b(n) = poly(η, d). Then the Knapsack function family K(n, q, d, χ) is pseudorandom.
+
+The proof of the Theorem [3.1](#page-12-0) requires an intermediate notion called predictability (and unpredictability), which is given in the Definition [2.3.](#page-10-1) The proof of Theorem [3.1](#page-12-0) is divided into two parts. In the first part (Section [3.1\)](#page-12-1), we show that any predictor for K can be efficiently transformed into an inverter for K. This step relies on the Fourier-analytic techniques and applies to the Knapsack family with input distribution χ over the module R<sup>d</sup> of rank d. In the second part (Section [3.2\)](#page-15-0), we show that if there is a distinguisher for K and folded Knapsacks K<sup>d</sup> (for small norm ideals d) are pseudorandom, then there must exist a predictor for K.
+
+### 3.1 Onewayness to Unpredictability
+
+In Proposition [3.1,](#page-12-1) we follow the reduction framework introduced by Micciancio and Mol [\[MM11\]](#page-19-0) to relate predictability to invertibility. Specifically, we show that the existence of a predictor with non-negligible bias implies the existence of an efficient inverter for the Knapsack function family K(n, q, d, χ). While the proof is instantiated for the Knapsack family, the reduction itself applies more generally to arbitrary function families (F, χ); in particular, the construction of the oracle required by the SFT algorithm, the running-time analysis, and the derivation of the advantage bound follow the same structure as in the classical setting. However, extending this reduction to structured settings over the ring of integers R requires additional care. In particular, we generalise the notion of an l-predictor to arbitrary ideals of R, which necessitates a corresponding adaptation of the oracle queried by the SFT algorithm.
+
+<span id="page-12-1"></span>Proposition 3.1 (One-wayness to Unpredictability). Let K be a number field of degree n with its ring of integers R and for positive integer q > 0, consider the knapsack function family K = K(n, q, d, χ) with input distribution χ over S d <sup>η</sup> ⊂ R<sup>d</sup> . If K is (t, ϵ, N(l))-biased for some ideal l of R with N(l) ≥ η, then K is poly n, logN(l), 1 ϵ 2 · t, ϵ/3 -invertible.
+
+{13}------------------------------------------------
+
+Proof. Assume that  $\mathcal{P}$  be a  $(t,\epsilon)$ -biased  $\mathfrak{l}$ -predictor for the function family  $\mathcal{K}$ . We use this  $\mathfrak{l}$ -predictor to construct an inverter  $\mathcal{I}$  to recover the secret  $\mathbf{x}$  in  $S_{\eta}^d$  from a random sample  $(\mathbf{g},y)$  of the function family  $\mathcal{K}$  such that  $y=\langle \mathbf{g},\mathbf{x}\rangle \mod qR$ . The SFT 2.2 algorithm outputs a short list of candidate solutions, and with high probability, one of these candidates will be the solution for the inverter  $\mathcal{I}$ . In order to run the SFT, inverter  $\mathcal{I}$  needs to answers the queries  $\mathbf{a}\in R_{\mathfrak{l}}^d$  made by SFT. Hence, the goal is to construct an oracle  $\Psi_{\mathbf{x}}\colon R_{\mathfrak{l}}^d\to\mathbb{C}$  for SFT, which is highly correlated with the character  $\chi_{\mathbf{x}}$ , so that SFT includes  $\mathbf{x}$  in the list of significant Fourier coefficients. The detailed construction of the inverter  $\mathcal{I}$  is as follows. Assume the inverter  $\mathcal{I}$  is given sample  $(\mathbf{g},y)$ , where  $\mathbf{g}$  is chosen uniformly at random from  $R_q^d$  and  $y=\langle \mathbf{g},\mathbf{x}\rangle \mod qR$  for some  $\mathbf{x}\leftarrow\chi$ . Then the inverter  $\mathcal{I}$  picks a random string using its coins and runs the SFT algorithm with a threshold value  $\tau=\epsilon^2/4$ . For every query  $\mathbf{a}\in R_{\mathfrak{l}}^d$  made by SFT, the inverter  $\mathcal{I}$  calls the predictor  $\mathcal{P}$  on input  $(f,y,\mathbf{a};\mathrm{coins})$  and returns  $\exp\left(\frac{2\pi i}{\ell}\mathrm{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(\mathcal{P}(f,y,\mathbf{a};\mathrm{coins}))\right)\in S^1$ . Since the coins are the same for all queries made by SFT, the answer is given by the deterministic function  $\Psi_{\mathbf{x}}\colon R_{\mathfrak{l}}^d\to\mathbb{C}$  defined as
+
+<span id="page-13-0"></span>
+$$\Psi_{\mathbf{x}}(\mathbf{a}) = \exp\left(\frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}} \left(\mathcal{P}(f, y, \mathbf{a}; \operatorname{coins})\right)\right) \text{ for all } \mathbf{a} \in R_{\mathfrak{l}}^{d}.$$
+ (16)
+
+Then the SFT outputs a finite list L of  $\epsilon^2/4$ -significant Fourier coefficients. Finally the inverter  $\mathcal{I}$  search  $\mathbf{x} \in L$  such that  $y = \langle \mathbf{g}, \mathbf{x} \rangle \mod qR$ . If  $y = \langle \mathbf{g}, \mathbf{x} \rangle \mod qR$  for some  $\mathbf{x} \in L$  then outputs  $\mathbf{x}$  otherwise, it fails. Note that, if more than one  $\mathbf{x} \in L$  satisfies  $y = \langle \mathbf{g}, \mathbf{x} \rangle \mod qR$ , then  $\mathcal{I}$  selects randomly one of them. For correctness, assume  $\mathcal{P}$  be the imperfect predictor for  $\mathcal{K}$ , so there are some errors with non-zero probability. Then for each query  $\mathbf{a} \in R^d_{\mathfrak{l}}$ , predictor  $\mathcal{P}$  outputs  $\langle \mathbf{a}, \mathbf{x} \rangle + e \mod \mathfrak{l}$ . Assume that the response to a query  $\mathbf{a}$  is perturbed by an independently sampled small error  $e \in R$ . So, invoking this into the Equation 16, we have
+
+$$\Psi_{\mathbf{x}}(\mathbf{a}) = \exp\left(\frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(\langle \mathbf{a}, \mathbf{x} \rangle + e \bmod \mathfrak{l})\right). \tag{17}$$
+
+The Fourier coefficient of  $\Psi_{\mathbf{x}}$  at  $\mathbf{v} \in R^d_{\mathfrak{l}}$  is
+
+<span id="page-13-1"></span>
+$$\hat{\Psi}_{\mathbf{x}}(\mathbf{v}) = \underset{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^d)}{\mathbb{E}} \left[ \Psi_{\mathbf{x}}(\mathbf{a}) \cdot \overline{\chi_{\mathbf{v}}(\mathbf{a})} \right]. \tag{18}$$
+
+Consider a function  $\phi: R_{\mathfrak{l}} \to S^1$  such that  $a \mapsto \exp(\frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(a))$ , which is a character over  $R_{\mathfrak{l}}$ . Then invoking this function and using the property  $\overline{\phi(x)} = \phi(-x)$  into Equation 18, we have
+
+$$\begin{split} \hat{\Psi}_{\mathbf{x}}(\mathbf{v}) &= \underset{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^{d})}{\mathbb{E}} \left[ \phi(\langle \mathbf{a}, \mathbf{x} - \mathbf{v} \rangle \bmod \mathfrak{l} + e) \right] \\ &= \underset{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^{d})}{\mathbb{E}} \left[ \phi(\langle \mathbf{a}, \mathbf{x} - \mathbf{v} \rangle \bmod \mathfrak{l}) \right] \underset{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^{d})}{\mathbb{E}} \left[ \phi(e) \right]. \end{split}$$
+
+Assume  $\mathbf{u} = \mathbf{x} - \mathbf{v} \in R^d_{\mathfrak{l}}$ , then for any  $\mathbf{a}$  in  $R^d_{\mathfrak{l}}$ ,  $\langle \mathbf{a}, \mathbf{u} \rangle$  mod  $\mathfrak{l}$  is contained in  $R_{\mathfrak{l}}$  and  $\operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(\langle \mathbf{a}, \mathbf{u} \rangle \mod \mathfrak{l}) = \sum_{i=1}^d \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(a_i u_i)$ , which implies
+
+$$\mathbb{E}_{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^{d})} \left[ \phi \left( \langle \mathbf{a}, \mathbf{x} - \mathbf{v} \rangle \bmod \mathfrak{l} \right) \right] = \mathbb{E}_{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^{d})} \left[ \omega_{\ell}^{\sum_{i=1}^{d} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(a_{i}u_{i})} \right] = \prod_{i=1}^{d} \frac{1}{\mathrm{N}(\mathfrak{l})} \sum_{a_{i} \in R_{\mathfrak{l}}} \chi_{u_{i}}(a_{i}).$$
+
+Consider the case, when **u** is non-zero, then there is one non-zero  $u_i \in R_{\mathfrak{l}}$  i.e., the corresponding
+
+{14}------------------------------------------------
+
+character  $\chi_{u_i}$  is non-trivial. So by the Lemma 2.7, we have
+
+$$\sum_{a_i \in R_{\mathfrak{l}}} \chi_{u_i}(a_i) = 0.$$
+
+Thus for all  $\mathbf{v} \neq \mathbf{x}$ , the Fourier coefficient  $\hat{\Psi}_{\mathbf{x}}(\mathbf{v})$  is zero. Otherwise,
+
+$$\hat{\Psi}_{\mathbf{x}}(\mathbf{x}) = \underset{\mathbf{a} \leftarrow \mathcal{U}(R_{\mathfrak{l}}^{d})}{\mathbb{E}} \left[ \phi\left(e\right) \right] = \underset{e \leftarrow \mathcal{E}_{\mathfrak{l}}(\mathcal{P})}{\mathbb{E}} \left[ \exp\left(\frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(e)\right) \right]$$
+
+Now, we show that  $|\hat{\Psi}_{\mathbf{x}}(\mathbf{x})| \geq \epsilon/2$  with decent non-negligible probability, accounting for the randomness of f,  $\mathbf{x}$  and coins. Subsequently, we analyse the success probability of the inverter  $\mathcal{I}$ . So by Jensen's inequality  $|\mathbb{E}[z]| \geq \mathbb{E}[|z|]$ , we have
+
+$$\mathbb{E}_{f, \mathbf{x}, \text{coins}} \left[ \left| \hat{\Psi}_{\mathbf{x}}(\mathbf{x}) \right| \right] \ge \left| \mathbb{E}_{f, \mathbf{x}, \text{coins}} \left[ \hat{\Psi}_{\mathbf{x}}(\mathbf{x}) \right] \right| = \left| \mathbb{E}_{e \leftarrow \mathcal{E}_{\mathfrak{l}}(\mathcal{P})} \left[ \exp \left( \frac{2\pi i}{\ell} \operatorname{Tr}_{R_{\mathfrak{l}}/\mathbb{Z}_{\ell}}(e) \right) \right] \right| = \epsilon$$
+
+Thus the expected magnitude of the Fourier coefficient  $\hat{\Psi}_{\mathbf{x}}(\mathbf{x})$  accounting for the randomness of f,  $\mathbf{x}$  and coins is at least  $\epsilon$ . Further, one can compute
+
+$$\Pr_{f, \mathbf{x}, \text{coins}} \left[ \left| \hat{\varPsi}_{\mathbf{x}}(\mathbf{x}) \right| \ge \frac{\epsilon}{2} \right] = 1 - \Pr_{f, \mathbf{x}, \text{coins}} \left[ \left| \hat{\varPsi}_{\mathbf{x}}(\mathbf{x}) \right| < \frac{\epsilon}{2} \right] = 1 - \Pr_{f, \mathbf{x}, \text{coins}} \left[ 1 - \left| \hat{\varPsi}_{\mathbf{x}}(\mathbf{x}) \right| \ge 1 - \frac{\epsilon}{2} \right].$$
+
+Employing Markov's inequality, we have
+
+$$\Pr_{f, \mathbf{x}, \text{coins}} \left[ 1 - \left| \hat{\Psi}_{\mathbf{x}}(\mathbf{x}) \right| \ge 1 - \frac{\epsilon}{2} \right] \le \frac{\mathbb{E}_{f, \mathbf{x}, \text{coins}} \left[ 1 - \left| \hat{\Psi}_{\mathbf{x}}(\mathbf{x}) \right| \right]}{1 - \frac{\epsilon}{2}} \le \frac{1 - \epsilon}{1 - \frac{\epsilon}{2}}.$$
+
+Finally, we obtain the desired result
+
+$$\Pr_{f, \mathbf{x}, \text{coins}} \left[ \left| \hat{\Psi}_{\mathbf{x}}(\mathbf{x}) \right| \ge \frac{\epsilon}{2} \right] \ge 1 - \frac{1 - \epsilon}{1 - \frac{\epsilon}{2}} \ge \frac{\epsilon}{2}.$$
+
+Therefore,  $|\hat{\Psi}_{\mathbf{x}}(\mathbf{x})| \geq \epsilon/2$  with probability at least  $\epsilon/2$ , accounting for the randomness of f,  $\mathbf{x}$  and the algorithm's random coins. Consequently, the  $\epsilon^2/4$ -significant list L output by SFT contains  $\mathbf{x}$  with probability at least  $\epsilon/2$ . To analyse the success probability of the inverter  $\mathcal{I}$  consider two events: first one is  $\{\mathbf{x} \in L\}$  i.e., true preimage  $\mathbf{x}$  appears in L and second one is the inverter succeeding i.e.,  $\{f(\mathcal{I}(f, f(\mathbf{x}))) = f(\mathbf{x})\}$ . If  $\mathbf{x} \in L$  then at least  $\mathbf{x}$  is contained in  $\{f(\mathcal{I}(f, f(\mathbf{x}))) = f(\mathbf{x})\}$ . As a result,  $\Pr[f(\mathcal{I}(f, f(\mathbf{x}))) = f(\mathbf{x})] \geq \Pr[\mathbf{x} \in L] \geq \frac{\epsilon}{2} \cdot \frac{2}{3} = \frac{\epsilon}{3}$ . Computational time of the inverter  $\mathcal{I}$  is bounded above by the running time of SFT times the time taken by  $\mathfrak{I}$ -predictor  $\mathcal{P}$ . Since  $\|\mathcal{\Psi}_{\mathbf{x}}\|_{\infty} = 1$  and  $|R_{\mathfrak{I}}| = \mathbb{N}(\mathfrak{l})$ , the overall running time of  $\mathcal{I}$  is poly  $(d \log \mathbb{N}(\mathfrak{l}), 1/\tau) \cdot t$ . Since  $d = \operatorname{poly}(n)$  and  $1/\tau = \mathbb{O}(\frac{1}{\epsilon^2})$ , asymptotically it is  $\operatorname{poly}(n, \log \mathbb{N}(\mathfrak{l}), \frac{1}{\epsilon^2}) \cdot t$ .
+
+### <span id="page-14-0"></span>3.2 Unpredictability to Pseudorandomness
+
+The classical work by Micciancio and Mol [MM11] proved the pseudorandomness of Knapsack family  $\mathcal{K} = \mathcal{K}(G,\chi)$ . This work introduced a reduction (Proposition 3.7 of the paper [MM11]) which is followed by an improved reduction (Proposition 3.9 of the paper [MM11]). In this case the set G is any finite Abelian group. Proposition 3.7 of the paper [MM11]) shows that, if a knapsack
+
+{15}------------------------------------------------
+
+family  $\mathcal{K} = \mathcal{K}(G,\chi)$ , with  $\operatorname{supp}(\chi) \subseteq [s]^m$  for  $s = \operatorname{poly}(n)$ , can be distinguished from uniform with noticeable advantage  $\delta$ , then this distinguishability induces a detectable bias. Specifically, assuming that all folded variants  $\mathcal{K}_d$  remain pseudorandom for dimensions  $d < 2ms^2$ , one can transform the distinguisher into a predictor running in time O(t+m) that achieves noticeable bias  $\varepsilon$  modulo any prime p with  $s \leq p < 2s$ . Next the Proposition 3.9 of the same paper [MM11] relaxed the bound to d < s, to ensure the pseudorandomness of  $\mathcal{K}$ . It states if a knapsack function family  $\mathcal{K}$  is distinguishable from the uniform distribution with noticeable advantage, while all its low-dimensional projections  $F_d(\mathcal{K})$  for d < s remain pseudorandom, then this distinguishing advantage must induce a noticeable bias in some higher-dimensional projection of dimension  $d^* \geq s$ , where  $d^*$  is polynomially bounded.
+
+The construction of an efficient prime  $\mathfrak{p}$ -predictor with noticeable bias from an imperfect distinguisher for the module Knapsack function family  $\mathcal{K} = \mathcal{K}(n,q,d,\chi)$  encounters certain structural limitations. Consequently, under the assumption that all folded variants  $\mathcal{K}_{\mathfrak{d}}$  with  $N(\mathfrak{d}) \leq 2^{O(n)}$  are pseudorandom, one can nevertheless obtain an efficient prime  $\mathfrak{p}$ -predictor whose bias is negligible in n. The detailed analysis is in Appendix A.1 Accordingly, in this work the reduction stated in Proposition 3.2 holds, under a critical parameter assumption, such as at least one folded instance  $\mathcal{K}_{\mathfrak{d}}$  is distinguishable for some ideal  $\mathfrak{d}$  whose norm is bounded by  $\operatorname{poly}(n)$ . In the absence of such a distinguisher, the construction of an  $\mathfrak{l}$ -predictor with non-negligible bias from an imperfect distinguisher does not seem achievable within Micciancio-Mol's framework. For the analysis of Algorithm 1, we further require an inequality concerning the generalised Euler totient function, stated in Lemma 2.2.
+
+<span id="page-15-0"></span>**Proposition 3.2.** Let K be a number field of degree n with ring of integers R. Let q, m be two positive integers and consider an input distribution  $\chi$  on  $S_{\eta}^d \subset R^d$ , where  $\eta$ , and d both are poly(n). If  $K = K(n, q, d, \chi)$  is  $(t, \delta)$ -distinguishable from uniform distribution on  $R_q^d \times R_q$ , but  $\mathcal{F}_{\mathfrak{d}}(K)$  is pseudorandom for all ideal  $\mathfrak{d}$  properly dividing qR with  $N(\mathfrak{d}) < \eta$ , and some  $K_{\mathfrak{d}}$  is  $\delta'$ -distinguishable for  $\eta \leq N(\mathfrak{d}) \leq b(n)$ , where  $b(n) = poly(\eta, d)$ . Then there is an ideal  $\mathfrak{m}$  with  $N(\mathfrak{m}) > \eta$ , the knapsack function family K is  $(O(t+m), \epsilon, N(\mathfrak{m}))$ -biased for some non-zero  $\epsilon > 0$ .
+
+Proof. Let  $\mathcal{D}$  be a  $(t, \delta)$  distinguisher of the Knapsack function family  $\mathcal{K}$  and let the probability  $\beta_{\mathfrak{d}} = \Pr\left[\mathcal{D}\left(\mathcal{F}_{\mathfrak{d}}(\mathcal{K})\right) = 1\right]$ . Note that the distribution  $\mathcal{F}_{qR}$  coincides with  $\mathcal{F}(\mathcal{K})$  and the distribution  $\mathcal{F}_{R}$  is uniform over  $R_q^d \times R_q$ . Therefore, we have  $|\beta_{qR} - \beta_{R}| = \delta$ , while for any proper divisor  $\mathfrak{d}$  of qR with  $N(\mathfrak{d}) < \eta$ , it holds that  $|\beta_{\mathfrak{d}} - \beta_{R}| = n^{-\omega(1)}$ . We assume that there is an ideal  $\mathfrak{d}'$  in R with  $\eta \leq N(\mathfrak{d}') \leq b(n)$  such that  $|\beta_{\mathfrak{d}'} - \beta_{R}| = \delta'$  for some positive real number  $\delta'$ . Define the collection of divisors  $\operatorname{Div}(\mathfrak{d}') = \{\mathfrak{d} \colon \mathfrak{d}' \subseteq \mathfrak{d} \text{ and } |\beta_{\mathfrak{d}} - \beta_{R}| \geq N(\mathfrak{d})^3 \delta'/N(\mathfrak{d}')^3 \}$ . This set is non-empty, because  $\operatorname{Div}(\mathfrak{d}')$  contains the ideal  $\mathfrak{d}'$ . By Zorn's lemma, there is a maximal element  $\mathfrak{m} \in \operatorname{Div}(\mathfrak{d}')$  such that  $\mathfrak{d} \subseteq \mathfrak{m}$  for all  $\mathfrak{d} \in \operatorname{Div}(\mathfrak{d}')$  and  $|\beta_{\mathfrak{m}} - \beta_{R}| \geq N(\mathfrak{m})^3 \delta'/N(\mathfrak{d}')^3$ . The ideal  $\mathfrak{m}$  has the following three properties:
+
+- 1.  $N(\mathfrak{m}) \geq \eta$ , because  $|\beta_{\mathfrak{m}} \beta_R|$  is at least  $N(\mathfrak{m})^3 \delta' / N(\mathfrak{d}')^3$ , which is non-zero.
+- 2.  $|\beta_{\mathfrak{d}} \beta_R| < N(\mathfrak{d})^3 \delta' / N(\mathfrak{d}')^3$  for each ideal  $\mathfrak{d}$  containing  $\mathfrak{m}$ .
+- 3. Let  $N_{\mathfrak{m}}$  be norm of the ideal  $\mathfrak{m}$ , then by Lemma 2.1, there is an element  $g \in R$  such that  $\mathfrak{m} = (N_{\mathfrak{m}}, g)$ .
+
+These properties allows us to construct the  $\mathfrak{m}$ -predictor  $\mathcal{P}$  for the knapsack family  $\mathcal{K}$  as described in the Algorithm 1 below.
+
+{16}------------------------------------------------
+
+#### Algorithm 1: m-predictor
+
+### <span id="page-16-0"></span>Input:
+
+1. 
+$$(\mathbf{a}, y) \leftarrow \mathcal{F}(\mathcal{K}) / / y = \langle \mathbf{a}, \mathbf{x} \rangle \mod qR$$
+  
+2.  $\mathbf{r} \xleftarrow{\$} R_{\mathfrak{m}}^d$ 
+
+Output: guess  $\in R_{\mathfrak{m}}$ 
+
+```
+[1] c \stackrel{\$}{\leftarrow} R_{\mathfrak{m}}
+
+[2] (a_1, a_2, a_3) \leftarrow \mathcal{U}(R_q^3)
+
+[3] \mathbf{a}' \leftarrow \mathbf{a} - a_1 \cdot \mathbf{r}
+
+[4] Run \mathcal{D} on input (\mathbf{a}', y - c \cdot a_1 + N_{\mathfrak{m}} \cdot a_2 + a_3 \cdot g)
+
+[5] if \mathcal{D} outputs 1 then
+
+[6] | guess \leftarrow c
+
+[7] end
+
+[8] else
+
+[9] | guess \stackrel{\$}{\leftarrow} R_{\mathfrak{m}} \setminus \{c\}
+
+[10] end
+
+[11] return guess
+```
+
+Let  $c' = \langle \mathbf{r}, \mathbf{x} \rangle = \sum_{i=1}^{m} r_i x_i$  be an element of R, where  $\|\mathbf{r}\|_{\infty} \leq N_{\mathfrak{m}} - 1$  and  $\|\mathbf{x}\|_{\infty} \leq \eta - 1$ . It is easy to see that the bound  $\|c'\|_{\infty} \leq d(\eta - 1)(N_{\mathfrak{m}} - 1)$  holds. The predictor proposed in the Algorithm 1 regenerates sample  $(\mathbf{a}', y - c \cdot a_1 + N_{\mathfrak{m}} \cdot a_2 + g \cdot a_3) \in R_q^d \times R_q$  from the challenge sample  $(\mathbf{a}, y)$  and query it to the distinguisher  $\mathcal{D}$ . Assume  $y' \in R_q$  be the second component of the input sample for  $\mathcal{D}$ , then we have
+
+$$y' = y - c \cdot a_1 + N_{\mathfrak{m}} \cdot a_2 + g \cdot a_3$$
+
+$$= \langle \mathbf{a}, \mathbf{x} \rangle + \underbrace{c'a_1 - c'a_1}_{=0} - ca_1 + N_{\mathfrak{m}}a_2 + ga_3$$
+
+$$= \underbrace{\langle \mathbf{a}, \mathbf{x} \rangle - \langle \mathbf{r}, \mathbf{x} \rangle a_1}_{=0} + (c' - c)a_1 + N_{\mathfrak{m}}a_2 + ga_3$$
+
+$$= \langle \mathbf{a} - a_1 \mathbf{r}, \mathbf{x} \rangle + (c' - c)a_1 + N_{\mathfrak{m}}a_2 + ga_3$$
+
+$$= \langle \mathbf{a}', \mathbf{x} \rangle + (c' - c)a_1 + N_{\mathfrak{m}}a_2 + ga_3$$
+
+$$= \langle \mathbf{a}', \mathbf{x} \rangle + (c' - c)a_1 + N_{\mathfrak{m}}a_2 + ga_3$$
+(19)
+
+By Lemma 2.5, the term  $(c'-c)a_1 + N_{\mathfrak{m}}a_2 + ga_3$  turns out to be a random sample of  $\mathfrak{d}$  mod qR, where  $\mathfrak{d} = \gcd_{qR}((c'-c)R, N_{\mathfrak{m}}R, gR)$ . More specifically,  $\mathfrak{d} = \gcd((c'-c)R, \mathfrak{m})$ . Hence  $(\mathbf{a}', y')$  is an random sample from the distribution  $\mathcal{F}_{\mathfrak{d}}(\mathcal{K})$  for some ideal  $\mathfrak{d} = \gcd((c'-c)R, \mathfrak{m})$  of R. For the input hint vector  $\mathbf{r}$  of the  $\mathfrak{m}$ -predictor  $\mathcal{P}$ , assume  $v \in R_{\mathfrak{m}}$  be the actual guess such that  $c' = \langle \mathbf{r}, \mathbf{x} \rangle \equiv v \mod \mathfrak{m}$ . If the initial guess c is same as actual guess v, i.e., c = v, the distinguisher  $\mathcal{D}$  is invoked random sample of  $\mathcal{F}_{\mathfrak{d}''}(\mathcal{K})$  and for the else case, i.e., if  $c \neq v$ , the distinguisher  $\mathcal{D}$  is given random sample of  $\mathcal{F}_{\mathfrak{d}''}$  for some ideal  $\mathfrak{d}'' = \gcd((c'-c)R, \mathfrak{m})$  which contains the ideal  $\mathfrak{m}$ , i.e., ideal  $\mathfrak{d}''$  divides  $\mathfrak{m}$ .
+
+The error distribution of the  $\mathfrak{m}$ -predictor is  $\Pr[\{\text{guess} \equiv v - e \mod \mathfrak{m} \colon e \in R_{\mathfrak{m}}\}]$ . Consider a disjoint and exhaustive family of events  $\{C_b\}_{b \in R_{\mathfrak{m}}}$ . For each  $b \in R_{\mathfrak{m}}$ , the event is defined as  $C_b := \{c \in R_{\mathfrak{m}} \colon c \equiv v - b \mod \mathfrak{m}\}$  i.e., each event  $C_b$  represents the initial guess c differs from the actual guess  $v \in R_{\mathfrak{m}}$  by  $b \mod \mathfrak{m}$  and  $\Pr[C_b] = 1/N_{\mathfrak{m}}$  for all  $b \in R_{\mathfrak{m}}$ . For each given event  $C_b$  for some  $b \in R_{\mathfrak{m}}$ , conditional probability  $\Pr[\mathrm{guess} \equiv v - e \mod \mathfrak{m} \mid C_b]$  is determined by the behaviour of the distinguisher  $\mathcal{D}$ . If  $\mathcal{D}$  outputs 1 with probability  $\beta_{\gcd(bR,\mathfrak{m})}$ ,  $\Pr[\mathrm{guess} \equiv v - e \mod \mathfrak{m} \mid C_b] =$ 
+
+{17}------------------------------------------------
+
+ $\delta_{be}\beta_{\gcd(bR,\mathfrak{m})}$ , where  $\delta_{be}=1$  if and only if b=e. Otherwise, the desired probability is
+
+$$\Pr\left[\text{guess} \equiv v - e \mod \mathfrak{m} \mid C_b\right] = \frac{(1 - \delta_{be})}{N_{\mathfrak{m}} - 1} \left(1 - \beta_{\gcd(bR,\mathfrak{m})}\right)$$
+
+The total probability of the event  $\Pr[\text{guess} \equiv v - e \mod \mathfrak{m}]$ , given  $C_b$ , is computed as follows.
+
+$$\Pr\left[\text{guess} \equiv v - e \mod \mathfrak{m} \mid C_b\right] = \delta_{be}\beta_{\gcd(bR,\mathfrak{m})} + \frac{(1 - \delta_{be})}{N_{\mathfrak{m}} - 1} \left(1 - \beta_{\gcd(bR,\mathfrak{m})}\right) \tag{20}$$
+
+Thus,
+
+$$\begin{split} \Pr_{e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P})}\left[e\right] &= \Pr_{e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P})}\left[\mathrm{guess} \equiv v - e \bmod \mathfrak{m}\right] \\ &= \sum_{b \in R_{\mathfrak{m}}} \Pr\left[\mathrm{guess} \equiv v - e \bmod \mathfrak{m} \mid C_b\right] \Pr\left[C_b\right] \\ &= \frac{1}{N_{\mathfrak{m}}} \sum_{b \in R_{\mathfrak{m}}} \Pr\left[\mathrm{guess} \equiv v - e \bmod \mathfrak{m} \mid C_b\right] \\ &= \frac{1}{N_{\mathfrak{m}}} \sum_{b \in R_{\mathfrak{m}}} \delta_{be} \beta_{\gcd(bR,\mathfrak{m})} + \frac{(1 - \delta_{be})}{N_{\mathfrak{m}} - 1} \left(1 - \beta_{\gcd(bR,\mathfrak{m})}\right) \\ &= \frac{1}{N_{\mathfrak{m}}} + \frac{1}{N_{\mathfrak{m}}} \beta_{\gcd(eR,\mathfrak{m})} - \frac{1}{N_{\mathfrak{m}}(N_{\mathfrak{m}} - 1)} \sum_{b \neq e} \beta_{\gcd(bR,\mathfrak{m})} \end{split}$$
+
+For the ideal  $\mathfrak{m}$ , there is an positive integer  $\ell$  such that  $\sum_{e \in R/\mathfrak{m}} \omega_{\ell}^{-\operatorname{Tr}_{R\mathfrak{m}/\mathbb{Z}_{\ell}}(e)} = 0$  by Lemma 2.7. We have,
+
+$$\mathbb{E}_{e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P})} \left[ \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)} \right] = \sum_{e \in R_{\mathfrak{m}}} \operatorname{Pr} \left[ e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P}) \right] \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)}$$
+
+$$= \sum_{e \in R_{\mathfrak{m}}} \left( \operatorname{Pr} \left[ e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P}) \right] - \operatorname{Pr} \left[ 1 \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P}) \right] \right) \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)}$$
+
+$$= \frac{1}{N_{\mathfrak{m}} - 1} \sum_{e \in R_{\mathfrak{m}}} \left( \beta_{\gcd(eR,\mathfrak{m})} - \beta_{\gcd(R,\mathfrak{m})} \right) \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)}$$
+
+Hence, one can write the following inequality
+
+<span id="page-17-0"></span>
+$$\left| \underset{e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P})}{\mathbb{E}} \left[ \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)} \right] \right| \ge \frac{1}{N_{\mathfrak{m}} - 1} \left\{ \left| \beta_{\mathfrak{m}} - \beta_{R} \right| - \sum_{e \neq 0} \left| \beta_{\gcd(eR,\mathfrak{m})} - \beta_{R} \right| \right\}. \tag{21}$$
+
+Invoking the Lemma 2.2, the second term of the right side of the above inequality (Eq. 21) can be written as
+
+$$\sum_{e\neq 0} \left| \beta_{\gcd(eR,\mathfrak{m})} - \beta_R \right| \leq \sum_{\mathfrak{m}\subsetneq \mathfrak{d}''} \sum_{\substack{\mathfrak{m}\subsetneq \mathfrak{d} \\ \gcd(\mathfrak{d},\mathfrak{m}) = \mathfrak{d}''}} \left| \beta_{\mathfrak{d}''} - \beta_R \right| = \sum_{\mathfrak{m}\subsetneq \mathfrak{d}''} \phi_{\mathfrak{d}''}(\mathfrak{m}) \left| \beta_{\mathfrak{d}''} - \beta_R \right| < \sum_{\mathfrak{m}\subsetneq \mathfrak{d}''} \frac{\mathrm{N}(\mathfrak{m})}{\mathrm{N}(\mathfrak{d}'')} \left| \beta_{\mathfrak{d}''} - \beta_R \right|.$$
+
+{18}------------------------------------------------
+
+Using the the second property of  $\mathfrak{m}$ , we have
+
+$$\sum_{e\neq 0} \left| \beta_{\gcd(eR,\mathfrak{m})} - \beta_R \right| < \sum_{\mathfrak{m}\subsetneq \mathfrak{d}''} \frac{\mathrm{N}(\mathfrak{m})}{\mathrm{N}(\mathfrak{d}'')} \left( \frac{\mathrm{N}(\mathfrak{d}'')}{\mathrm{N}(\mathfrak{d}')} \right)^3 \delta' = \frac{\mathrm{N}(\mathfrak{m})\delta'}{(\mathrm{N}(\mathfrak{d}'))^3} \sum_{\mathfrak{m}\subsetneq \mathfrak{d}''} \mathrm{N}(\mathfrak{d}'')^2.$$
+
+Finally, substituting this inequality in the inequality in Eq. 21 and utilising the first property of  $\mathfrak{m}$ , we get
+
+$$\left| \underset{e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P})}{\mathbb{E}} \left[ \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)} \right] \right| > \frac{1}{N_{\mathfrak{m}} - 1} \left\{ \left( \frac{\mathrm{N}(\mathfrak{m})}{\mathrm{N}(\mathfrak{d}')} \right)^{3} \delta' - \frac{\mathrm{N}(\mathfrak{m})\delta'}{(\mathrm{N}(\mathfrak{d}'))^{3}} \sum_{\mathfrak{m} \subsetneq \mathfrak{d}''} \mathrm{N}(\mathfrak{d}'')^{2} \right\}$$
+
+$$= \frac{N_{\mathfrak{m}}\delta'}{(N_{\mathfrak{m}} - 1)N_{\mathfrak{d}'}^{3}} \left\{ N_{\mathfrak{m}}^{2} - \sum_{\mathfrak{m} \subsetneq \mathfrak{d}''} N_{\mathfrak{d}''}^{2} \right\}.$$
+
+By Lemma 2.3, we have  $\sum_{\mathfrak{m} \subseteq \mathfrak{d}''} N_{\mathfrak{d}''}^2 \leq (\frac{\pi^2}{6} - 1) N_{\mathfrak{m}}^2$  and hence we have
+
+$$\left| \underset{e \leftarrow \mathcal{E}_{\mathfrak{m}}(\mathcal{P})}{\mathbb{E}} \left[ \omega_{\ell}^{-\operatorname{Tr}_{R_{\mathfrak{m}}/\mathbb{Z}_{\ell}}(e)} \right] \right| > \frac{N_{\mathfrak{m}}\delta'}{(N_{\mathfrak{m}}-1)N_{\mathfrak{d}'}^{3}} \left( 2 - \frac{\pi^{2}}{6} \right).$$
+
+Thus, we finally proved that the Knapsack function family  $\mathcal{K}$  is  $(O(t+m), \epsilon, N(\mathfrak{m}))$ -biased for some non-zero  $\epsilon > 0$ , where  $\epsilon = \frac{N_{\mathfrak{m}}\delta'}{(N_{\mathfrak{m}}-1)N_{\mathfrak{d}'}^3} \left(2 - \frac{\pi^2}{6}\right)$ .
+
+## 4 Conclusion
+
+In this work, we extend the framework of Micciancio and Mol to analyse the pseudorandomness of Knapsack distributions defined over arbitrary number fields. Our reduction shows that the construction of an  $\mathfrak{d}$ -predictor with non-negligible bias from a distinguisher requires the existence of at least one folded knapsack distribution  $\mathcal{K}_{\mathfrak{d}}$  whose norm satisfies  $N(\mathfrak{d}) \leq \operatorname{poly}(n)$  and is distinguishable. This requirement arises implicitly from the task of  $\mathfrak{d}$ -predictor, which we have defined. A natural question is whether a relaxed notion of the  $\mathfrak{d}$ -predictor could enable the construction of one with overwhelming bias from an imperfect distinguisher, potentially removing the additional assumption.
+
+## References
+
+- <span id="page-18-2"></span>[Aka08] Adi Akavia. Learning noisy characters, MPC, and cryptographic hardcore predicates. PhD thesis, Massachusetts Institute of Technology, Cambridge, MA, USA, 2008.
+- <span id="page-18-3"></span>[Con25] Keith Conrad. Characters of finite abelian groups. https://kconrad.math.uconn.edu/blurbs/grouptheory/charthy.pdf, 2025. Lecture notes, University of Connecticut.
+- <span id="page-18-0"></span>[IN96] Russell Impagliazzo and Moni Naor. Efficient cryptographic schemes provably as secure as subset sum. J. Cryptol., 9(4):199–216, 1996.
+- <span id="page-18-1"></span>[KM93] Eyal Kushilevitz and Yishay Mansour. Learning decision trees using the fourier spectrum. SIAM Journal on Computing, 22(6):1331–1348, 1993.
+
+{19}------------------------------------------------
+
+- <span id="page-19-2"></span>[LPR13] Vadim Lyubashevsky, Chris Peikert, and Oded Regev. On ideal lattices and learning with errors over rings.  $J.\ ACM,\ 60(6):43:1-43:35,\ 2013.$
+- <span id="page-19-3"></span>[Mig14] Celino Miguel. Menon's identity in residually finite dedekind domains.  $Journal\ of\ Number\ Theory,\ 137:179-185,\ 04\ 2014.$
+- <span id="page-19-0"></span>[MM11] Daniele Micciancio and Petros Mol. Pseudorandom knapsacks and the sample complexity of LWE search-to-decision reductions. *IACR Cryptol. ePrint Arch.*, page 521, 2011.
+- <span id="page-19-8"></span>[MOS03] Elchanan Mossel, Ryan O'Donnell, and Rocco P. Servedio. Learning juntas. In *Proceedings of the Thirty-Fifth Annual ACM Symposium on Theory of Computing*, STOC '03, page 206–212, New York, NY, USA, 2003. Association for Computing Machinery.
+- <span id="page-19-5"></span>[MR04] Daniele Micciancio and Oded Regev. Worst-case to average-case reductions based on gaussian measures. In 45th Symposium on Foundations of Computer Science, FOCS 2004, Rome, Italy, October 17-19, 2004, Proceedings, pages 372–381. IEEE Computer Society, 2004.
+- <span id="page-19-7"></span>[Pei08] Chris Peikert. Public-key cryptosystems from the worst-case shortest vector problem. Cryptology ePrint Archive, Paper 2008/481, 2008.
+- <span id="page-19-4"></span>[QFCZ12] Xiaolin Qin, Yong Feng, Jingwei Chen, and Jingzhong Zhang. A complete algorithm to find exact minimal polynomial by approximations. *International Journal of Computer Mathematics*, 89(17):2333–2344, 2012.
+- <span id="page-19-6"></span>[Reg09] Oded Regev. On lattices, learning with errors, random linear codes, and cryptography.  $J.\ ACM,\ 56(6):34:1-34:40,\ 2009.$
+- <span id="page-19-1"></span>[Ste12] William Stein. Algebraic number theory: A computational approach. https://wstein.org/books/ant/ant.pdf, 2012. Lecture notes, November 14, 2012.
+
+## A Appendix
+
+<span id="page-19-9"></span>Result A.1. Let K be a number field of degree n with ring of integers R, and let q, d be positive integers. Let  $\chi$  be a distribution supported on  $S_{\eta}^d \subset R^d$ , where  $\eta$  and d are both bounded by  $\operatorname{poly}(n)$ . Consider the associated knapsack function family  $K = K(n, q, d, \chi)$ , and assume  $B(n) := \exp(n \log d_K + O(n \log n))$ . Suppose that K is  $(t, \delta)$ -distinguishable from the uniform distribution over  $R_q^d \times R_q$ , and that for every nontrivial ideal  $\mathfrak d$  dividing qR with  $N(\mathfrak d) \leq B(n)$  the folded family  $K_{\mathfrak d}$  is pseudorandom. Then, for any prime ideal  $\mathfrak p$  satisfying  $\eta \leq N(\mathfrak p) \leq \operatorname{poly}(\eta, d)$ , the Knapsack family K admits an  $n^{-\omega(1)}$ -bias.
+
+Proof. Consider  $\mathcal{D}$  to be a  $(t, \delta)$  distinguisher of the knapsack family  $\mathcal{K}$ . Let the probability  $\beta_{\mathfrak{d}} = \Pr[\mathcal{D}(\mathcal{F}_{\mathfrak{d}}(\mathcal{K})) = 1]$ . Note that for ideal  $\mathfrak{d} = qR$  in R, the  $\mathcal{F}_{qR}$  turns out to be the Knapsack distribution  $\mathcal{F}(\mathcal{K})$  because  $qR \equiv 0 \mod qR$ . For the ideal  $\mathfrak{d} = R$  then the distribution  $\mathcal{F}_R$  turns out to be uniform over  $R_q^d \times R_q$ . Therefore  $|\beta_{qR} - \beta_R| = \delta$  and  $|\beta_{\mathfrak{d}} - \beta_R| = n^{-\omega(1)}$  for all  $\mathfrak{d}$  properly dividing qR with  $N(\mathfrak{d}) \leq B(n)$ . By the Lemma 2.4, there is a rational prime p and a monic irreducible polynomial  $g(x) \in \mathcal{F}_p[x]$  such that  $\mathfrak{p} = (p, g(x))$  and norm of the ideal  $\mathfrak{p}$  is  $p^{\deg(g)}$ .
+
+{20}------------------------------------------------
+
+#### **Algorithm 2:** p-predictor
+
+### <span id="page-20-0"></span>Input:
+
+1. 
+$$(\mathbf{a}, y) \leftarrow \mathcal{F}(\mathcal{K}) // y = \langle \mathbf{a}, \mathbf{x} \rangle \mod qR$$
+  
+2.  $\mathbf{r} \stackrel{\$}{\leftarrow} R_{\mathfrak{n}}^d$ 
+
+**Output:** guess  $v \in R_{\mathfrak{p}}$  such that  $c' = \langle \mathbf{r}, \mathbf{x} \rangle \equiv v \mod \mathfrak{p}$ 
+
+```
+[1] c \stackrel{\$}{\leftarrow} R/\langle d(\eta-1)p \rangle
+[2] a \stackrel{\$}{\leftarrow} R_q
+[3] \mathbf{a}' \leftarrow \mathbf{a} - a \cdot \mathbf{r}
+[4] Run \mathcal{D} on input (\mathbf{a}', y - c \cdot a)
+[5] if \mathcal{D} outputs 1 then
+[6] | guess \leftarrow c \mod \mathfrak{p}
+[7] end
+[8] else
+[9] | guess \stackrel{\$}{\leftarrow} R_{\mathfrak{p}} \setminus \{c \mod \mathfrak{p}\}
+[10] end
+[11] return guess
+```
+
+Let  $c' = \langle \mathbf{r}, \mathbf{x} \rangle = \sum_{i=1}^{d} r_i x_i$  is an element of R, where  $\|\mathbf{r}\|_{\infty} \leq p-1$  and  $\|\mathbf{x}\|_{\infty} \leq \eta-1$ , one readily observes that the bound  $\|c'\|_{\infty} \leq d(\eta-1)(p-1) < d(\eta-1)p$  holds. Since the predictor tries to predict  $v \equiv c' \mod \mathfrak{p}$ , the sample space for the guess should be the collection of all polynomials whose  $\ell_{\infty}$  norm is less than  $d(\eta-1)p$ . The predictor, given in the Algorithm 2, regenerates sample  $(\mathbf{a}', y-c\cdot a)$  from  $(\mathbf{a}, y)$ , where  $y-c\cdot a = \langle \mathbf{a}, \mathbf{x} \rangle \mod qR - c'\cdot a + c'\cdot a - c\cdot a = \langle \mathbf{a}', \mathbf{x} \rangle + (c'-c)\cdot a \mod qR$ . By the lemma 2.5 the distinguisher  $\mathcal{D}$  takes random input from  $\mathcal{F}_{\mathfrak{d}}(\mathcal{K})$ , where  $\mathfrak{d} = \gcd_{qR}(c'-c)$ .
+
+For an ideal  $\mathfrak{d} \subseteq R$ , define the event  $C_{\mathfrak{d}} = \{c' : \gcd((c'-c)R, qR) = \mathfrak{d}\}$ , i.e., the set of all samples whose difference from a fixed sample c has ideal  $\gcd$  equal to  $\mathfrak{d}$ . For any sample c', the ideal  $\gcd((c'-c)R, qR)$  is uniquely determined; hence every sample belongs to exactly one event  $C_{\mathfrak{d}}$  with  $\mathfrak{d} \mid qR$ . The uniqueness of the  $\gcd$  ensures that these events are mutually disjoint. In particular, for any two distinct ideals  $\mathfrak{d}$  and  $\mathfrak{d}'$  of R the events  $C_{\mathfrak{d}} \cap C_{\mathfrak{d}'} = \phi$ . Therefore the family  $\{C_{\mathfrak{d}}\}_{\mathfrak{d}\mid qR}$  forms a partition of the sample space. Conditioning on this partition, the probability of the event  $\{\gcd = v\}$  can be written as
+
+<span id="page-20-2"></span>
+$$\Pr\left[\text{guess} = v\right] = \sum_{\mathfrak{d}\mid qR} \Pr\left[\text{guess} = v \mid C_{\mathfrak{d}}\right] \Pr\left[C_{\mathfrak{d}}\right]. \tag{22}$$
+
+For each ideal  $\mathfrak{d}$  dividing qR, the conditional probability  $\Pr[\text{guess} = v \mid C_{\mathfrak{d}}]$  is determined by the behaviour of the distinguisher  $\mathcal{D}$ . Suppose  $\mathcal{D}$  outputs 1 with probability  $\beta_{\mathfrak{d}}$ . In this case, the 'guess' is assigned by  $c \mod \mathfrak{p}$  with some non-zero probability  $a_{\mathfrak{d}}$ , where  $a_{\mathfrak{d}}$  is probability of  $c' \equiv c \mod \mathfrak{p}$  whenever  $C_{\mathfrak{d}}$  is given i.e.,  $a_{\mathfrak{d}} = \Pr[c' \equiv c \mod \mathfrak{p} \mid C_{\mathfrak{d}}]$ . Otherwise, when the distinguisher  $\mathcal{D}$  outputs 0, the 'guess' is chosen uniformly at random from  $R_{\mathfrak{p}} \setminus \{c \mod \mathfrak{p}\}$ . As a result, the total condition probability is
+
+<span id="page-20-1"></span>
+$$\Pr\left[\text{guess} = v \mid C_{\mathfrak{d}}\right] = a_{\mathfrak{d}}\beta_{\mathfrak{d}} + \frac{1 - a_{\mathfrak{d}}}{N(\mathfrak{p}) - 1}(1 - \beta_{\mathfrak{d}}). \tag{23}$$
+
+{21}------------------------------------------------
+
+Thus by substituting Eq.(23) into Eq.(22), we have
+
+$$\Pr\left[\text{guess} = v\right] = \Pr\left[C_{qR}\right] \left\{ a_{qR} \beta_{qR} + (1 - \beta_{qR}) \frac{1 - a_{qR}}{N(\mathfrak{p}) - 1} \right\} + \sum_{\substack{\mathfrak{d} \mid qR \\ \mathfrak{d} \neq qR}} \Pr\left[C_{\mathfrak{d}}\right] \left\{ a_{\mathfrak{d}} \beta_{\mathfrak{d}} + (1 - \beta_{\mathfrak{d}}) \frac{1 - a_{\mathfrak{d}}}{N(\mathfrak{p}) - 1} \right\}$$
+
+The norm of any ideal  $\mathfrak{d}$  in R which divides (c'-c)R is bounded above by N((c'-c)R). Therefore, the probability of such events  $C_{\mathfrak{d}}$  with  $N(\mathfrak{d})$  is greater than N((c'-c)R) is zero. In particular,  $Pr[C_{\mathfrak{d}}]$  is zero for all proper divisor of qR and whose norm is bigger than the norm of (c'-c)R. The upper bound of the norm of (c'-c)R is derived below.
+
+$$N((c'-c)R) = |N_{K/\mathbb{Q}}(c'-c)| = \prod_{j=1}^{n} |\sigma_j(c'-c)| \le ||\sigma(c'-c)||_{\infty}^n \le d_K^n ||c'-c||_{\infty}^n$$
+
+Since, c and c' both belong to  $S_{d(\eta-1)p} \subset R$ , the maximum  $\ell_{\infty}$  norm of  $(c'-c) \in R$  is  $d(\eta-1)p$ . Consequently,  $N((c'-c)R) \leq B(n)$ . More precisely, for any proper divisor  $\mathfrak{d}$  of qR with  $N(\mathfrak{d}) > B(n)$  the probability of events  $C_{\mathfrak{d}}$  are zero. If  $\mathfrak{d} = qR$ , then the event  $C_{qR}$  consists of the single element c', because  $C_{qR} = \{c \in R : \gcd((c'-c)R, qR) = qR\}$ , which is possible only when  $c \equiv c' \mod qR$ . Hence, c' is the unique sample contained in  $C_{qR}$ . Thus in one hand  $\mathfrak{d} = qR$ ,  $\Pr[C_{qR}] = 1/N(\langle d(\eta-1)p \rangle)$ ,  $a_{qR} = 1$ , and  $\beta_{qR} = \beta_R + n^{-\omega(1)}$ . On the other hand  $\beta_{\mathfrak{d}} = \beta_R + \delta$  for all  $\mathfrak{d} \neq qR$ . Therefore the  $\Pr[\text{guess} = v]$  can be reduced to
+
+$$\Pr\left[\text{guess} = v\right] = \frac{\beta_R + \delta}{(d(\eta - 1)p)^n} + \left(\beta_R + n^{-\omega(1)}\right) \sum_{\substack{\mathfrak{d} \mid qR \\ \mathfrak{d} \neq qR}} a_{\mathfrak{d}} \Pr\left[C_{\mathfrak{d}}\right] + \frac{1 - \beta_R - n^{-\omega(1)}}{\mathrm{N}(\mathfrak{p}) - 1} \sum_{\substack{\mathfrak{d} \mid qR \\ \mathfrak{d} \neq qR}} (1 - a_{\mathfrak{d}}) \Pr\left[C_{\mathfrak{d}}\right]$$
+
+Finally invoking  $\sum_{\mathfrak{d}|qR} \Pr[C_{\mathfrak{d}}] = 1$  and  $\sum_{\mathfrak{d}|qR} a_{\mathfrak{d}} \Pr[C_{\mathfrak{d}}] = \Pr[c \equiv c' \mod \mathfrak{p}]$ , we obtain
+
+$$\Pr\left[\text{guess} = v\right] = \frac{\delta}{(d(\eta - 1)p)^n} + \frac{\beta_R}{N(\mathfrak{p})} + n^{-\omega(1)} \left(\frac{1}{N(\mathfrak{p})} - \frac{1}{(d(\eta - 1)p)^n}\right) + \frac{1 - \beta_R - n^{-\omega(1)}}{N(\mathfrak{p})}$$
+$$= \frac{\delta}{(d(\eta - 1)p)^n} - \frac{n^{-\omega(1)}}{(d(\eta - 1)p)^n} + \frac{1}{N(\mathfrak{p})} \ge \frac{1}{N(\mathfrak{p})} + \left(\frac{\delta}{(d(\eta - 1)p)^n} - n^{-\omega(1)}\right).$$
+
+Thus we have proved that the knapsack family  $\mathcal{K}$  is  $\epsilon$ -accurate for some  $\epsilon \geq \delta/(d(\eta-1)p)^n$ , which is  $n^{-\omega(1)}$ . Since  $\mathfrak{p}$  is prime ideal in R, by the Lemma 2.9, every  $\mathfrak{p}$  has  $n^{-\omega(1)}$ -bias.

--- a/data/markdown/eprint/2026_270/2026_270_meta.json
+++ b/data/markdown/eprint/2026_270/2026_270_meta.json
@@ -1,0 +1,1423 @@
+{
+  "table_of_contents": [
+    {
+      "title": "Pseudorandomness of Knapsacks over a Number Ring",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          119.89599609375,
+          112.53515625
+        ],
+        [
+          491.71417236328125,
+          112.53515625
+        ],
+        [
+          491.71417236328125,
+          130.47119140625
+        ],
+        [
+          119.89599609375,
+          130.47119140625
+        ]
+      ]
+    },
+    {
+      "title": "Abstract",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          282.69140625,
+          239.765625
+        ],
+        [
+          327.8874816894531,
+          239.765625
+        ],
+        [
+          327.8874816894531,
+          250.21649169921875
+        ],
+        [
+          282.69140625,
+          250.21649169921875
+        ]
+      ]
+    },
+    {
+      "title": "1 Introduction",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          71.419921875,
+          361.1129455566406
+        ],
+        [
+          184.97622680664062,
+          360.421875
+        ],
+        [
+          184.97622680664062,
+          375.4591369628906
+        ],
+        [
+          71.419921875,
+          375.4591369628906
+        ]
+      ]
+    },
+    {
+      "title": "2 Preliminaries",
+      "heading_level": null,
+      "page_id": 0,
+      "polygon": [
+        [
+          71.419921875,
+          636.6239776611328
+        ],
+        [
+          189.610107421875,
+          636.5390625
+        ],
+        [
+          189.610107421875,
+          650.9701690673828
+        ],
+        [
+          71.419921875,
+          650.9701690673828
+        ]
+      ]
+    },
+    {
+      "title": "2.1 Probabilities and Asymptotics",
+      "heading_level": null,
+      "page_id": 1,
+      "polygon": [
+        [
+          70.5,
+          282.69140625
+        ],
+        [
+          281.5,
+          281.14453125
+        ],
+        [
+          281.5,
+          293.0
+        ],
+        [
+          70.224609375,
+          294.29296875
+        ]
+      ]
+    },
+    {
+      "title": "2.2 Function Families",
+      "heading_level": null,
+      "page_id": 1,
+      "polygon": [
+        [
+          70.5,
+          478.0
+        ],
+        [
+          206.5,
+          476.82421875
+        ],
+        [
+          206.5,
+          488.0
+        ],
+        [
+          69.92578125,
+          488.0
+        ]
+      ]
+    },
+    {
+      "title": "2.3 Algebraic Number Theory",
+      "heading_level": null,
+      "page_id": 2,
+      "polygon": [
+        [
+          70.0,
+          305.0
+        ],
+        [
+          259.0,
+          303.57421875
+        ],
+        [
+          259.0,
+          315.5
+        ],
+        [
+          70.0,
+          316.72265625
+        ]
+      ]
+    },
+    {
+      "title": "2.4 Embeddings and Geometry of Numbers",
+      "heading_level": null,
+      "page_id": 2,
+      "polygon": [
+        [
+          70.5,
+          477.5
+        ],
+        [
+          337.0,
+          476.05078125
+        ],
+        [
+          337.0,
+          487.5
+        ],
+        [
+          70.5,
+          487.65234375
+        ]
+      ]
+    },
+    {
+      "title": "2.4.1 Modules, Ideals and Units",
+      "heading_level": null,
+      "page_id": 3,
+      "polygon": [
+        [
+          70.5,
+          441.6328125
+        ],
+        [
+          255.5,
+          440.0859375
+        ],
+        [
+          255.5,
+          451.5
+        ],
+        [
+          70.5,
+          451.5
+        ]
+      ]
+    },
+    {
+      "title": "2.5 Knapsack Functions Family",
+      "heading_level": null,
+      "page_id": 6,
+      "polygon": [
+        [
+          70.5,
+          352.30078125
+        ],
+        [
+          265.0,
+          350.75390625
+        ],
+        [
+          265.0,
+          363.5
+        ],
+        [
+          70.5,
+          363.90234375
+        ]
+      ]
+    },
+    {
+      "title": "2.6 Fourier Analysis and Learning",
+      "heading_level": null,
+      "page_id": 7,
+      "polygon": [
+        [
+          70.5,
+          627.64453125
+        ],
+        [
+          281.5,
+          626.09765625
+        ],
+        [
+          281.5,
+          639.0
+        ],
+        [
+          70.5,
+          639.24609375
+        ]
+      ]
+    },
+    {
+      "title": "2.6.1 Characters of Finite Abelian Group",
+      "heading_level": null,
+      "page_id": 8,
+      "polygon": [
+        [
+          70.5,
+          170.9296875
+        ],
+        [
+          308.0,
+          169.3828125
+        ],
+        [
+          308.0,
+          181.0
+        ],
+        [
+          70.5,
+          181.7578125
+        ]
+      ]
+    },
+    {
+      "title": "3 Pseudorandomness of Knapsack Functions",
+      "heading_level": null,
+      "page_id": 12,
+      "polygon": [
+        [
+          72.0,
+          119.66796875
+        ],
+        [
+          394.7894592285156,
+          118.72265625
+        ],
+        [
+          394.7894592285156,
+          134.01422119140625
+        ],
+        [
+          71.419921875,
+          134.01422119140625
+        ]
+      ]
+    },
+    {
+      "title": "3.1 Onewayness to Unpredictability",
+      "heading_level": null,
+      "page_id": 12,
+      "polygon": [
+        [
+          72.0,
+          491.1167907714844
+        ],
+        [
+          290.42156982421875,
+          489.97265625
+        ],
+        [
+          290.42156982421875,
+          503.0719909667969
+        ],
+        [
+          70.822265625,
+          503.12109375
+        ]
+      ]
+    },
+    {
+      "title": "3.2 Unpredictability to Pseudorandomness",
+      "heading_level": null,
+      "page_id": 14,
+      "polygon": [
+        [
+          70.5,
+          639.0
+        ],
+        [
+          332.0,
+          638.0859375
+        ],
+        [
+          332.0,
+          650.0
+        ],
+        [
+          70.5,
+          650.4609375
+        ]
+      ]
+    },
+    {
+      "title": "Algorithm 1: m-predictor",
+      "heading_level": null,
+      "page_id": 16,
+      "polygon": [
+        [
+          137.5,
+          76.18359375
+        ],
+        [
+          267.5,
+          76.18359375
+        ],
+        [
+          267.5,
+          87.0
+        ],
+        [
+          137.5,
+          87.0
+        ]
+      ]
+    },
+    {
+      "title": "Input:",
+      "heading_level": null,
+      "page_id": 16,
+      "polygon": [
+        [
+          166.74609375,
+          90.4921875
+        ],
+        [
+          204.0,
+          88.9453125
+        ],
+        [
+          204.0,
+          101.0
+        ],
+        [
+          165.55078125,
+          101.3203125
+        ]
+      ]
+    },
+    {
+      "title": "4 Conclusion",
+      "heading_level": null,
+      "page_id": 18,
+      "polygon": [
+        [
+          70.0,
+          392.5
+        ],
+        [
+          174.0,
+          391.74609375
+        ],
+        [
+          173.5,
+          407.0
+        ],
+        [
+          70.0,
+          406.0
+        ]
+      ]
+    },
+    {
+      "title": "References",
+      "heading_level": null,
+      "page_id": 18,
+      "polygon": [
+        [
+          70.0,
+          547.5
+        ],
+        [
+          147.0,
+          546.046875
+        ],
+        [
+          147.0,
+          560.0
+        ],
+        [
+          70.0,
+          560.0
+        ]
+      ]
+    },
+    {
+      "title": "A Appendix",
+      "heading_level": null,
+      "page_id": 19,
+      "polygon": [
+        [
+          70.0,
+          475.27734375
+        ],
+        [
+          169.5,
+          473.73046875
+        ],
+        [
+          169.5,
+          489.0
+        ],
+        [
+          70.0,
+          489.97265625
+        ]
+      ]
+    },
+    {
+      "title": "Algorithm 2: p-predictor",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          137.5,
+          77.5
+        ],
+        [
+          265.0,
+          76.18359375
+        ],
+        [
+          265.0,
+          87.5
+        ],
+        [
+          137.5,
+          87.78515625
+        ]
+      ]
+    },
+    {
+      "title": "Input:",
+      "heading_level": null,
+      "page_id": 20,
+      "polygon": [
+        [
+          166.74609375,
+          91.265625
+        ],
+        [
+          204.0,
+          89.71875
+        ],
+        [
+          204.0,
+          101.0
+        ],
+        [
+          165.55078125,
+          102.09375
+        ]
+      ]
+    }
+  ],
+  "page_stats": [
+    {
+      "page_id": 0,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          195
+        ],
+        [
+          "Line",
+          37
+        ],
+        [
+          "Text",
+          6
+        ],
+        [
+          "SectionHeader",
+          4
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 1,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          161
+        ],
+        [
+          "Line",
+          46
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 2,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          168
+        ],
+        [
+          "Line",
+          50
+        ],
+        [
+          "Text",
+          6
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 3,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          172
+        ],
+        [
+          "Line",
+          45
+        ],
+        [
+          "Text",
+          6
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 4,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          240
+        ],
+        [
+          "Line",
+          49
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 5,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          168
+        ],
+        [
+          "Line",
+          46
+        ],
+        [
+          "Text",
+          11
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "Reference",
+          4
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 6,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          168
+        ],
+        [
+          "Line",
+          55
+        ],
+        [
+          "Text",
+          11
+        ],
+        [
+          "Equation",
+          6
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 7,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          83
+        ],
+        [
+          "Line",
+          48
+        ],
+        [
+          "Text",
+          12
+        ],
+        [
+          "Equation",
+          7
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 8,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          81
+        ],
+        [
+          "Line",
+          43
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Equation",
+          5
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 9,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          157
+        ],
+        [
+          "Line",
+          45
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 10,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          173
+        ],
+        [
+          "Line",
+          50
+        ],
+        [
+          "Text",
+          9
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 11,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          100
+        ],
+        [
+          "Line",
+          39
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Equation",
+          7
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 12,
+      "text_extraction_method": "pdftext",
+      "block_counts": [
+        [
+          "Span",
+          428
+        ],
+        [
+          "Line",
+          59
+        ],
+        [
+          "Text",
+          7
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 13,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          137
+        ],
+        [
+          "Line",
+          42
+        ],
+        [
+          "Text",
+          6
+        ],
+        [
+          "Equation",
+          5
+        ],
+        [
+          "Reference",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 14,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          92
+        ],
+        [
+          "Line",
+          41
+        ],
+        [
+          "Text",
+          8
+        ],
+        [
+          "Equation",
+          6
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 15,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          192
+        ],
+        [
+          "Line",
+          51
+        ],
+        [
+          "Text",
+          5
+        ],
+        [
+          "ListItem",
+          3
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 16,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          144
+        ],
+        [
+          "Line",
+          61
+        ],
+        [
+          "Text",
+          4
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "Equation",
+          2
+        ],
+        [
+          "Code",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 17,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Line",
+          29
+        ],
+        [
+          "Span",
+          22
+        ],
+        [
+          "Text",
+          6
+        ],
+        [
+          "Equation",
+          6
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "Reference",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 18,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Line",
+          46
+        ],
+        [
+          "Span",
+          38
+        ],
+        [
+          "Text",
+          5
+        ],
+        [
+          "ListItem",
+          4
+        ],
+        [
+          "Reference",
+          4
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 19,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          112
+        ],
+        [
+          "Line",
+          58
+        ],
+        [
+          "Reference",
+          10
+        ],
+        [
+          "ListItem",
+          9
+        ],
+        [
+          "Text",
+          2
+        ],
+        [
+          "SectionHeader",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ],
+        [
+          "ListGroup",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 20,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          129
+        ],
+        [
+          "Line",
+          49
+        ],
+        [
+          "Text",
+          4
+        ],
+        [
+          "Equation",
+          3
+        ],
+        [
+          "Reference",
+          3
+        ],
+        [
+          "SectionHeader",
+          2
+        ],
+        [
+          "Code",
+          1
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    },
+    {
+      "page_id": 21,
+      "text_extraction_method": "surya",
+      "block_counts": [
+        [
+          "Span",
+          102
+        ],
+        [
+          "Line",
+          25
+        ],
+        [
+          "Text",
+          5
+        ],
+        [
+          "Equation",
+          4
+        ],
+        [
+          "PageFooter",
+          1
+        ]
+      ],
+      "block_metadata": {
+        "llm_request_count": 0,
+        "llm_error_count": 0,
+        "llm_tokens_used": 0,
+        "previous_text": "",
+        "previous_type": "",
+        "previous_order": 0
+      }
+    }
+  ],
+  "debug_data_path": "debug_data/2026_270",
+  "eprint": {
+    "title": "Pseudorandomness of Knapsacks over a Number Ring",
+    "authors": [
+      {
+        "name": "Biswajit Mandal",
+        "email": "biswajit22@iiserb",
+        "affiliation": ""
+      },
+      {
+        "name": "Shashank Singh",
+        "email": "inshashank@iiserb",
+        "affiliation": ""
+      }
+    ],
+    "abstract": "In this work, we study the pseudorandomness of the bounded Knapsack function family defined over a number ring ${R}$. We establish that if the Knapsack function family is one-way and certain related folded Knapsack function families are pseudorandom, then the original Knapsack is pseudorandom. This can be seen as a generalisation of the work of Micciancio and Mol presented at the CRYPTO-2011, for the case of Knapsack function families defined over arbitrary number ring.",
+    "keywords": [
+      "Pseudorandomness",
+      "Knapsack",
+      "Unpredictability"
+    ],
+    "category": "Foundations",
+    "publication_info": "Preprint.",
+    "last_updated": "2026-02-17",
+    "license": "CC BY",
+    "related_papers": []
+  }
+}

--- a/data/markdown/eprint/2026_270/conversion_info.json
+++ b/data/markdown/eprint/2026_270/conversion_info.json
@@ -1,0 +1,23 @@
+{
+  "backend": "marker",
+  "converted_at": "2026-04-29T10:37:22.875552+00:00",
+  "elapsed_seconds": 694.81,
+  "pdf_sha256": "57379361fdeb17d75fc905e1b073c30acfe214af7c61be046aa8b7878f10c6a2",
+  "source_pdf": "2026_270.pdf",
+  "output_path": "2026_270/2026_270.md",
+  "backend_version": "",
+  "machine": {
+    "hostname": "socs-MacBook-Pro.local",
+    "os": "Darwin",
+    "os_version": "25.4.0",
+    "arch": "arm64",
+    "python_version": "3.13.11",
+    "cpu_count": 14,
+    "provider": "",
+    "gpu_count": 0,
+    "gpu_name": "",
+    "gpu_vram_mb": 0,
+    "cuda_version": ""
+  },
+  "estimated_cost_usd": null
+}


### PR DESCRIPTION
Papyrus: markdown for paper 2026/270

---
Generated by [Papyrus](https://github.com/dannywillems/papyrus) (commit a16329b)
Website: https://papyrus.badaas.eu